### PR TITLE
Add health endpoint with disk usage info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ dependencies = [
  "serde_url_params",
  "signal-hook",
  "simdutf8",
+ "sysinfo",
  "tar",
  "threadpool",
  "time 0.3.17",
@@ -171,7 +172,7 @@ dependencies = [
  "firestorm",
  "http",
  "log",
- "regex 1.6.0",
+ "regex 1.7.1",
  "serde",
 ]
 
@@ -273,7 +274,7 @@ dependencies = [
  "mime",
  "once_cell",
  "pin-project-lite",
- "regex 1.6.0",
+ "regex 1.7.1",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -677,7 +678,7 @@ dependencies = [
  "peeking_take_while",
  "proc-macro2",
  "quote",
- "regex 1.6.0",
+ "regex 1.7.1",
  "rustc-hash",
  "shlex",
 ]
@@ -776,9 +777,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "bytesize"
@@ -844,9 +845,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -907,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "6.1.2"
+version = "6.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1090f39f45786ec6dc6286f8ea9c75d0a7ef0a0d3cda674cef0c3af7b307fbc2"
+checksum = "6e7b787b0dc42e8111badfdbe4c3059158ccb2db8780352fa1b01e8ccf45cc4d"
 dependencies = [
  "crossterm",
  "strum",
@@ -935,7 +936,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "regex 1.6.0",
+ "regex 1.7.1",
  "terminal_size",
  "unicode-width",
  "winapi",
@@ -1330,7 +1331,7 @@ dependencies = [
  "atty",
  "humantime",
  "log",
- "regex 1.6.0",
+ "regex 1.7.1",
  "termcolor",
 ]
 
@@ -1606,7 +1607,7 @@ dependencies = [
  "bstr",
  "fnv",
  "log",
- "regex 1.6.0",
+ "regex 1.7.1",
 ]
 
 [[package]]
@@ -1825,7 +1826,7 @@ dependencies = [
  "lazy_static",
  "log",
  "memchr",
- "regex 1.6.0",
+ "regex 1.7.1",
  "same-file",
  "thread_local 1.1.7",
  "walkdir",
@@ -2106,6 +2107,7 @@ dependencies = [
  "serde_url_params",
  "signal-hook",
  "simdutf8",
+ "sysinfo",
  "tar",
  "threadpool",
  "time 0.3.17",
@@ -2339,6 +2341,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d89e9874397a1f0a52fc1f197a8effd9735223cb2390e9dcc83ac6cd02923d0"
 dependencies = [
  "chrono",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -2667,7 +2678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48b9f792eceda75e0b4febff66105639933dd775007ed1f3a13ae4911c5d97e1"
 dependencies = [
  "lazy_static",
- "regex 1.6.0",
+ "regex 1.7.1",
 ]
 
 [[package]]
@@ -2717,7 +2728,7 @@ dependencies = [
  "rand",
  "rand_distr",
  "rayon",
- "regex 1.6.0",
+ "regex 1.7.1",
  "smartstring",
  "thiserror",
  "xxhash-rust",
@@ -2745,7 +2756,7 @@ dependencies = [
  "polars-time",
  "polars-utils",
  "rayon",
- "regex 1.6.0",
+ "regex 1.7.1",
  "serde_json",
  "simd-json",
  "simdutf8",
@@ -3003,9 +3014,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick 0.7.18",
  "memchr",
@@ -3484,6 +3495,21 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a81bbc26c485910df47772df6bbcdb417036132caa9e51e29d2e39c4636d4e"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ serde_json = "1.0.78"
 serde_url_params = "0.2.1"
 signal-hook = "0.3.13"
 simdutf8 = "0.1.4"
+sysinfo = "0.28.1"
 tar = "0.4.38"
 threadpool = "1.8.1"
 time = { version = "0.3.17", features = ["serde"] }

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -50,6 +50,7 @@ serde_json = "1.0.78"
 serde_url_params = "0.2.1"
 signal-hook = "0.3.13"
 simdutf8 = "0.1.4"
+sysinfo = "0.28.1"
 tar = "0.4.38"
 threadpool = "1.8.1"
 time = { version = "0.3.17", features = ["serde"] }

--- a/src/lib/src/view.rs
+++ b/src/lib/src/view.rs
@@ -2,6 +2,7 @@ pub mod branch;
 pub mod commit;
 pub mod entry;
 pub mod entry_meta_data;
+pub mod health;
 pub mod http;
 pub mod json_data_frame;
 pub mod namespace;
@@ -34,5 +35,6 @@ pub use crate::view::branch::{BranchNew, BranchResponse, BranchUpdate, ListBranc
 
 pub use crate::view::entry_meta_data::EntryMetaDataResponse;
 
+pub use crate::view::health::HealthResponse;
 pub use crate::view::oxen_response::OxenResponse;
 pub use crate::view::version::VersionResponse;

--- a/src/lib/src/view/health.rs
+++ b/src/lib/src/view/health.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct HealthResponse {
+    pub status: String,
+    pub status_message: String,
+    pub disk_usage: f64,
+}

--- a/src/lib/src/view/health.rs
+++ b/src/lib/src/view/health.rs
@@ -4,5 +4,13 @@ use serde::{Deserialize, Serialize};
 pub struct HealthResponse {
     pub status: String,
     pub status_message: String,
-    pub disk_usage: f64,
+    pub disk_usage: DiskUsage,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DiskUsage {
+    pub total_gb: f64,
+    pub used_gb: f64,
+    pub free_gb: f64,
+    pub percent_used: f64,
 }

--- a/src/server/src/controllers.rs
+++ b/src/server/src/controllers.rs
@@ -4,6 +4,7 @@ pub mod df;
 pub mod dir;
 pub mod entries;
 pub mod file;
+pub mod health;
 pub mod namespaces;
 pub mod repositories;
 pub mod schemas;

--- a/src/server/src/controllers/health.rs
+++ b/src/server/src/controllers/health.rs
@@ -1,0 +1,23 @@
+use crate::app_data::OxenAppData;
+use actix_web::{HttpRequest, HttpResponse};
+use liboxen::util;
+use liboxen::view::http::{MSG_RESOURCE_FOUND, STATUS_SUCCESS};
+use liboxen::view::{HealthResponse, StatusMessage};
+
+pub async fn index(req: HttpRequest) -> HttpResponse {
+    let app_data = req.app_data::<OxenAppData>().unwrap();
+    match util::fs::disk_usage_for_path(&app_data.path) {
+        Ok(disk_usage) => {
+            let response = HealthResponse {
+                status: String::from(STATUS_SUCCESS),
+                status_message: String::from(MSG_RESOURCE_FOUND),
+                disk_usage,
+            };
+            HttpResponse::Ok().json(response)
+        }
+        Err(err) => {
+            log::error!("Error getting disk usage: {:?}", err);
+            HttpResponse::InternalServerError().json(StatusMessage::internal_server_error())
+        }
+    }
+}

--- a/src/server/src/main.rs
+++ b/src/server/src/main.rs
@@ -120,6 +120,7 @@ async fn main() -> std::io::Result<()> {
                         App::new()
                             .app_data(data.clone())
                             .route("/api/version", web::get().to(controllers::version::index))
+                            .route("/api/health", web::get().to(controllers::health::index))
                             .route(
                                 "/api/namespaces",
                                 web::get().to(controllers::namespaces::index),


### PR DESCRIPTION
- Uses sysinfo library for gather disk info
- Selects the disk with the longest mount point that is a prefix of the oxen data directory
- Tested locally as well as in our Hub environment