### PR TITLE
fix restore tabular modified file

### DIFF
--- a/src/lib/src/constants.rs
+++ b/src/lib/src/constants.rs
@@ -27,6 +27,8 @@ pub const FIELDS_DIR: &str = "fields";
 pub const VERSIONS_DIR: &str = "versions";
 /// merge/ is where any merge conflicts are stored so that we can get rid of them
 pub const MERGE_DIR: &str = "merge";
+/// data.arrow
+pub const DATA_ARROW_FILE: &str = "data.arrow";
 
 /// if we have merge conflicts we write to MERGE_HEAD and ORIG_HEAD to keep track of the parents
 pub const MERGE_HEAD_FILE: &str = "MERGE_HEAD";

--- a/src/lib/src/index/entry_indexer.rs
+++ b/src/lib/src/index/entry_indexer.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::api;
-use crate::constants::HISTORY_DIR;
+use crate::constants::{DATA_ARROW_FILE, HISTORY_DIR};
 use crate::df::{tabular, DFOpts};
 use crate::error::OxenError;
 use crate::index::{
@@ -280,7 +280,7 @@ impl EntryIndexer {
 
         println!("🐂 push computing size...");
         for entry in entries.iter() {
-            // If tabular, we save off data.arrow file that we are going to push, and compute size off of
+            // If tabular, we save off data file that we are going to push, and compute size off of
             let version_path = if util::fs::is_tabular(&entry.path) {
                 let schema_reader = SchemaReader::new(&self.repository, &entry.commit_id)?;
                 log::debug!("Looking up schema for file: {:?}", entry.path);
@@ -296,11 +296,12 @@ impl EntryIndexer {
                 let mut df = reader.sorted_entry_df_with_row_hash()?;
 
                 log::debug!("Saving and computing size for DF {}", df);
+                log::debug!("Got df to version path {}", df);
 
                 // save DataFrame to disk in it's proper version dir
                 let version_path =
                     util::fs::version_dir_from_hash(&self.repository, entry.hash.clone())
-                        .join("data.arrow");
+                        .join(DATA_ARROW_FILE);
                 tabular::write_df(&mut df, &version_path)?;
 
                 version_path
@@ -370,7 +371,7 @@ impl EntryIndexer {
                                 &self.repository,
                                 entry.hash.clone(),
                             )
-                            .join("data.arrow");
+                            .join(DATA_ARROW_FILE);
                             log::debug!("ZIPPING TABULAR {:?}", version_path);
 
                             let name =
@@ -709,9 +710,9 @@ impl EntryIndexer {
                             }
                         } else {
                             let version_dir = util::fs::version_dir_from_hash(&self.repository, entry.hash.clone());
-                            let hash_results_file = version_dir.join("data.arrow");
+                            let hash_results_file = version_dir.join(DATA_ARROW_FILE);
                             if !hash_results_file.exists() {
-                                log::error!("pull_entries_for_commit no tmp data.arrow file for entry {:?} -> {:?}", entry.path, hash_results_file);
+                                log::error!("pull_entries_for_commit no tmp data file for entry {:?} -> {:?}", entry.path, hash_results_file);
                                 return;
                             }
 

--- a/src/server/src/controllers/entries.rs
+++ b/src/server/src/controllers/entries.rs
@@ -3,6 +3,7 @@ use crate::controllers;
 use crate::view::PaginatedLinesResponse;
 
 use liboxen::api;
+use liboxen::constants::DATA_ARROW_FILE;
 use liboxen::error::OxenError;
 use liboxen::index::CommitDirReader;
 use liboxen::model::{Commit, CommitEntry, LocalRepository, RemoteEntry};
@@ -82,15 +83,15 @@ pub async fn download_content_by_ids(req: HttpRequest, mut body: web::Payload) -
                     continue;
                 }
 
-                // TODO: if tabular, get content from data.arrow file
+                // TODO: if tabular, get content from data file
                 log::debug!("Checking for content file {}", content_file);
 
                 let version_path = repo.path.join(content_file);
                 if util::fs::is_tabular(&version_path) {
-                    let data_file = version_path.parent().unwrap().join("data.arrow");
+                    let data_file = version_path.parent().unwrap().join(DATA_ARROW_FILE);
                     let path = Path::new(content_file);
-                    // in order to unzip it to data.arrow on the other end
-                    let content_file = path.parent().unwrap().join("data.arrow");
+                    // in order to unzip it to data on the other end
+                    let content_file = path.parent().unwrap().join(DATA_ARROW_FILE);
                     tar.append_path_with_name(data_file, content_file).unwrap();
                 } else if version_path.exists() {
                     tar.append_path_with_name(version_path, content_file)


### PR DESCRIPTION
There was a bug if you modified a tabular file, then restored it, it restored it properly but it was still "marked as modified".

This is because as an optimization we check the file timestamp for when the file was modified to check if it is modified, and we didn't update the file timestamps in the DB.

Realizing this is kind of brittle...but it is faster than hashing every single file to check if it has changed, we only check contents if the timestamp has changed.

<img width="668" alt="Screenshot 2022-11-30 at 11 01 24 PM" src="https://user-images.githubusercontent.com/1326790/206021977-14b13c9b-9b14-4332-90bc-6fa0c376f2ad.png">
