### PR TITLE
get rid of set-remote command and make it more like the git commands

### DIFF
--- a/src/cli/src/dispatch.rs
+++ b/src/cli/src/dispatch.rs
@@ -43,6 +43,15 @@ pub fn set_remote(name: &str, url: &str) -> Result<(), OxenError> {
     Ok(())
 }
 
+pub fn remove_remote(name: &str) -> Result<(), OxenError> {
+    let repo_dir = env::current_dir().unwrap();
+    let mut repo = LocalRepository::from_dir(&repo_dir)?;
+
+    command::remove_remote(&mut repo, name)?;
+
+    Ok(())
+}
+
 pub fn list_remotes() -> Result<(), OxenError> {
     let repo_dir = env::current_dir().unwrap();
     let repo = LocalRepository::from_dir(&repo_dir)?;

--- a/src/lib/src/command.rs
+++ b/src/lib/src/command.rs
@@ -444,6 +444,14 @@ pub fn set_remote(
     Ok(RemoteRepository::from_local(repo, url))
 }
 
+/// # Remove the remote for a repository
+/// If you added a remote you no longer want, can remove it by supplying the name
+pub fn remove_remote(repo: &mut LocalRepository, name: &str) -> Result<(), OxenError> {
+    repo.remove_remote(name);
+    repo.save_default()?;
+    Ok(())
+}
+
 /// # Get a log of all the commits
 ///
 /// ```

--- a/src/lib/src/model/repository/local_repository.rs
+++ b/src/lib/src/model/repository/local_repository.rs
@@ -124,6 +124,16 @@ impl LocalRepository {
         }
     }
 
+    pub fn remove_remote(&mut self, name: &str) {
+        let mut new_remotes: Vec<Remote> = vec![];
+        for i in 0..self.remotes.len() {
+            if self.remotes[i].name != name {
+                new_remotes.push(self.remotes[i].clone());
+            }
+        }
+        self.remotes = new_remotes;
+    }
+
     pub fn has_remote(&self, name: &str) -> bool {
         for remote in self.remotes.iter() {
             if remote.name == name {
@@ -237,6 +247,26 @@ mod tests {
             let remote = local_repo.get_remote(remote_name).unwrap();
             assert_eq!(remote.name, remote_name);
             assert_eq!(remote.url, url);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_remove_remote() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test(|mut local_repo| {
+            let origin_url = "http://0.0.0.0:3000/repositories/OxenData";
+            let origin_name = "origin";
+
+            let other_url = "http://0.0.0.0:4000/repositories/OxenData";
+            let other_name = "other";
+            local_repo.set_remote(origin_name, origin_url);
+            local_repo.set_remote(other_name, other_url);
+
+            // Remove and make sure we cannot get again
+            local_repo.remove_remote(origin_name);
+            let remote = local_repo.get_remote(origin_name);
+            assert!(remote.is_none());
 
             Ok(())
         })


### PR DESCRIPTION
This goes in combination with [this PR](https://github.com/Oxen-AI/OxenHub/pull/10) to make the oxen remote commands more git like

<img width="764" alt="Screen Shot 2022-08-01 at 5 03 24 PM" src="https://user-images.githubusercontent.com/1326790/182264711-3e05feb4-caf2-48a1-83ec-64e7ed11811c.png">
