### PR TITLE
add schemas API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,6 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
- "walkdir",
  "x25519-dalek",
  "xxhash-rust",
 ]
@@ -1975,7 +1974,6 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
- "walkdir",
  "xxhash-rust",
 ]
 
@@ -2990,15 +2988,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3722,17 +3711,6 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
-
-[[package]]
-name = "walkdir"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
-dependencies = [
- "same-file",
- "winapi",
- "winapi-util",
-]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ openssl = { version = "0.10" }
 dotenv = "0.9.0"
 flate2 = "1.0.23"
 tar = "0.4.38"
-walkdir = "2"
 env_logger = "0.9.0"
 log = "0.4.17"
 actix-web-httpauth = "0.6.0"

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -31,7 +31,6 @@ openssl = { version = "0.10" }
 dotenv = "0.9.0"
 flate2 = "1.0.23"
 tar = "0.4.38"
-walkdir = "2"
 env_logger = "0.9.0"
 log = "0.4.17"
 futures-util = "0.3.21"

--- a/src/lib/src/api/local.rs
+++ b/src/lib/src/api/local.rs
@@ -3,3 +3,4 @@ pub mod commits;
 pub mod entries;
 pub mod namespaces;
 pub mod repositories;
+pub mod schemas;

--- a/src/lib/src/api/local/commits.rs
+++ b/src/lib/src/api/local/commits.rs
@@ -37,3 +37,23 @@ pub fn get_parents(repo: &LocalRepository, commit: &Commit) -> Result<Vec<Commit
     }
     Ok(commits)
 }
+
+pub fn commit_from_branch_or_commit_id<S: AsRef<str>>(
+    repo: &LocalRepository,
+    val: S,
+) -> Result<Option<Commit>, OxenError> {
+    let val = val.as_ref();
+    let commit_reader = CommitReader::new(repo)?;
+    if let Some(commit) = commit_reader.get_commit_by_id(val)? {
+        return Ok(Some(commit));
+    }
+
+    let ref_reader = RefReader::new(repo)?;
+    if let Some(branch) = ref_reader.get_branch_by_name(val)? {
+        if let Some(commit) = commit_reader.get_commit_by_id(branch.commit_id)? {
+            return Ok(Some(commit));
+        }
+    }
+
+    Ok(None)
+}

--- a/src/lib/src/api/local/repositories.rs
+++ b/src/lib/src/api/local/repositories.rs
@@ -6,8 +6,8 @@ use crate::index::{CommitDirReader, CommitWriter, RefWriter};
 use crate::model::{CommitStats, LocalRepository, RepositoryNew};
 use crate::util;
 
+use jwalk::WalkDir;
 use std::path::Path;
-use walkdir::WalkDir;
 
 pub fn get_by_namespace_and_name(
     sync_dir: &Path,
@@ -95,14 +95,14 @@ pub fn list_repos_in_namespace(namespace_path: &Path) -> Vec<LocalRepository> {
     {
         // if the directory has a .oxen dir, let's add it, otherwise ignore
         let local_dir = entry.path();
-        let oxen_dir = util::fs::oxen_hidden_dir(local_dir);
+        let oxen_dir = util::fs::oxen_hidden_dir(&local_dir);
         log::debug!(
             "api::local::entries::list_repos_in_namespace got local dir {:?}",
             local_dir
         );
 
         if oxen_dir.exists() {
-            if let Ok(repository) = LocalRepository::from_dir(local_dir) {
+            if let Ok(repository) = LocalRepository::from_dir(&local_dir) {
                 repos.push(repository);
             }
         }

--- a/src/lib/src/api/local/schemas.rs
+++ b/src/lib/src/api/local/schemas.rs
@@ -1,0 +1,23 @@
+use crate::api;
+
+use crate::error::OxenError;
+use crate::index::SchemaReader;
+use crate::model::{LocalRepository, Schema};
+use crate::util::resource;
+
+pub fn list(repo: &LocalRepository, commit_id: Option<&str>) -> Result<Vec<Schema>, OxenError> {
+    log::debug!("api::local::schemas::list for path {:?}", repo.path);
+    if let Some(commit_id) = commit_id {
+        if let Some(commit) = api::local::commits::commit_from_branch_or_commit_id(repo, commit_id)?
+        {
+            let schema_reader = SchemaReader::new(repo, &commit.id)?;
+            schema_reader.list_schemas()
+        } else {
+            Err(OxenError::commit_id_does_not_exist(commit_id))
+        }
+    } else {
+        let head_commit = resource::get_head_commit(repo)?;
+        let schema_reader = SchemaReader::new(repo, &head_commit.id)?;
+        schema_reader.list_schemas()
+    }
+}

--- a/src/lib/src/df/tabular.rs
+++ b/src/lib/src/df/tabular.rs
@@ -322,16 +322,16 @@ pub fn transform_df(mut df: LazyFrame, opts: DFOpts) -> Result<DataFrame, OxenEr
     }
 
     // These ops should be the last ops since they depends on order
+    if let Some(indices) = opts.take_indices() {
+        df = take(df, indices).unwrap().lazy();
+    }
+
     if let Some((start, end)) = opts.slice_indices() {
         if start >= end {
             panic!("Slice error: Start must be greater than end.");
         }
         let len = end - start;
         df = df.slice(start, len as u32);
-    }
-
-    if let Some(indices) = opts.take_indices() {
-        df = take(df, indices).unwrap().lazy();
     }
 
     if let Some(item) = opts.column_at() {

--- a/src/lib/src/view.rs
+++ b/src/lib/src/view.rs
@@ -2,6 +2,7 @@ pub mod branch;
 pub mod commit;
 pub mod entry;
 pub mod http;
+pub mod json_data_frame;
 pub mod namespace;
 pub mod repository;
 pub mod schema;
@@ -9,6 +10,7 @@ pub mod status_message;
 
 pub use crate::view::status_message::{IsValidStatusMessage, StatusMessage};
 
+pub use crate::view::json_data_frame::{JsonDataFrame, JsonDataFrameResponse};
 pub use crate::view::namespace::{ListNamespacesResponse, NamespaceView};
 pub use crate::view::schema::{ListSchemaResponse, SchemaResponse};
 

--- a/src/lib/src/view.rs
+++ b/src/lib/src/view.rs
@@ -10,7 +10,7 @@ pub mod status_message;
 
 pub use crate::view::status_message::{IsValidStatusMessage, StatusMessage};
 
-pub use crate::view::json_data_frame::{JsonDataFrame, JsonDataFrameResponse};
+pub use crate::view::json_data_frame::{JsonDataFrame, JsonDataFrameSliceResponse};
 pub use crate::view::namespace::{ListNamespacesResponse, NamespaceView};
 pub use crate::view::schema::{ListSchemaResponse, SchemaResponse};
 

--- a/src/lib/src/view.rs
+++ b/src/lib/src/view.rs
@@ -4,11 +4,13 @@ pub mod entry;
 pub mod http;
 pub mod namespace;
 pub mod repository;
+pub mod schema;
 pub mod status_message;
 
 pub use crate::view::status_message::{IsValidStatusMessage, StatusMessage};
 
 pub use crate::view::namespace::{ListNamespacesResponse, NamespaceView};
+pub use crate::view::schema::{ListSchemaResponse, SchemaResponse};
 
 pub use crate::view::repository::{
     ListRepositoryResponse, RepositoryResolveResponse, RepositoryResponse, RepositoryView,

--- a/src/lib/src/view/json_data_frame.rs
+++ b/src/lib/src/view/json_data_frame.rs
@@ -1,0 +1,60 @@
+use std::io::BufWriter;
+use std::str;
+
+use polars::prelude::*;
+use serde::{Deserialize, Serialize};
+
+
+use crate::model::Schema;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct JsonDataShape {
+    pub height: usize,
+    pub width: usize,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct JsonDataFrame {
+    pub schema: Schema,
+    pub shape: JsonDataShape,
+    pub data: serde_json::Value,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct JsonDataFrameResponse {
+    pub status: String,
+    pub status_message: String,
+    pub df: JsonDataFrame,
+}
+
+impl JsonDataFrame {
+    pub fn from_df(df: &mut DataFrame) -> JsonDataFrame {
+        JsonDataFrame {
+            schema: Schema::from_polars(&df.schema()),
+            shape: JsonDataShape {
+                height: df.height(),
+                width: df.width(),
+            },
+            data: JsonDataFrame::json_data(df),
+        }
+    }
+
+    fn json_data(df: &mut DataFrame) -> serde_json::Value {
+        println!("Serializing df: [{}]", df);
+
+        // TODO: serialize to json
+        let data: Vec<u8> = Vec::new();
+        let mut buf = BufWriter::new(data);
+
+        let mut writer = JsonWriter::new(&mut buf).with_json_format(JsonFormat::Json);
+        writer.finish(df).expect("Could not write df json buffer");
+
+        let buffer = buf.into_inner().expect("Could not get buffer");
+        println!("Got buf len: [{}]", buffer.len());
+
+        let json_str = str::from_utf8(&buffer).unwrap();
+        println!("Got json_str: [{}]", json_str);
+
+        serde_json::from_str(json_str).unwrap()
+    }
+}

--- a/src/lib/src/view/schema.rs
+++ b/src/lib/src/view/schema.rs
@@ -1,0 +1,17 @@
+use serde::{Deserialize, Serialize};
+
+use crate::model::Schema;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SchemaResponse {
+    pub status: String,
+    pub status_message: String,
+    pub schema: Schema,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ListSchemaResponse {
+    pub status: String,
+    pub status_message: String,
+    pub schemas: Vec<Schema>,
+}

--- a/src/server/src/controllers.rs
+++ b/src/server/src/controllers.rs
@@ -5,4 +5,5 @@ pub mod entries;
 pub mod file;
 pub mod namespaces;
 pub mod repositories;
+pub mod schemas;
 pub mod version;

--- a/src/server/src/controllers.rs
+++ b/src/server/src/controllers.rs
@@ -1,5 +1,6 @@
 pub mod branches;
 pub mod commits;
+pub mod df;
 pub mod dir;
 pub mod entries;
 pub mod file;

--- a/src/server/src/controllers/df.rs
+++ b/src/server/src/controllers/df.rs
@@ -1,0 +1,71 @@
+use crate::app_data::OxenAppData;
+
+use liboxen::api;
+
+use actix_web::{HttpRequest, HttpResponse};
+use liboxen::df::{tabular, DFOpts};
+use liboxen::view::http::{MSG_RESOURCE_FOUND, STATUS_SUCCESS};
+use liboxen::view::{JsonDataFrame, JsonDataFrameResponse, StatusMessage};
+use std::path::PathBuf;
+
+use liboxen::util;
+
+pub async fn get(req: HttpRequest) -> HttpResponse {
+    let app_data = req.app_data::<OxenAppData>().unwrap();
+
+    let namespace: &str = req.match_info().get("namespace").unwrap();
+    let name: &str = req.match_info().get("repo_name").unwrap();
+    let resource: PathBuf = req.match_info().query("resource").parse().unwrap();
+
+    log::debug!("file::get repo name [{}] resource [{:?}]", name, resource,);
+    match api::local::repositories::get_by_namespace_and_name(&app_data.path, namespace, name) {
+        Ok(Some(repo)) => {
+            if let Ok(Some((commit_id, filepath))) =
+                util::resource::parse_resource(&repo, &resource)
+            {
+                log::debug!(
+                    "dir::get commit_id [{}] and filepath {:?}",
+                    commit_id,
+                    filepath
+                );
+
+                match util::fs::version_path_for_commit_id(&repo, &commit_id, &filepath) {
+                    Ok(version_path) => match tabular::read_df(version_path, DFOpts::empty()) {
+                        Ok(mut df) => {
+                            let response = JsonDataFrameResponse {
+                                status: String::from(STATUS_SUCCESS),
+                                status_message: String::from(MSG_RESOURCE_FOUND),
+                                df: JsonDataFrame::from_df(&mut df),
+                            };
+                            HttpResponse::Ok().json(response)
+                        }
+                        Err(err) => {
+                            log::error!("unable to read data frame {:?}. Err: {}", resource, err);
+                            HttpResponse::InternalServerError()
+                                .json(StatusMessage::internal_server_error())
+                        }
+                    },
+                    Err(err) => {
+                        log::error!("df::get err: {:?}", err);
+                        HttpResponse::InternalServerError()
+                            .json(StatusMessage::internal_server_error())
+                    }
+                }
+            } else {
+                log::debug!(
+                    "schema::get could not find resource from uri {:?}",
+                    resource
+                );
+                HttpResponse::NotFound().json(StatusMessage::resource_not_found())
+            }
+        }
+        Ok(None) => {
+            log::debug!("schema::get could not find repo with name {}", name);
+            HttpResponse::NotFound().json(StatusMessage::resource_not_found())
+        }
+        Err(err) => {
+            log::error!("schema::get Err: {}", err);
+            HttpResponse::InternalServerError().json(StatusMessage::internal_server_error())
+        }
+    }
+}

--- a/src/server/src/controllers/df.rs
+++ b/src/server/src/controllers/df.rs
@@ -2,15 +2,30 @@ use crate::app_data::OxenAppData;
 
 use liboxen::api;
 
-use actix_web::{HttpRequest, HttpResponse};
+use actix_web::{web, HttpRequest, HttpResponse};
 use liboxen::df::{tabular, DFOpts};
+use liboxen::model::Schema;
 use liboxen::view::http::{MSG_RESOURCE_FOUND, STATUS_SUCCESS};
-use liboxen::view::{JsonDataFrame, JsonDataFrameResponse, StatusMessage};
+use liboxen::view::json_data_frame::JsonDataSize;
+use liboxen::view::{JsonDataFrame, JsonDataFrameSliceResponse, StatusMessage};
+use serde::Deserialize;
 use std::path::PathBuf;
 
 use liboxen::util;
 
-pub async fn get(req: HttpRequest) -> HttpResponse {
+#[derive(Deserialize, Debug)]
+pub struct DFOptsQuery {
+    pub slice: Option<String>,
+    pub take: Option<String>,
+    pub columns: Option<String>,
+    pub filter: Option<String>,
+    pub aggregate: Option<String>,
+    pub sort_by: Option<String>,
+    pub randomize: Option<bool>,
+    pub reverse: Option<bool>,
+}
+
+pub async fn get(req: HttpRequest, query: web::Query<DFOptsQuery>) -> HttpResponse {
     let app_data = req.app_data::<OxenAppData>().unwrap();
 
     let namespace: &str = req.match_info().get("namespace").unwrap();
@@ -30,12 +45,26 @@ pub async fn get(req: HttpRequest) -> HttpResponse {
                 );
 
                 match util::fs::version_path_for_commit_id(&repo, &commit_id, &filepath) {
-                    Ok(version_path) => match tabular::read_df(version_path, DFOpts::empty()) {
-                        Ok(mut df) => {
-                            let response = JsonDataFrameResponse {
+                    Ok(version_path) => match tabular::scan_df(version_path) {
+                        Ok(lazy_df) => {
+                            let polars_schema = lazy_df.schema().unwrap();
+                            let schema = Schema::from_polars(&polars_schema);
+                            let mut filter = DFOpts::from_filter_schema_exclude_hidden(&schema);
+                            log::debug!("Initial filter {:?}", filter);
+                            filter = parse_opts(query, &mut filter);
+
+                            log::debug!("Got filter {:?}", filter);
+                            let lazy_cp = lazy_df.clone();
+                            let mut df = tabular::transform_df(lazy_cp, filter).unwrap();
+                            let full_df = lazy_df.collect().unwrap();
+                            let response = JsonDataFrameSliceResponse {
                                 status: String::from(STATUS_SUCCESS),
                                 status_message: String::from(MSG_RESOURCE_FOUND),
                                 df: JsonDataFrame::from_df(&mut df),
+                                full_size: JsonDataSize {
+                                    width: full_df.width(),
+                                    height: full_df.height(),
+                                },
                             };
                             HttpResponse::Ok().json(response)
                         }
@@ -68,4 +97,35 @@ pub async fn get(req: HttpRequest) -> HttpResponse {
             HttpResponse::InternalServerError().json(StatusMessage::internal_server_error())
         }
     }
+}
+
+/// Provide some default vals for opts
+fn parse_opts(query: web::Query<DFOptsQuery>, filter_ops: &mut DFOpts) -> DFOpts {
+    // Default to 0..10 unless they ask for "all"
+    if let Some(slice) = query.slice.clone() {
+        if slice == "all" {
+            // Return everything...probably don't want to do this unless explicitly asked for
+            filter_ops.slice = None;
+        } else {
+            // Return what they asked for
+            filter_ops.slice = Some(slice);
+        }
+    } else {
+        // No slice val supplied, only return first 10
+        filter_ops.slice = Some(String::from("0..10"));
+    }
+
+    // we are already filtering the hidden columns
+    if let Some(columns) = query.columns.clone() {
+        filter_ops.columns = Some(columns);
+    }
+
+    filter_ops.take = query.take.clone();
+    filter_ops.filter = query.filter.clone();
+    filter_ops.aggregate = query.aggregate.clone();
+    filter_ops.sort_by = query.sort_by.clone();
+    filter_ops.should_randomize = query.randomize.unwrap_or(false);
+    filter_ops.should_reverse = query.reverse.unwrap_or(false);
+
+    filter_ops.clone()
 }

--- a/src/server/src/controllers/df.rs
+++ b/src/server/src/controllers/df.rs
@@ -76,8 +76,7 @@ pub async fn get(req: HttpRequest, query: web::Query<DFOptsQuery>) -> HttpRespon
                     },
                     Err(err) => {
                         log::error!("df::get err: {:?}", err);
-                        HttpResponse::InternalServerError()
-                            .json(StatusMessage::internal_server_error())
+                        HttpResponse::NotFound().json(StatusMessage::resource_not_found())
                     }
                 }
             } else {

--- a/src/server/src/controllers/entries.rs
+++ b/src/server/src/controllers/entries.rs
@@ -1,5 +1,4 @@
 use crate::app_data::OxenAppData;
-use crate::controllers;
 use crate::view::PaginatedLinesResponse;
 
 use liboxen::api;
@@ -278,9 +277,7 @@ pub async fn list_lines_in_file(req: HttpRequest, query: web::Query<PageNumQuery
                     commit_id,
                     filepath
                 );
-                match controllers::repositories::get_version_path_for_commit_id(
-                    &repo, &commit_id, &filepath,
-                ) {
+                match util::fs::version_path_for_commit_id(&repo, &commit_id, &filepath) {
                     Ok(version_path) => {
                         let start = page_num * page_size;
                         let (lines, total_entries) =

--- a/src/server/src/controllers/file.rs
+++ b/src/server/src/controllers/file.rs
@@ -4,7 +4,6 @@ use liboxen::api;
 
 use actix_files::NamedFile;
 use actix_web::HttpRequest;
-use liboxen::error::OxenError;
 use std::path::{Path, PathBuf};
 
 use liboxen::model::LocalRepository;
@@ -50,7 +49,7 @@ fn get_file_for_commit_id(
     commit_id: &str,
     filepath: &Path,
 ) -> Result<NamedFile, actix_web::Error> {
-    match get_version_path_for_commit_id(repo, commit_id, filepath) {
+    match util::fs::version_path_for_commit_id(repo, commit_id, filepath) {
         Ok(version_path) => {
             log::debug!(
                 "get_file_for_commit_id looking for {:?} -> {:?}",
@@ -64,19 +63,5 @@ fn get_file_for_commit_id(
             // gives a 404
             Ok(NamedFile::open("")?)
         }
-    }
-}
-
-pub fn get_version_path_for_commit_id(
-    repo: &LocalRepository,
-    commit_id: &str,
-    filepath: &Path,
-) -> Result<PathBuf, OxenError> {
-    match api::local::commits::get_by_id(repo, commit_id)? {
-        Some(commit) => match api::local::entries::get_entry_for_commit(repo, &commit, filepath)? {
-            Some(entry) => Ok(util::fs::version_path(repo, &entry)),
-            None => Err(OxenError::file_does_not_exist(filepath)),
-        },
-        None => Err(OxenError::commit_id_does_not_exist(commit_id)),
     }
 }

--- a/src/server/src/controllers/repositories.rs
+++ b/src/server/src/controllers/repositories.rs
@@ -1,7 +1,6 @@
 use crate::app_data::OxenAppData;
 
 use liboxen::api;
-use liboxen::error::OxenError;
 use liboxen::util;
 use liboxen::view::http::{
     MSG_RESOURCE_CREATED, MSG_RESOURCE_DELETED, MSG_RESOURCE_FOUND, STATUS_SUCCESS,
@@ -193,26 +192,12 @@ pub async fn get_file_for_commit_id(req: HttpRequest) -> Result<NamedFile, actix
     }
 }
 
-pub fn get_version_path_for_commit_id(
-    repo: &LocalRepository,
-    commit_id: &str,
-    filepath: &Path,
-) -> Result<PathBuf, OxenError> {
-    match api::local::commits::get_by_id(repo, commit_id)? {
-        Some(commit) => match api::local::entries::get_entry_for_commit(repo, &commit, filepath)? {
-            Some(entry) => Ok(util::fs::version_path(repo, &entry)),
-            None => Err(OxenError::file_does_not_exist(filepath)),
-        },
-        None => Err(OxenError::commit_id_does_not_exist(commit_id)),
-    }
-}
-
 fn p_get_file_for_commit_id(
     repo: &LocalRepository,
     commit_id: &str,
     filepath: &Path,
 ) -> Result<NamedFile, actix_web::Error> {
-    match get_version_path_for_commit_id(repo, commit_id, filepath) {
+    match util::fs::version_path_for_commit_id(repo, commit_id, filepath) {
         Ok(version_path) => {
             log::debug!(
                 "p_get_file_for_commit_id looking for {:?} -> {:?}",

--- a/src/server/src/controllers/schemas.rs
+++ b/src/server/src/controllers/schemas.rs
@@ -1,0 +1,63 @@
+use crate::app_data::OxenAppData;
+
+use liboxen::api;
+
+use actix_web::{HttpRequest, HttpResponse};
+use liboxen::view::http::{MSG_RESOURCE_FOUND, STATUS_SUCCESS};
+use liboxen::view::{ListSchemaResponse, StatusMessage};
+use std::path::PathBuf;
+
+use liboxen::util;
+
+pub async fn get(req: HttpRequest) -> HttpResponse {
+    let app_data = req.app_data::<OxenAppData>().unwrap();
+
+    let namespace: &str = req.match_info().get("namespace").unwrap();
+    let name: &str = req.match_info().get("repo_name").unwrap();
+    let resource: PathBuf = req.match_info().query("resource").parse().unwrap();
+
+    log::debug!("file::get repo name [{}] resource [{:?}]", name, resource,);
+    match api::local::repositories::get_by_namespace_and_name(&app_data.path, namespace, name) {
+        Ok(Some(repo)) => {
+            if let Ok(Some((commit_id, filepath))) =
+                util::resource::parse_resource(&repo, &resource)
+            {
+                log::debug!(
+                    "dir::get commit_id [{}] and filepath {:?}",
+                    commit_id,
+                    filepath
+                );
+
+                match api::local::schemas::list(&repo, Some(&commit_id)) {
+                    Ok(schemas) => {
+                        let response = ListSchemaResponse {
+                            status: String::from(STATUS_SUCCESS),
+                            status_message: String::from(MSG_RESOURCE_FOUND),
+                            schemas,
+                        };
+                        HttpResponse::Ok().json(response)
+                    }
+                    Err(err) => {
+                        log::error!("unable to get directory {:?}. Err: {}", resource, err);
+                        HttpResponse::InternalServerError()
+                            .json(StatusMessage::internal_server_error())
+                    }
+                }
+            } else {
+                log::debug!(
+                    "schema::get could not find resource from uri {:?}",
+                    resource
+                );
+                HttpResponse::NotFound().json(StatusMessage::resource_not_found())
+            }
+        }
+        Ok(None) => {
+            log::debug!("schema::get could not find repo with name {}", name);
+            HttpResponse::NotFound().json(StatusMessage::resource_not_found())
+        }
+        Err(err) => {
+            log::error!("schema::get Err: {}", err);
+            HttpResponse::InternalServerError().json(StatusMessage::internal_server_error())
+        }
+    }
+}

--- a/src/server/src/routes.rs
+++ b/src/server/src/routes.rs
@@ -91,6 +91,11 @@ pub fn config(cfg: &mut web::ServiceConfig) {
         "/{namespace}/{repo_name}/schemas/{resource:.*}",
         web::get().to(controllers::schemas::get),
     )
+    // ----- DataFrame ----- //
+    .route(
+        "/{namespace}/{repo_name}/df/{resource:.*}",
+        web::get().to(controllers::df::get),
+    )
 
     // .route(
     //     "/{namespace}/{repo_name}/commits/{commit_id}/entries",

--- a/src/server/src/routes.rs
+++ b/src/server/src/routes.rs
@@ -86,6 +86,11 @@ pub fn config(cfg: &mut web::ServiceConfig) {
         "/{namespace}/{repo_name}/versions",
         web::post().to(controllers::entries::download_content_by_ids),
     )
+    // ----- Schemas ----- //
+    .route(
+        "/{namespace}/{repo_name}/schemas/{resource:.*}",
+        web::get().to(controllers::schemas::get),
+    )
 
     // .route(
     //     "/{namespace}/{repo_name}/commits/{commit_id}/entries",


### PR DESCRIPTION
Added two endpoints, one for schemas and one to return data frames as json

To list schemas for a branch or commit:

```
curl -X GET -H 'Content-Type: application/json' "http://$SERVER/api/repos/oxen/CatVsDog/schemas/main" | jq
```

To list a data frame:

```
curl -X GET -H 'Content-Type: application/json' "http://$SERVER/api/repos/oxen/CatVsDog/df/main/annotations/train.csv
```

Data Frames default to returning slice=0..10  (first 10 items) but support all the query parameters that the CLI supports for `oxen df`

Example query params:
```
slice=10..23
take=1,2,32
columns=file,label
filter=min_x>10
aggregate=('label') -> (count('file'))
sort_by=min_x
randomize=true
reverse=true
```