### PR TITLE
update add command to take multiple values

### DIFF
--- a/src/cli/src/cmd_setup.rs
+++ b/src/cli/src/cmd_setup.rs
@@ -274,8 +274,7 @@ pub fn schemas() -> Command<'static> {
 pub fn add() -> Command<'static> {
     Command::new(ADD)
         .about("Adds the specified files or directories")
-        .arg(arg!(<PATH> ... "The files or directory to add"))
-        .arg_required_else_help(true)
+        .arg(Arg::new("files").required(true).min_values(1))
 }
 
 pub fn restore() -> Command<'static> {

--- a/src/cli/src/dispatch.rs
+++ b/src/cli/src/dispatch.rs
@@ -100,11 +100,13 @@ pub fn set_user_email(email: &str) -> Result<(), OxenError> {
     Ok(())
 }
 
-pub fn add(path: &str) -> Result<(), OxenError> {
+pub fn add(paths: Vec<PathBuf>) -> Result<(), OxenError> {
     let repo_dir = env::current_dir().unwrap();
     let repository = LocalRepository::from_dir(&repo_dir)?;
 
-    command::add(&repository, Path::new(path))?;
+    for path in paths {
+        command::add(&repository, &path)?;
+    }
 
     Ok(())
 }

--- a/src/cli/src/parse_and_run.rs
+++ b/src/cli/src/parse_and_run.rs
@@ -276,9 +276,13 @@ pub fn schemas(sub_matches: &ArgMatches) {
 }
 
 pub fn add(sub_matches: &ArgMatches) {
-    let path = sub_matches.value_of("PATH").expect("required");
+    let paths: Vec<PathBuf> = sub_matches
+        .values_of("files")
+        .expect("Must supply files")
+        .map(PathBuf::from)
+        .collect();
 
-    match dispatch::add(path) {
+    match dispatch::add(paths) {
         Ok(_) => {}
         Err(err) => {
             eprintln!("{}", err)


### PR DESCRIPTION
Previously you could only add one file at a time with the `oxen add` command. Now you can provide a list of paths.