### PR TITLE
Feature/add performance

### DIFF
--- a/docs/comps/CompetitiveLandscape.md
+++ b/docs/comps/CompetitiveLandscape.md
@@ -1,8 +1,8 @@
 # Competitors
 
 - DVC
-- git lfs
 - Weights & Biases
+- git + git lfs (hugging face datasets)
 - perforce
 
 # Why Oxen?
@@ -11,7 +11,7 @@
     - Different datasets can be used with the same codebase
     - Share datasets without sharing code
     - Easy to accidentally commit data to the codebase
-- Datasets have many files, or long csvs that Oxen works well with natively
+- Datasets have many files, or long CSVs that Oxen works well with natively
 
 # DVC Comparison
 
@@ -47,3 +47,10 @@ Executed in    9.72 secs    fish           external
    usr time    2.68 secs    0.32 millis    2.68 secs
    sys time    5.79 secs    1.91 millis    5.79 secs
 ```
+
+
+# Wandb Comparison
+
+>>> wandb.log_artifact('img_align_celeba/', name='celeba_images', type='images')
+wandb: Adding directory to artifact (./img_align_celeba)... 
+Done. 70.1s

--- a/docs/examples/3_Merge.md
+++ b/docs/examples/3_Merge.md
@@ -178,7 +178,9 @@ dog
 fish
 ```
 
-Let's add back in the human category add the end of the file, add and commit it.
+Let's add back in the human category add the end of the file, add and commit it. This will create the merge commit linking both parents where the conflict occurred.
+
+TODO: A command similar to `git log --oneline --graph --decorate --all` to display the tree.
 
 ```shell
 $ echo "human" >> labels.txt

--- a/src/lib/src/command.rs
+++ b/src/lib/src/command.rs
@@ -131,7 +131,7 @@ pub fn status(repository: &LocalRepository) -> Result<StagedData, OxenError> {
 /// # }
 /// ```
 pub fn add<P: AsRef<Path>>(repo: &LocalRepository, path: P) -> Result<(), OxenError> {
-    let stager = Stager::new(repo)?;
+    let stager = Stager::new_with_merge(repo)?;
     let commit = head_commit(repo)?;
     let reader = CommitEntryReader::new(repo, &commit)?;
     stager.add(path.as_ref(), &reader)?;

--- a/src/lib/src/command.rs
+++ b/src/lib/src/command.rs
@@ -34,6 +34,10 @@ use std::str;
 /// ```
 pub fn init(path: &Path) -> Result<LocalRepository, OxenError> {
     let hidden_dir = util::fs::oxen_hidden_dir(path);
+    if hidden_dir.exists() {
+        return Err(OxenError::basic_str("Oxen repository already exists."));
+    }
+
     std::fs::create_dir_all(hidden_dir)?;
     let config_path = util::fs::config_filepath(path);
     let repo = LocalRepository::new(path)?;

--- a/src/lib/src/index/merger.rs
+++ b/src/lib/src/index/merger.rs
@@ -125,14 +125,19 @@ impl Merger {
         merge_commits: &MergeCommits,
     ) -> Result<Commit, OxenError> {
         let repo = &self.repository;
-        command::add(repo, &repo.path)?;
+        
+        // Stage changes
+        let stager = Stager::new(repo)?;
+        let commit = command::head_commit(repo)?;
+        let reader = CommitEntryReader::new(repo, &commit)?;
+        stager.add(&repo.path, &reader)?;
+
         let commit_msg = format!("Merge branch '{}'", branch_name.as_ref());
 
-        log::debug!("{}", commit_msg);
+        log::debug!("create_merge_commit {}", commit_msg);
 
         // Create a commit with both parents
         let reader = CommitEntryReader::new_from_head(repo)?;
-        let stager = Stager::new(repo)?;
         let status = stager.status(&reader)?;
         let commit_writer = CommitWriter::new(repo)?;
         let parent_ids: Vec<String> = vec![

--- a/src/lib/src/model.rs
+++ b/src/lib/src/model.rs
@@ -13,7 +13,7 @@ pub use crate::model::repository::local_repository::{LocalRepository, Repository
 pub use crate::model::repository::remote_repository::RemoteRepository;
 
 // Commit
-pub use crate::model::commit::{Commit, CommitStats};
+pub use crate::model::commit::{Commit, CommitStats, NewCommit};
 
 // Merge
 pub use crate::model::merge_conflict::MergeConflict;

--- a/src/lib/src/model/commit.rs
+++ b/src/lib/src/model/commit.rs
@@ -4,6 +4,16 @@ use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct NewCommit {
+    pub parent_ids: Vec<String>,
+    pub message: String,
+    pub author: String,
+    #[serde(with = "oxen_date_format")]
+    pub date: DateTime<Local>,
+    pub timestamp: i64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Commit {
     pub id: String,
     pub parent_ids: Vec<String>,
@@ -28,6 +38,17 @@ impl Hash for Commit {
 }
 
 impl Commit {
+    pub fn from_new_and_id(new_commit: &NewCommit, id: String) -> Commit {
+        Commit {
+            id: id.to_owned(),
+            parent_ids: new_commit.parent_ids.to_owned(),
+            message: new_commit.message.to_owned(),
+            author: new_commit.author.to_owned(),
+            date: new_commit.date.to_owned(),
+            timestamp: new_commit.timestamp.to_owned(),
+        }
+    }
+
     pub fn to_uri_encoded(&self) -> String {
         serde_url_params::to_string(&self).unwrap()
     }


### PR DESCRIPTION
Fix performance on `oxen add <DIRECTORY>` command by not instantiating the merger every time. On my machine this improved oxen add on 24000 images from the CatVsDog dataset from 27 seconds to 2 seconds. 

Also compute the commit_id from all the hash values of the entries + the commit data so that it is more verifiable and not just a random ID