### PR TITLE
Features: clone empty remote, enforce same root commit on push

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ Build the binaries
 
 `cargo build`
 
+If on intel mac, you may need to build with the following
+
+```
+$ rustup target install x86_64-apple-darwin
+$ cargo build --target x86_64-apple-darwin
+```
+
 Generate a config file and token to give user access to the server
 
 `./target/debug/oxen-server add-user --email ox@oxen.ai --name Ox --output user_config.toml`

--- a/src/lib/src/api/local/commits.rs
+++ b/src/lib/src/api/local/commits.rs
@@ -108,9 +108,6 @@ pub fn create_commit_object(repo_dir: &Path, commit: &Commit) -> Result<(), Oxen
     // Instantiate repo from dir
     let repo = LocalRepository::from_dir(repo_dir)?;
 
-    log::debug!("CREATE COMMIT OBJ {commit:?}");
-    log::debug!("WITH {} PARENTS", commit.parent_ids.len());
-
     // If we have a root, and we are trying to push a new one, don't allow it
     if let Ok(root) = command::root_commit(&repo) {
         if commit.parent_ids.is_empty() && root.id != commit.id {
@@ -120,7 +117,6 @@ pub fn create_commit_object(repo_dir: &Path, commit: &Commit) -> Result<(), Oxen
 
     // Check parent ids to make sure they are synced, otherwise we should not add to tree
     for id in commit.parent_ids.iter() {
-        log::debug!("CHECKING PARENT {} -> '{}'", commit.id, commit.message);
         if get_by_id_or_branch(&repo, id)?.is_none() {
             return Err(OxenError::basic_str("Parent commit not found"));
         }

--- a/src/lib/src/command.rs
+++ b/src/lib/src/command.rs
@@ -73,8 +73,7 @@ fn p_init(path: &Path) -> Result<LocalRepository, OxenError> {
     let repo = LocalRepository::new(path)?;
     repo.save(&config_path)?;
 
-    let commit = commit_with_no_files(&repo, constants::INITIAL_COMMIT_MSG)?;
-    println!("Initial commit {}", commit.id);
+    api::local::commits::commit_with_no_files(&repo, constants::INITIAL_COMMIT_MSG)?;
 
     // TODO: cleanup .oxen on failure
 
@@ -355,26 +354,8 @@ pub fn commit(repo: &LocalRepository, message: &str) -> Result<Option<Commit>, O
         );
         return Ok(None);
     }
-    let commit = p_commit(repo, &status, message)?;
+    let commit = api::local::commits::commit(repo, &status, message)?;
     Ok(Some(commit))
-}
-
-fn commit_with_no_files(repo: &LocalRepository, message: &str) -> Result<Commit, OxenError> {
-    let status = StagedData::empty();
-    let commit = p_commit(repo, &status, message)?;
-    Ok(commit)
-}
-
-fn p_commit(
-    repo: &LocalRepository,
-    status: &StagedData,
-    message: &str,
-) -> Result<Commit, OxenError> {
-    let stager = Stager::new(repo)?;
-    let commit_writer = CommitWriter::new(repo)?;
-    let commit = commit_writer.commit(status, message)?;
-    stager.unstage()?;
-    Ok(commit)
 }
 
 /// # Get a log of all the commits

--- a/src/lib/src/test.rs
+++ b/src/lib/src/test.rs
@@ -248,6 +248,49 @@ where
     Ok(())
 }
 
+/// Test where we synced training data to the remote
+pub async fn run_training_data_fully_sync_remote<T, Fut>(test: T) -> Result<(), OxenError>
+where
+    T: FnOnce(LocalRepository, RemoteRepository) -> Fut,
+    Fut: Future<Output = Result<RemoteRepository, OxenError>>,
+{
+    init_test_env();
+    let repo_dir = create_repo_dir(TEST_RUN_DIR)?;
+    let mut local_repo = command::init(&repo_dir)?;
+
+    // Write all the training data files
+    populate_dir_with_training_data(&repo_dir)?;
+    // Add all the files
+    command::add(&local_repo, &local_repo.path)?;
+    // Commit all the data locally
+    command::commit(&local_repo, "Adding all data")?;
+
+    // Create remote
+    let namespace = constants::DEFAULT_NAMESPACE;
+    let name = local_repo.dirname();
+    let remote_repo =
+        api::remote::repositories::create(&local_repo, namespace, &name, test_host()).await?;
+
+    // Add remote
+    let remote_url = repo_remote_url_from(&local_repo.dirname());
+    command::add_remote(&mut local_repo, constants::DEFAULT_REMOTE_NAME, &remote_url)?;
+    // Push data
+    command::push(&local_repo).await?;
+
+    // Run test to see if it panic'd
+    let result = match test(local_repo, remote_repo).await {
+        Ok(_remote_repo) => true,
+        Err(err) => {
+            eprintln!("Error running test. Err: {err}");
+            false
+        }
+    };
+
+    // Assert everything okay after we cleanup the repo dir
+    assert!(result);
+    Ok(())
+}
+
 /// Test interacting with a remote repo that was created via API, not local repo
 pub async fn run_no_commit_remote_repo_test<T, Fut>(test: T) -> Result<(), OxenError>
 where
@@ -344,7 +387,7 @@ where
     Ok(())
 }
 
-/// Run a test on a repo with a bunch of filees
+/// Run a test on a repo with a bunch of files
 pub fn run_training_data_repo_test_no_commits<T>(test: T) -> Result<(), OxenError>
 where
     T: FnOnce(LocalRepository) -> Result<(), OxenError> + std::panic::UnwindSafe,
@@ -386,13 +429,8 @@ where
 
     // Write all the files
     populate_dir_with_training_data(&repo_dir)?;
-    command::add(&repo, repo_dir.join("train"))?;
-    command::add(&repo, repo_dir.join("test"))?;
-    command::add(&repo, repo_dir.join("annotations"))?;
-    command::add(&repo, repo_dir.join("large_files"))?;
-    command::add(&repo, repo_dir.join("nlp"))?;
-    command::add(&repo, repo_dir.join("labels.txt"))?;
-    command::add(&repo, repo_dir.join("README.md"))?;
+    // Add all the files
+    command::add(&repo, &repo.path)?;
 
     // Make it easy to find these schemas during testing
     command::schema_name(&repo, "b821946753334c083124fd563377d795", "bounding_box")?;
@@ -432,13 +470,8 @@ where
 
     // Write all the files
     populate_dir_with_training_data(&repo_dir)?;
-    command::add(&repo, repo_dir.join("train"))?;
-    command::add(&repo, repo_dir.join("test"))?;
-    command::add(&repo, repo_dir.join("annotations"))?;
-    command::add(&repo, repo_dir.join("large_files"))?;
-    command::add(&repo, repo_dir.join("nlp"))?;
-    command::add(&repo, repo_dir.join("labels.txt"))?;
-    command::add(&repo, repo_dir.join("README.md"))?;
+    // Add all the files
+    command::add(&repo, &repo.path)?;
 
     // Make it easy to find these schemas during testing
     command::schema_name(&repo, "b821946753334c083124fd563377d795", "bounding_box")?;

--- a/src/server/src/controllers/repositories.rs
+++ b/src/server/src/controllers/repositories.rs
@@ -118,7 +118,7 @@ pub async fn stats(req: HttpRequest) -> HttpResponse {
 
 pub async fn create(req: HttpRequest, body: String) -> HttpResponse {
     let app_data = req.app_data::<OxenAppData>().unwrap();
-    // println!("controllers::repositories::create body:\n{}", body);
+    println!("controllers::repositories::create body:\n{}", body);
     let data: Result<RepositoryNew, serde_json::Error> = serde_json::from_str(&body);
     match data {
         Ok(data) => match api::local::repositories::create_empty(&app_data.path, &data) {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3083,7 +3083,7 @@ async fn test_oxen_clone_empty_repo_then_push() -> Result<(), OxenError> {
 }
 
 #[tokio::test]
-async fn test_cannot_push_separate_histories() -> Result<(), OxenError> {
+async fn test_cannot_push_two_separate_empty_roots() -> Result<(), OxenError> {
     test::run_no_commit_remote_repo_test(|remote_repo| async move {
         let ret_repo = remote_repo.clone();
 
@@ -3121,6 +3121,7 @@ async fn test_cannot_push_separate_histories() -> Result<(), OxenError> {
                 command::add(&second_cloned_repo, &new_file_path)?;
                 command::commit(&second_cloned_repo, "Adding third file path.")?;
 
+                // Push should FAIL
                 let result = command::push(&second_cloned_repo).await;
                 assert!(result.is_err());
 
@@ -3137,10 +3138,128 @@ async fn test_cannot_push_separate_histories() -> Result<(), OxenError> {
     .await
 }
 
-// TODO: Test that we cannot push two completely separate repos to the same history
-// 1) Create remote repo A with data
-// 2) Create remote repo B with data
-// 3) Clone repo A
-// 4) Clone repo B
-// 5) Add & commit file to repo B
-// 6) Push repo B to repo A and fail
+// Test that we cannot push two completely separate local repos to the same history
+// 1) Create repo A with data
+// 2) Create repo B with data
+// 3) Push Repo A
+// 4) Push repo B to repo A and fail
+#[tokio::test]
+async fn test_cannot_push_two_separate_repos() -> Result<(), OxenError> {
+    test::run_training_data_repo_test_fully_committed_async(|mut repo_1| async move {
+        test::run_training_data_repo_test_fully_committed_async(|mut repo_2| async move {
+            // Add to the first repo
+            let new_file = "new_file.txt";
+            let new_file_path = repo_1.path.join(new_file);
+            let new_file_path = test::write_txt_file_to_path(new_file_path, "new file")?;
+            command::add(&repo_1, &new_file_path)?;
+            command::commit(&repo_1, "Adding first file path.")?;
+            // Set/create the proper remote
+            let remote = test::repo_remote_url_from(&repo_1.dirname());
+            command::add_remote(&mut repo_1, constants::DEFAULT_REMOTE_NAME, &remote)?;
+            test::create_remote_repo(&repo_1).await?;
+            command::push(&repo_1).await?;
+
+            // Adding two commits to have a longer history that also should fail
+            let new_file = "new_file_2.txt";
+            let new_file_path = repo_2.path.join(new_file);
+            let new_file_path = test::write_txt_file_to_path(new_file_path, "new file 2")?;
+            command::add(&repo_2, &new_file_path)?;
+            command::commit(&repo_2, "Adding second file path.")?;
+
+            let new_file = "new_file_3.txt";
+            let new_file_path = repo_2.path.join(new_file);
+            let new_file_path = test::write_txt_file_to_path(new_file_path, "new file 3")?;
+            command::add(&repo_2, &new_file_path)?;
+            command::commit(&repo_2, "Adding third file path.")?;
+
+            // Set remote to the same as the first repo
+            command::add_remote(&mut repo_2, constants::DEFAULT_REMOTE_NAME, &remote)?;
+
+            // Push should FAIL
+            let result = command::push(&repo_2).await;
+            assert!(result.is_err());
+
+            Ok(())
+        })
+        .await?;
+
+        Ok(())
+    })
+    .await
+}
+
+// Test that we cannot clone separate repos with separate histories, then push to the same history
+// 1) Clone repo A with data
+// 2) Clone repo B with data
+// 3) Push Repo A
+// 4) Push repo B to repo A and fail
+#[tokio::test]
+async fn test_cannot_push_two_separate_cloned_repos() -> Result<(), OxenError> {
+    // Push the first repo with data
+    test::run_training_data_fully_sync_remote(|_, remote_repo_1| async move {
+        let remote_repo_1_copy = remote_repo_1.clone();
+
+        // Push the second repo with data
+        test::run_training_data_fully_sync_remote(|_, remote_repo_2| async move {
+            let remote_repo_2_copy = remote_repo_2.clone();
+            // Clone the first repo
+            test::run_empty_dir_test_async(|first_repo_dir| async move {
+                let shallow = false;
+                let first_cloned_repo =
+                    command::clone(&remote_repo_1.remote.url, &first_repo_dir, shallow).await?;
+
+                // Clone the second repo
+                test::run_empty_dir_test_async(|second_repo_dir| async move {
+                    let shallow = false;
+                    let mut second_cloned_repo =
+                        command::clone(&remote_repo_2.remote.url, &second_repo_dir, shallow)
+                            .await?;
+
+                    // Add to the first repo, after we have the second repo cloned
+                    let new_file = "new_file.txt";
+                    let new_file_path = first_cloned_repo.path.join(new_file);
+                    let new_file_path = test::write_txt_file_to_path(new_file_path, "new file")?;
+                    command::add(&first_cloned_repo, &new_file_path)?;
+                    command::commit(&first_cloned_repo, "Adding first file path.")?;
+                    command::push(&first_cloned_repo).await?;
+
+                    // Reset the remote on the second repo to the first repo
+                    let first_remote = test::repo_remote_url_from(&first_cloned_repo.dirname());
+                    command::add_remote(
+                        &mut second_cloned_repo,
+                        constants::DEFAULT_REMOTE_NAME,
+                        &first_remote,
+                    )?;
+
+                    // Adding two commits to have a longer history that also should fail
+                    let new_file = "new_file_2.txt";
+                    let new_file_path = second_cloned_repo.path.join(new_file);
+                    let new_file_path = test::write_txt_file_to_path(new_file_path, "new file 2")?;
+                    command::add(&second_cloned_repo, &new_file_path)?;
+                    command::commit(&second_cloned_repo, "Adding second file path.")?;
+
+                    let new_file = "new_file_3.txt";
+                    let new_file_path = second_cloned_repo.path.join(new_file);
+                    let new_file_path = test::write_txt_file_to_path(new_file_path, "new file 3")?;
+                    command::add(&second_cloned_repo, &new_file_path)?;
+                    command::commit(&second_cloned_repo, "Adding third file path.")?;
+
+                    // Push should FAIL
+                    let result = command::push(&second_cloned_repo).await;
+                    assert!(result.is_err());
+
+                    Ok(second_repo_dir)
+                })
+                .await?;
+
+                Ok(first_repo_dir)
+            })
+            .await?;
+            Ok(remote_repo_2_copy)
+        })
+        .await?;
+
+        Ok(remote_repo_1_copy)
+    })
+    .await
+}


### PR DESCRIPTION
There are two separate features here:

1) You can now clone an "empty repo" and it will create the initial commit for you locally
2) We are now checking to make sure you have pushed the parent before pushing a child. This makes it so you cannot push to a repo with a different history than yours.