### PR TITLE
🪟 Build Oxen on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,6 @@ dependencies = [
  "log",
  "nom",
  "num_cpus",
- "openssl",
  "polars",
  "rand",
  "rand_core 0.5.1",
@@ -58,7 +57,6 @@ dependencies = [
  "signal-hook",
  "simdutf8",
  "tar",
- "termion",
  "threadpool",
  "time 0.3.17",
  "tokio",
@@ -225,10 +223,10 @@ dependencies = [
  "actix-utils",
  "futures-core",
  "log",
- "openssl",
  "pin-project-lite",
- "tokio-openssl",
+ "tokio-rustls",
  "tokio-util 0.7.4",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -526,6 +524,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-process"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02111fd8655a613c25069ea89fc8d9bb89331fa77486eb3bc059ee757cfa481c"
+dependencies = [
+ "async-io",
+ "autocfg",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "libc",
+ "once_cell",
+ "signal-hook",
+ "winapi",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +562,7 @@ dependencies = [
  "async-global-executor",
  "async-io",
  "async-lock",
+ "async-process",
  "crossbeam-utils",
  "futures-channel",
  "futures-core",
@@ -2025,7 +2042,6 @@ dependencies = [
  "log",
  "nom",
  "num_cpus",
- "openssl",
  "polars",
  "rand",
  "rayon",
@@ -2039,7 +2055,6 @@ dependencies = [
  "signal-hook",
  "simdutf8",
  "tar",
- "termion",
  "threadpool",
  "time 0.3.17",
  "tokio",
@@ -2366,12 +2381,6 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
-name = "numtoa"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 
 [[package]]
 name = "once_cell"
@@ -2906,15 +2915,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_termios"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
-dependencies = [
- "redox_syscall",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3066,6 +3066,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3098,6 +3110,16 @@ name = "scratch"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -3437,18 +3459,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termion"
-version = "1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
-dependencies = [
- "libc",
- "numtoa",
- "redox_syscall",
- "redox_termios",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3597,15 +3607,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-openssl"
-version = "0.6.3"
+name = "tokio-rustls"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08f9ffb7809f1b20c1b398d92acf4cc719874b3b2b2d9ea2f09b4a80350878a"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "futures-util",
- "openssl",
- "openssl-sys",
+ "rustls",
  "tokio",
+ "webpki",
 ]
 
 [[package]]
@@ -3923,6 +3932,25 @@ checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ edition = "2018"
 actix-files = "0.6.0"
 actix-http = "3.0.4"
 actix-service = "2.0.2"
-actix-web = { version = "4", features = ["openssl"] }
+actix-web = { version = "4", features = ["rustls"] }
 actix-web-httpauth = "0.6.0"
 async-compression = { version = "0.3.14", features = ["futures-io", "gzip"] }
 async-recursion = "1.0.0"
-async-std = "1.12.0"
+async-std = { version = "1.12.0", features = ["unstable"] }
 async-tar = "0.4.2"
 bytes = "1.2.1"
 bytesize = "1.1.0"
@@ -43,7 +43,6 @@ lazy_static = "1.4.0"
 log = "0.4.17"
 nom = "7.1.1"
 num_cpus = "1.13.1"
-openssl = { version = "0.10" }
 polars = { version = "0.26.1", features = ["lazy", "parquet", "csv-file", "json", "ipc", "dtype-struct"] }
 rand = "0.8.5"
 rand_core = "0.5"
@@ -58,7 +57,6 @@ serde_url_params = "0.2.1"
 signal-hook = "0.3.13"
 simdutf8 = "0.1.4"
 tar = "0.4.38"
-termion = "1.5.6"
 threadpool = "1.8.1"
 time = { version = "0.3.17", features = ["serde"] }
 tokio = { version = "1", features = ["full"] }

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2018"
 
 [dependencies]
 actix-files = "0.6.0"
-actix-web = { version = "4", features = ["openssl"] }
+actix-web = { version = "4", features = ["rustls"] }
 async-compression = { version = "0.3.14", features = ["futures-io", "gzip"] }
 async-recursion = "1.0.0"
-async-std = "1.12.0"
+async-std = { version = "1.12.0", features = ["unstable"] }
 async-tar = "0.4.2"
 bytes = "1.2.1"
 bytesize = "1.1.0"
@@ -35,7 +35,6 @@ lazy_static = "1.4.0"
 log = "0.4.17"
 nom = "7.1.1"
 num_cpus = "1.13.1"
-openssl = { version = "0.10" }
 polars = { version = "0.26.1", features = ["lazy", "parquet", "csv-file", "json", "ipc", "dtype-struct"] }
 rand = "0.8.5"
 rayon = "1.5.1"
@@ -49,7 +48,6 @@ serde_url_params = "0.2.1"
 signal-hook = "0.3.13"
 simdutf8 = "0.1.4"
 tar = "0.4.38"
-termion = "1.5.6"
 threadpool = "1.8.1"
 time = { version = "0.3.17", features = ["serde"] }
 tokio = { version = "1", features = ["full"] }

--- a/src/server/Cargo.toml
+++ b/src/server/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 actix-files = "0.6.0"
 actix-http = "3.0.4"
 actix-service = "2.0.2"
-actix-web = { version = "4", features = ["openssl"] }
+actix-web = { version = "4", features = ["rustls"] }
 actix-web-httpauth = "0.6.0"
 bytesize = "1.1.0"
 chrono = "0.4.19"


### PR DESCRIPTION
This PR does a few small things;

- Remove `openssl` dependency in favor of `rustls`, one of the bigger issues with openssl is it's insistence on native build tools such as vcpkg and others. Switching to rustls makes sure we're building with the rust toolchain for tls support
- Remove `termion` from Cargo.toml, the dependency wasn't used and doesn't support windows
- Enable the "unstable" feature on `async-std` so that `async-tar` can compile (creating symlinks on windows is an "unstable" feature in `async-std`, but `async-tar` depends on it).

With these relatively minor dependency changes I've managed to build Oxen on windows.