### PR TITLE
bug fix: committing a file with out an extension

### DIFF
--- a/src/lib/src/model/entry/commit_entry.rs
+++ b/src/lib/src/model/entry/commit_entry.rs
@@ -65,8 +65,11 @@ impl CommitEntry {
     }
 
     pub fn extension(&self) -> String {
-        let err = format!("Could not get extension for path: {:?}", self.path);
-        String::from(self.path.extension().expect(&err).to_str().unwrap())
+        if let Some(ext) = self.path.extension() {
+            String::from(ext.to_str().unwrap_or(""))
+        } else {
+            String::from("")
+        }
     }
 
     pub fn to_synced(&self) -> CommitEntry {


### PR DESCRIPTION
We were unwrapping an optional and assuming all files had an extension, when of course, in fact, they do not.