### PR TITLE
Optimize dir size

### DIFF
--- a/src/lib/src/index/commit_dir_reader.rs
+++ b/src/lib/src/index/commit_dir_reader.rs
@@ -187,7 +187,7 @@ impl CommitDirReader {
                 let commit_dir_reader =
                     CommitDirEntryReader::new(&self.repository, &self.commit_id, &dir)?;
                 for entry in commit_dir_reader.list_entries()? {
-                    total_size += util::fs::version_file_size(&self.repository, &entry)?;
+                    total_size += entry.num_bytes;
 
                     let commit = if commits.contains_key(&entry.commit_id) {
                         Some(commits[&entry.commit_id].clone())


### PR DESCRIPTION
I forgot that we already computed file size on commit within the CommitEntry, so we don't have to do it again. Speeds up MSCoco compute from 11s -> 3s