### PR TITLE
Fix/checkout older commit after clone

### DIFF
--- a/src/cli/src/dispatch.rs
+++ b/src/cli/src/dispatch.rs
@@ -394,10 +394,10 @@ pub fn force_delete_branch(name: &str) -> Result<(), OxenError> {
     Ok(())
 }
 
-pub fn checkout(name: &str) -> Result<(), OxenError> {
+pub async fn checkout(name: &str) -> Result<(), OxenError> {
     let repo_dir = env::current_dir().unwrap();
     let repository = LocalRepository::from_dir(&repo_dir)?;
-    command::checkout(&repository, name)?;
+    command::checkout(&repository, name).await?;
     Ok(())
 }
 

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -58,7 +58,7 @@ async fn main() {
         Some((cmd_setup::RM, sub_matches)) => parse_and_run::rm(sub_matches),
         Some((cmd_setup::RESTORE, sub_matches)) => parse_and_run::restore(sub_matches),
         Some((cmd_setup::BRANCH, sub_matches)) => parse_and_run::branch(sub_matches).await,
-        Some((cmd_setup::CHECKOUT, sub_matches)) => parse_and_run::checkout(sub_matches),
+        Some((cmd_setup::CHECKOUT, sub_matches)) => parse_and_run::checkout(sub_matches).await,
         Some((cmd_setup::MERGE, sub_matches)) => parse_and_run::merge(sub_matches),
         Some((cmd_setup::PUSH, sub_matches)) => parse_and_run::push(sub_matches).await,
         Some((cmd_setup::PULL, sub_matches)) => parse_and_run::pull(sub_matches).await,

--- a/src/cli/src/parse_and_run.rs
+++ b/src/cli/src/parse_and_run.rs
@@ -339,7 +339,7 @@ pub async fn branch(sub_matches: &ArgMatches) {
     }
 }
 
-pub fn checkout(sub_matches: &ArgMatches) {
+pub async fn checkout(sub_matches: &ArgMatches) {
     if sub_matches.is_present("create") {
         let name = sub_matches.value_of("create").expect("required");
         if let Err(err) = dispatch::create_checkout_branch(name) {
@@ -352,7 +352,7 @@ pub fn checkout(sub_matches: &ArgMatches) {
         }
     } else if sub_matches.is_present("name") {
         let name = sub_matches.value_of("name").expect("required");
-        if let Err(err) = dispatch::checkout(name) {
+        if let Err(err) = dispatch::checkout(name).await {
             eprintln!("{err}")
         }
     } else {

--- a/src/lib/src/command.rs
+++ b/src/lib/src/command.rs
@@ -472,7 +472,7 @@ pub fn force_delete_branch(repo: &LocalRepository, name: &str) -> Result<(), Oxe
 /// # Checkout a branch or commit id
 /// This switches HEAD to point to the branch name or commit id,
 /// it also updates all the local files to be from the commit that this branch references
-pub fn checkout<S: AsRef<str>>(repo: &LocalRepository, value: S) -> Result<(), OxenError> {
+pub async fn checkout<S: AsRef<str>>(repo: &LocalRepository, value: S) -> Result<(), OxenError> {
     let value = value.as_ref();
     log::debug!("--- CHECKOUT START {} ----", value);
     if branch_exists(repo, value) {
@@ -482,7 +482,7 @@ pub fn checkout<S: AsRef<str>>(repo: &LocalRepository, value: S) -> Result<(), O
         }
 
         println!("Checkout branch: {value}");
-        set_working_branch(repo, value)?;
+        set_working_branch(repo, value).await?;
         set_head(repo, value)?;
     } else {
         // If we are already on the commit, do nothing
@@ -492,7 +492,7 @@ pub fn checkout<S: AsRef<str>>(repo: &LocalRepository, value: S) -> Result<(), O
         }
 
         println!("Checkout commit: {value}");
-        set_working_commit_id(repo, value)?;
+        set_working_commit_id(repo, value).await?;
         set_head(repo, value)?;
     }
     log::debug!("--- CHECKOUT END {} ----", value);
@@ -575,14 +575,14 @@ pub fn checkout_combine<P: AsRef<Path>>(repo: &LocalRepository, path: P) -> Resu
     }
 }
 
-fn set_working_branch(repo: &LocalRepository, name: &str) -> Result<(), OxenError> {
+async fn set_working_branch(repo: &LocalRepository, name: &str) -> Result<(), OxenError> {
     let commit_writer = CommitWriter::new(repo)?;
-    commit_writer.set_working_repo_to_branch(name)
+    commit_writer.set_working_repo_to_branch(name).await
 }
 
-fn set_working_commit_id(repo: &LocalRepository, commit_id: &str) -> Result<(), OxenError> {
+async fn set_working_commit_id(repo: &LocalRepository, commit_id: &str) -> Result<(), OxenError> {
     let commit_writer = CommitWriter::new(repo)?;
-    commit_writer.set_working_repo_to_commit_id(commit_id)
+    commit_writer.set_working_repo_to_commit_id(commit_id).await
 }
 
 fn set_head(repo: &LocalRepository, value: &str) -> Result<(), OxenError> {

--- a/src/lib/src/constants.rs
+++ b/src/lib/src/constants.rs
@@ -12,7 +12,7 @@ pub const REFS_DIR: &str = "refs";
 /// history/ dir is a list of directories named after commit ids
 pub const HISTORY_DIR: &str = "history";
 /// commits/ is a key-value database of commit ids to commit objects
-pub const COMMITS_DB: &str = "commits";
+pub const COMMITS_DIR: &str = "commits";
 /// name of the schema db
 pub const SCHEMAS_DIR: &str = "schemas";
 /// prefix for the commit rows
@@ -21,8 +21,10 @@ pub const ROWS_DIR: &str = "rows";
 pub const FILES_DIR: &str = "files";
 /// prefix for the commit entry dirs
 pub const DIRS_DIR: &str = "dirs";
-/// prefix for the commit entry dirs
+/// prefix for the cached stats dirs
 pub const CACHE_DIR: &str = "cache";
+/// prefix for the sync status dirs to tell if commits are synced locally
+pub const SYNC_STATUS_DIR: &str = "sync_status";
 /// prefix for the commit indices
 pub const INDICES_DIR: &str = "indices";
 /// prefix for the schema fields that are indexed
@@ -41,6 +43,7 @@ pub const ORIG_HEAD_FILE: &str = "ORIG_HEAD";
 // Precomputed vals
 pub const HASH_FILE: &str = "HASH";
 pub const CONTENT_IS_VALID: &str = "CONTENT_IS_VALID";
+pub const IS_SYNCED: &str = "IS_SYNCED";
 
 // Default Remotes and Origins
 pub const DEFAULT_BRANCH_NAME: &str = "main";

--- a/src/lib/src/index.rs
+++ b/src/lib/src/index.rs
@@ -4,6 +4,7 @@ pub mod commit_dir_entry_writer;
 pub mod commit_dir_reader;
 pub mod commit_entry_writer;
 pub mod commit_reader;
+pub mod commit_sync_status;
 pub mod commit_validator;
 pub mod commit_writer;
 pub mod differ;

--- a/src/lib/src/index/commit_reader.rs
+++ b/src/lib/src/index/commit_reader.rs
@@ -1,4 +1,4 @@
-use crate::constants::COMMITS_DB;
+use crate::constants::COMMITS_DIR;
 use crate::db;
 use crate::error::OxenError;
 use crate::index::CommitDBReader;
@@ -19,7 +19,7 @@ pub struct CommitReader {
 impl CommitReader {
     /// Create a new reader that can find commits, list history, etc
     pub fn new(repository: &LocalRepository) -> Result<CommitReader, OxenError> {
-        let db_path = util::fs::oxen_hidden_dir(&repository.path).join(COMMITS_DB);
+        let db_path = util::fs::oxen_hidden_dir(&repository.path).join(COMMITS_DIR);
         let opts = db::opts::default();
         if !db_path.exists() {
             std::fs::create_dir_all(&db_path)?;

--- a/src/lib/src/index/commit_sync_status.rs
+++ b/src/lib/src/index/commit_sync_status.rs
@@ -1,0 +1,49 @@
+use crate::constants;
+use crate::error::OxenError;
+use crate::model::{Commit, LocalRepository};
+
+use std::path::PathBuf;
+
+pub fn commit_is_synced(repo: &LocalRepository, commit: &Commit) -> bool {
+    let is_synced_path = commit_is_synced_file_path(repo, commit);
+    log::debug!("Checking if commit is synced: {is_synced_path:?}");
+    match std::fs::read_to_string(&is_synced_path) {
+        Ok(value) => {
+            log::debug!("Is synced value: {value}");
+            "true" == value
+        }
+        Err(err) => {
+            log::debug!("Could not read is_synced file {is_synced_path:?}: {}", err);
+            false
+        }
+    }
+}
+
+pub fn mark_commit_as_synced(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError> {
+    let is_synced_path = commit_is_synced_file_path(repo, commit);
+    if let Some(parent) = is_synced_path.parent() {
+        if !parent.exists() {
+            log::debug!("Creating parent directory: {parent:?}");
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+
+    log::debug!("Writing is synced: {is_synced_path:?}");
+
+    match std::fs::write(&is_synced_path, "true") {
+        Ok(_) => Ok(()),
+        Err(err) => Err(OxenError::basic_str(format!(
+            "Could not write is_synced file: {}",
+            err
+        ))),
+    }
+}
+
+fn commit_is_synced_file_path(repo: &LocalRepository, commit: &Commit) -> PathBuf {
+    repo.path
+        .join(constants::OXEN_HIDDEN_DIR)
+        .join(constants::SYNC_STATUS_DIR)
+        .join(constants::COMMITS_DIR)
+        .join(&commit.id)
+        .join(constants::IS_SYNCED)
+}

--- a/src/lib/src/index/entry_indexer.rs
+++ b/src/lib/src/index/entry_indexer.rs
@@ -12,7 +12,6 @@ use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use crate::api;
 use crate::api::remote::commits::ChunkParams;
 use crate::constants::{AVG_CHUNK_SIZE, HISTORY_DIR};
 use crate::error::OxenError;
@@ -22,6 +21,7 @@ use crate::index::{
 };
 use crate::model::{Commit, CommitEntry, LocalRepository, RemoteBranch, RemoteRepository};
 use crate::util;
+use crate::{api, index};
 
 pub struct UnsyncedCommitEntries {
     commit: Commit,
@@ -686,11 +686,20 @@ impl EntryIndexer {
         };
 
         if let Some(commit) = self.pull_all_commit_objects(&remote_repo, rb).await? {
-            let limit: usize = 0; // zero means pull all
-            self.pull_entries_for_commit(&remote_repo, &commit, limit)
+            self.pull_all_entries_for_commit(&remote_repo, &commit)
                 .await?;
         }
         Ok(())
+    }
+
+    pub async fn pull_all_entries_for_commit(
+        &self,
+        remote_repo: &RemoteRepository,
+        commit: &Commit,
+    ) -> Result<(), OxenError> {
+        let limit: usize = 0; // zero means pull all
+        self.pull_entries_for_commit(remote_repo, commit, limit)
+            .await
     }
 
     pub async fn pull_all_commit_objects(
@@ -717,6 +726,11 @@ impl EntryIndexer {
                 // Sync the commit objects
                 self.rpull_missing_commit_objects(remote_repo, &commit)
                     .await?;
+                log::debug!(
+                    "pull_all_commit_objects DONE {} -> '{}'",
+                    commit.id,
+                    commit.message
+                );
                 return Ok(Some(commit));
             }
             Ok(None) => {
@@ -884,12 +898,27 @@ impl EntryIndexer {
         results
     }
 
-    async fn pull_entries_for_commit(
+    pub async fn pull_entries_for_commit(
         &self,
         remote_repo: &RemoteRepository,
         commit: &Commit,
         limit: usize,
     ) -> Result<(), OxenError> {
+        log::debug!(
+            "🐂 pull_entries_for_commit_id commit {} -> '{}'",
+            commit.id,
+            commit.message
+        );
+
+        if index::commit_sync_status::commit_is_synced(&self.repository, commit) {
+            log::debug!(
+                "🐂 commit {} -> '{}' is already synced",
+                commit.id,
+                commit.message
+            );
+            return Ok(());
+        }
+
         let entries = self.read_pulled_commit_entries(commit, limit)?;
         log::debug!(
             "🐂 pull_entries_for_commit_id commit_id {} limit {} entries.len() {}",
@@ -932,6 +961,12 @@ impl EntryIndexer {
                 (Ok(_), Ok(_)) => {
                     log::debug!("Successfully synced entries!");
                     self.unpack_version_files(commit, entries)?;
+
+                    if limit == 0 {
+                        // limit == 0 means we pulled everything
+                        // Mark as synced so we know we don't need to pull versions files again
+                        index::commit_sync_status::mark_commit_as_synced(&self.repository, commit)?;
+                    }
                 }
                 (Err(err), Ok(_)) => {
                     let err = format!("Error syncing large entries: {err}");
@@ -1181,6 +1216,7 @@ impl EntryIndexer {
         });
 
         bar.finish();
+
         Ok(())
     }
 

--- a/src/lib/src/index/restore.rs
+++ b/src/lib/src/index/restore.rs
@@ -101,6 +101,7 @@ fn restore_regular(
         std::fs::create_dir_all(parent)?;
     }
 
+    log::debug!("Restore file: {:?}", entry.path);
     std::fs::copy(version_path, working_path)?;
     Ok(())
 }

--- a/src/lib/src/index/restore.rs
+++ b/src/lib/src/index/restore.rs
@@ -75,12 +75,24 @@ pub fn restore_file(
     commit_id: &str,
     entry: &CommitEntry,
 ) -> Result<(), OxenError> {
+    // Update the local modified timestamps
+    let dir = path.parent().unwrap();
+    let committer = CommitDirEntryWriter::new(repo, commit_id, dir)?;
+    restore_file_with_commit_writer(repo, path, entry, &committer)?;
+
+    Ok(())
+}
+
+pub fn restore_file_with_commit_writer(
+    repo: &LocalRepository,
+    path: &Path,
+    entry: &CommitEntry,
+    committer: &CommitDirEntryWriter,
+) -> Result<(), OxenError> {
     // copy data back over
     restore_regular(repo, path, entry)?;
 
     // Update the local modified timestamps
-    let dir = path.parent().unwrap();
-    let committer = CommitDirEntryWriter::new(repo, commit_id, dir).unwrap();
     let working_path = repo.path.join(path);
     let metadata = std::fs::metadata(working_path).unwrap();
     let mtime = FileTime::from_last_modification_time(&metadata);

--- a/src/lib/src/test.rs
+++ b/src/lib/src/test.rs
@@ -7,6 +7,7 @@ use crate::constants;
 use crate::error::OxenError;
 use crate::index::{RefWriter, Stager};
 use crate::model::{LocalRepository, RemoteRepository};
+use crate::opts::RmOpts;
 
 use env_logger::Env;
 use rand::Rng;
@@ -260,10 +261,29 @@ where
 
     // Write all the training data files
     populate_dir_with_training_data(&repo_dir)?;
+    // Make a few commits before we sync
+    command::add(&local_repo, local_repo.path.join("train"))?;
+    command::commit(&local_repo, "Adding train/")?;
+
+    command::add(&local_repo, local_repo.path.join("test"))?;
+    command::commit(&local_repo, "Adding test/")?;
+
+    command::add(&local_repo, local_repo.path.join("annotations"))?;
+    command::commit(&local_repo, "Adding annotations/")?;
+
+    // Remove the test dir to make a more complex history
+    let rm_opts = RmOpts {
+        path: PathBuf::from("test"),
+        recursive: true,
+        staged: false,
+    };
+    command::rm(&local_repo, &rm_opts)?;
+    command::commit(&local_repo, "Removing test/")?;
+
     // Add all the files
     command::add(&local_repo, &local_repo.path)?;
     // Commit all the data locally
-    command::commit(&local_repo, "Adding all data")?;
+    command::commit(&local_repo, "Adding rest of data")?;
 
     // Create remote
     let namespace = constants::DEFAULT_NAMESPACE;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -290,20 +290,21 @@ fn test_command_restore_file_from_commit_id() -> Result<(), OxenError> {
     })
 }
 
-#[test]
-fn test_command_checkout_non_existant_commit_id() -> Result<(), OxenError> {
-    test::run_empty_local_repo_test(|repo| {
+#[tokio::test]
+async fn test_command_checkout_non_existant_commit_id() -> Result<(), OxenError> {
+    test::run_empty_local_repo_test_async(|repo| async move {
         // This shouldn't work
-        let checkout_result = command::checkout(&repo, "non-existant");
+        let checkout_result = command::checkout(&repo, "non-existant").await;
         assert!(checkout_result.is_err());
 
         Ok(())
     })
+    .await
 }
 
-#[test]
-fn test_command_checkout_commit_id() -> Result<(), OxenError> {
-    test::run_empty_local_repo_test(|repo| {
+#[tokio::test]
+async fn test_command_checkout_commit_id() -> Result<(), OxenError> {
+    test::run_empty_local_repo_test_async(|repo| async move {
         // Write a hello file
         let hello_file = repo.path.join("hello.txt");
         util::fs::write_to_path(&hello_file, "Hello")?;
@@ -329,7 +330,7 @@ fn test_command_checkout_commit_id() -> Result<(), OxenError> {
         assert!(world_file.exists());
 
         // We checkout the previous commit
-        command::checkout(&repo, first_commit.unwrap().id)?;
+        command::checkout(&repo, first_commit.unwrap().id).await?;
 
         // // Then we do not have the world file anymore
         assert!(!world_file.exists());
@@ -340,6 +341,7 @@ fn test_command_checkout_commit_id() -> Result<(), OxenError> {
 
         Ok(())
     })
+    .await
 }
 
 #[test]
@@ -388,9 +390,9 @@ fn test_command_commit_dir_recursive() -> Result<(), OxenError> {
     })
 }
 
-#[test]
-fn test_command_checkout_current_branch_name_does_nothing() -> Result<(), OxenError> {
-    test::run_empty_local_repo_test(|repo| {
+#[tokio::test]
+async fn test_command_checkout_current_branch_name_does_nothing() -> Result<(), OxenError> {
+    test::run_empty_local_repo_test_async(|repo| async move {
         // Write the first file
         let hello_file = repo.path.join("hello.txt");
         util::fs::write_to_path(&hello_file, "Hello")?;
@@ -402,15 +404,16 @@ fn test_command_checkout_current_branch_name_does_nothing() -> Result<(), OxenEr
         // Create and checkout branch
         let branch_name = "feature/world-explorer";
         command::create_checkout_branch(&repo, branch_name)?;
-        command::checkout(&repo, branch_name)?;
+        command::checkout(&repo, branch_name).await?;
 
         Ok(())
     })
+    .await
 }
 
-#[test]
-fn test_command_checkout_added_file() -> Result<(), OxenError> {
-    test::run_empty_local_repo_test(|repo| {
+#[tokio::test]
+async fn test_command_checkout_added_file() -> Result<(), OxenError> {
+    test::run_empty_local_repo_test_async(|repo| async move {
         // Write the first file
         let hello_file = repo.path.join("hello.txt");
         util::fs::write_to_path(&hello_file, "Hello")?;
@@ -446,24 +449,25 @@ fn test_command_checkout_added_file() -> Result<(), OxenError> {
         assert!(world_file.exists());
 
         // Go back to the main branch
-        command::checkout(&repo, orig_branch.name)?;
+        command::checkout(&repo, orig_branch.name).await?;
 
         // The world file should no longer be there
         assert!(hello_file.exists());
         assert!(!world_file.exists());
 
         // Go back to the world branch
-        command::checkout(&repo, branch_name)?;
+        command::checkout(&repo, branch_name).await?;
         assert!(hello_file.exists());
         assert!(world_file.exists());
 
         Ok(())
     })
+    .await
 }
 
-#[test]
-fn test_command_checkout_added_file_keep_untracked() -> Result<(), OxenError> {
-    test::run_empty_local_repo_test(|repo| {
+#[tokio::test]
+async fn test_command_checkout_added_file_keep_untracked() -> Result<(), OxenError> {
+    test::run_empty_local_repo_test_async(|repo| async move {
         // Write the first file
         let hello_file = repo.path.join("hello.txt");
         util::fs::write_to_path(&hello_file, "Hello")?;
@@ -504,7 +508,7 @@ fn test_command_checkout_added_file_keep_untracked() -> Result<(), OxenError> {
         assert!(keep_file.exists());
 
         // Go back to the main branch
-        command::checkout(&repo, orig_branch.name)?;
+        command::checkout(&repo, orig_branch.name).await?;
 
         // The world file should no longer be there
         assert!(hello_file.exists());
@@ -512,18 +516,19 @@ fn test_command_checkout_added_file_keep_untracked() -> Result<(), OxenError> {
         assert!(keep_file.exists());
 
         // Go back to the world branch
-        command::checkout(&repo, branch_name)?;
+        command::checkout(&repo, branch_name).await?;
         assert!(hello_file.exists());
         assert!(world_file.exists());
         assert!(keep_file.exists());
 
         Ok(())
     })
+    .await
 }
 
-#[test]
-fn test_command_checkout_modified_file() -> Result<(), OxenError> {
-    test::run_empty_local_repo_test(|repo| {
+#[tokio::test]
+async fn test_command_checkout_modified_file() -> Result<(), OxenError> {
+    test::run_empty_local_repo_test_async(|repo| async move {
         // Write the first file
         let hello_file = repo.path.join("hello.txt");
         util::fs::write_to_path(&hello_file, "Hello")?;
@@ -550,7 +555,7 @@ fn test_command_checkout_modified_file() -> Result<(), OxenError> {
         assert_eq!(util::fs::read_from_path(&hello_file)?, "World");
 
         // Go back to the main branch
-        command::checkout(&repo, orig_branch.name)?;
+        command::checkout(&repo, orig_branch.name).await?;
 
         // The file contents should be Hello, not World
         log::debug!("HELLO FILE NAME: {:?}", hello_file);
@@ -561,6 +566,7 @@ fn test_command_checkout_modified_file() -> Result<(), OxenError> {
 
         Ok(())
     })
+    .await
 }
 
 #[test]
@@ -586,9 +592,9 @@ fn test_command_add_modified_file_in_subdirectory() -> Result<(), OxenError> {
     })
 }
 
-#[test]
-fn test_command_checkout_modified_file_in_subdirectory() -> Result<(), OxenError> {
-    test::run_training_data_repo_test_no_commits(|repo| {
+#[tokio::test]
+async fn test_command_checkout_modified_file_in_subdirectory() -> Result<(), OxenError> {
+    test::run_training_data_repo_test_no_commits_async(|repo| async move {
         // Get the original branch name
         let orig_branch = command::current_branch(&repo)?.unwrap();
 
@@ -614,22 +620,23 @@ fn test_command_checkout_modified_file_in_subdirectory() -> Result<(), OxenError
         command::commit(&repo, "Changing one shot")?;
 
         // checkout OG and make sure it reverts
-        command::checkout(&repo, orig_branch.name)?;
+        command::checkout(&repo, orig_branch.name).await?;
         let updated_content = util::fs::read_from_path(&one_shot_path)?;
         assert_eq!(og_content, updated_content);
 
         // checkout branch again and make sure it reverts
-        command::checkout(&repo, branch_name)?;
+        command::checkout(&repo, branch_name).await?;
         let updated_content = util::fs::read_from_path(&one_shot_path)?;
         assert_eq!(file_contents, updated_content);
 
         Ok(())
     })
+    .await
 }
 
-#[test]
-fn test_command_checkout_modified_file_from_fully_committed_repo() -> Result<(), OxenError> {
-    test::run_training_data_repo_test_no_commits(|repo| {
+#[tokio::test]
+async fn test_command_checkout_modified_file_from_fully_committed_repo() -> Result<(), OxenError> {
+    test::run_training_data_repo_test_no_commits_async(|repo| async move {
         // Get the original branch name
         let orig_branch = command::current_branch(&repo)?.unwrap();
 
@@ -658,22 +665,23 @@ fn test_command_checkout_modified_file_from_fully_committed_repo() -> Result<(),
         command::commit(&repo, "Changing one shot")?;
 
         // checkout OG and make sure it reverts
-        command::checkout(&repo, orig_branch.name)?;
+        command::checkout(&repo, orig_branch.name).await?;
         let updated_content = util::fs::read_from_path(&one_shot_path)?;
         assert_eq!(og_content, updated_content);
 
         // checkout branch again and make sure it reverts
-        command::checkout(&repo, branch_name)?;
+        command::checkout(&repo, branch_name).await?;
         let updated_content = util::fs::read_from_path(&one_shot_path)?;
         assert_eq!(file_contents, updated_content);
 
         Ok(())
     })
+    .await
 }
 
-#[test]
-fn test_command_commit_top_level_dir_then_revert() -> Result<(), OxenError> {
-    test::run_training_data_repo_test_no_commits(|repo| {
+#[tokio::test]
+async fn test_command_commit_top_level_dir_then_revert() -> Result<(), OxenError> {
+    test::run_training_data_repo_test_no_commits_async(|repo| async move {
         // Get the original branch name
         let orig_branch = command::current_branch(&repo)?.unwrap();
 
@@ -698,21 +706,22 @@ fn test_command_commit_top_level_dir_then_revert() -> Result<(), OxenError> {
         assert_eq!(status.added_dirs.len(), 0);
 
         // checkout OG and make sure it removes the train dir
-        command::checkout(&repo, orig_branch.name)?;
+        command::checkout(&repo, orig_branch.name).await?;
         assert!(!train_path.exists());
 
         // checkout branch again and make sure it reverts
-        command::checkout(&repo, branch_name)?;
+        command::checkout(&repo, branch_name).await?;
         assert!(train_path.exists());
         assert_eq!(util::fs::rcount_files_in_dir(&train_path), og_num_files);
 
         Ok(())
     })
+    .await
 }
 
-#[test]
-fn test_command_add_second_level_dir_then_revert() -> Result<(), OxenError> {
-    test::run_training_data_repo_test_no_commits(|repo| {
+#[tokio::test]
+async fn test_command_add_second_level_dir_then_revert() -> Result<(), OxenError> {
+    test::run_training_data_repo_test_no_commits_async(|repo| async move {
         // Get the original branch name
         let orig_branch = command::current_branch(&repo)?.unwrap();
 
@@ -728,16 +737,17 @@ fn test_command_add_second_level_dir_then_revert() -> Result<(), OxenError> {
         command::commit(&repo, "Adding train dir")?;
 
         // checkout OG and make sure it removes the train dir
-        command::checkout(&repo, orig_branch.name)?;
+        command::checkout(&repo, orig_branch.name).await?;
         assert!(!new_dir_path.exists());
 
         // checkout branch again and make sure it reverts
-        command::checkout(&repo, branch_name)?;
+        command::checkout(&repo, branch_name).await?;
         assert!(new_dir_path.exists());
         assert_eq!(util::fs::rcount_files_in_dir(&new_dir_path), og_num_files);
 
         Ok(())
     })
+    .await
 }
 
 #[test]
@@ -761,9 +771,10 @@ fn test_command_add_removed_file() -> Result<(), OxenError> {
     })
 }
 
-#[test]
-fn test_command_restore_removed_file_from_branch_with_commits_between() -> Result<(), OxenError> {
-    test::run_training_data_repo_test_no_commits(|repo| {
+#[tokio::test]
+async fn test_command_restore_removed_file_from_branch_with_commits_between(
+) -> Result<(), OxenError> {
+    test::run_training_data_repo_test_no_commits_async(|repo| async move {
         // (file already created in helper)
         let file_to_remove = repo.path.join("labels.txt");
 
@@ -795,12 +806,13 @@ fn test_command_restore_removed_file_from_branch_with_commits_between() -> Resul
         assert!(!file_to_remove.exists());
 
         // Switch back to main branch
-        command::checkout(&repo, orig_branch.name)?;
+        command::checkout(&repo, orig_branch.name).await?;
         // Make sure we restore file
         assert!(file_to_remove.exists());
 
         Ok(())
     })
+    .await
 }
 
 #[test]
@@ -834,9 +846,9 @@ fn test_command_commit_removed_dir() -> Result<(), OxenError> {
     })
 }
 
-#[test]
-fn test_command_remove_dir_then_revert() -> Result<(), OxenError> {
-    test::run_training_data_repo_test_no_commits(|repo| {
+#[tokio::test]
+async fn test_command_remove_dir_then_revert() -> Result<(), OxenError> {
+    test::run_training_data_repo_test_no_commits_async(|repo| async move {
         // Get the original branch name
         let orig_branch = command::current_branch(&repo)?.unwrap();
 
@@ -860,16 +872,17 @@ fn test_command_remove_dir_then_revert() -> Result<(), OxenError> {
         command::commit(&repo, "Removing train dir")?;
 
         // checkout OG and make sure it restores the train dir
-        command::checkout(&repo, orig_branch.name)?;
+        command::checkout(&repo, orig_branch.name).await?;
         assert!(dir_to_remove.exists());
         assert_eq!(util::fs::rcount_files_in_dir(&dir_to_remove), og_num_files);
 
         // checkout branch again and make sure it reverts
-        command::checkout(&repo, branch_name)?;
+        command::checkout(&repo, branch_name).await?;
         assert!(!dir_to_remove.exists());
 
         Ok(())
     })
+    .await
 }
 
 #[tokio::test]
@@ -1660,10 +1673,22 @@ async fn test_push_pull_push_pull_on_branch() -> Result<(), OxenError> {
 // Make sure we can push again after pulling on the other side, then pull again
 #[tokio::test]
 async fn test_push_pull_push_pull_on_other_branch() -> Result<(), OxenError> {
-    test::run_training_data_repo_test_no_commits_async(|mut repo| async move {
+    test::run_empty_local_repo_test_async(|mut repo| async move {
         // Track a dir
-        let train_path = repo.path.join("train");
-        command::add(&repo, &train_path)?;
+        let train_dir = repo.path.join("train");
+        let train_paths = vec![
+            Path::new("data/test/images/cat_1.jpg"),
+            Path::new("data/test/images/cat_2.jpg"),
+            Path::new("data/test/images/cat_3.jpg"),
+            Path::new("data/test/images/dog_1.jpg"),
+            Path::new("data/test/images/dog_2.jpg"),
+        ];
+        std::fs::create_dir_all(&train_dir)?;
+        for path in train_paths.iter() {
+            std::fs::copy(path, train_dir.join(path.file_name().unwrap()))?;
+        }
+
+        command::add(&repo, &train_dir)?;
         command::commit(&repo, "Adding train dir")?.unwrap();
 
         let og_branch = command::current_branch(&repo)?.unwrap();
@@ -1685,10 +1710,10 @@ async fn test_push_pull_push_pull_on_other_branch() -> Result<(), OxenError> {
                 command::clone(&remote_repo.remote.url, &new_repo_dir, shallow).await?;
             command::pull(&cloned_repo).await?;
             let cloned_num_files = util::fs::rcount_files_in_dir(&cloned_repo.path);
-            // 5 training files
-            assert_eq!(5, cloned_num_files);
+            // the original training files
+            assert_eq!(train_paths.len(), cloned_num_files);
 
-            // Create a branch to collab on
+            // Create a branch to collaborate on
             let branch_name = "adding-training-data";
             command::create_checkout_branch(&cloned_repo, branch_name)?;
 
@@ -1707,8 +1732,8 @@ async fn test_push_pull_push_pull_on_other_branch() -> Result<(), OxenError> {
             command::pull_remote_branch(&repo, constants::DEFAULT_REMOTE_NAME, &og_branch.name)
                 .await?;
             let og_num_files = util::fs::rcount_files_in_dir(&repo.path);
-            // Now there should be still be 5 train files
-            assert_eq!(5, og_num_files);
+            // Now there should be still be the original train files, not the new file
+            assert_eq!(train_paths.len(), og_num_files);
 
             api::remote::repositories::delete(&remote_repo).await?;
 
@@ -1916,9 +1941,9 @@ fn test_do_not_commit_any_files_on_init() -> Result<(), OxenError> {
     })
 }
 
-#[test]
-fn test_delete_branch() -> Result<(), OxenError> {
-    test::run_training_data_repo_test_no_commits(|repo| {
+#[tokio::test]
+async fn test_delete_branch() -> Result<(), OxenError> {
+    test::run_training_data_repo_test_no_commits_async(|repo| async move {
         // Get the original branches
         let og_branches = command::list_branches(&repo)?;
         let og_branch = command::current_branch(&repo)?.unwrap();
@@ -1927,7 +1952,7 @@ fn test_delete_branch() -> Result<(), OxenError> {
         command::create_checkout_branch(&repo, branch_name)?;
 
         // Must checkout main again before deleting
-        command::checkout(&repo, og_branch.name)?;
+        command::checkout(&repo, og_branch.name).await?;
 
         // Now we can delete
         command::delete_branch(&repo, branch_name)?;
@@ -1938,11 +1963,12 @@ fn test_delete_branch() -> Result<(), OxenError> {
 
         Ok(())
     })
+    .await
 }
 
-#[test]
-fn test_cannot_delete_branch_you_are_on() -> Result<(), OxenError> {
-    test::run_training_data_repo_test_no_commits(|repo| {
+#[tokio::test]
+async fn test_cannot_delete_branch_you_are_on() -> Result<(), OxenError> {
+    test::run_training_data_repo_test_no_commits_async(|repo| async move {
         let branch_name = "my-branch";
         command::create_checkout_branch(&repo, branch_name)?;
 
@@ -1953,6 +1979,7 @@ fn test_cannot_delete_branch_you_are_on() -> Result<(), OxenError> {
 
         Ok(())
     })
+    .await
 }
 
 #[test]
@@ -1970,9 +1997,9 @@ fn test_cannot_force_delete_branch_you_are_on() -> Result<(), OxenError> {
     })
 }
 
-#[test]
-fn test_cannot_delete_branch_that_is_ahead_of_current() -> Result<(), OxenError> {
-    test::run_training_data_repo_test_no_commits(|repo| {
+#[tokio::test]
+async fn test_cannot_delete_branch_that_is_ahead_of_current() -> Result<(), OxenError> {
+    test::run_training_data_repo_test_no_commits_async(|repo| async move {
         let og_branches = command::list_branches(&repo)?;
         let og_branch = command::current_branch(&repo)?.unwrap();
 
@@ -1985,7 +2012,7 @@ fn test_cannot_delete_branch_that_is_ahead_of_current() -> Result<(), OxenError>
         command::commit(&repo, "adding initial labels file")?;
 
         // Checkout main again
-        command::checkout(&repo, og_branch.name)?;
+        command::checkout(&repo, og_branch.name).await?;
 
         // Should not be able to delete `my-branch` because it is ahead of `main`
         if command::delete_branch(&repo, branch_name).is_ok() {
@@ -1998,11 +2025,12 @@ fn test_cannot_delete_branch_that_is_ahead_of_current() -> Result<(), OxenError>
 
         Ok(())
     })
+    .await
 }
 
-#[test]
-fn test_force_delete_branch_that_is_ahead_of_current() -> Result<(), OxenError> {
-    test::run_training_data_repo_test_no_commits(|repo| {
+#[tokio::test]
+async fn test_force_delete_branch_that_is_ahead_of_current() -> Result<(), OxenError> {
+    test::run_training_data_repo_test_no_commits_async(|repo| async move {
         let og_branches = command::list_branches(&repo)?;
         let og_branch = command::current_branch(&repo)?.unwrap();
 
@@ -2015,7 +2043,7 @@ fn test_force_delete_branch_that_is_ahead_of_current() -> Result<(), OxenError> 
         command::commit(&repo, "adding initial labels file")?;
 
         // Checkout main again
-        command::checkout(&repo, og_branch.name)?;
+        command::checkout(&repo, og_branch.name).await?;
 
         // Force delete
         command::force_delete_branch(&repo, branch_name)?;
@@ -2026,11 +2054,12 @@ fn test_force_delete_branch_that_is_ahead_of_current() -> Result<(), OxenError> 
 
         Ok(())
     })
+    .await
 }
 
-#[test]
-fn test_merge_conflict_shows_in_status() -> Result<(), OxenError> {
-    test::run_training_data_repo_test_no_commits(|repo| {
+#[tokio::test]
+async fn test_merge_conflict_shows_in_status() -> Result<(), OxenError> {
+    test::run_training_data_repo_test_no_commits_async(|repo| async move {
         let labels_path = repo.path.join("labels.txt");
         command::add(&repo, &labels_path)?;
         command::commit(&repo, "adding initial labels file")?;
@@ -2046,7 +2075,7 @@ fn test_merge_conflict_shows_in_status() -> Result<(), OxenError> {
         command::commit(&repo, "adding none category")?;
 
         // Add a "person" category on a the main branch
-        command::checkout(&repo, og_branch.name)?;
+        command::checkout(&repo, og_branch.name).await?;
 
         test::modify_txt_file(&labels_path, "cat\ndog\nperson")?;
         command::add(&repo, &labels_path)?;
@@ -2064,11 +2093,12 @@ fn test_merge_conflict_shows_in_status() -> Result<(), OxenError> {
 
         Ok(())
     })
+    .await
 }
 
-#[test]
-fn test_can_add_merge_conflict() -> Result<(), OxenError> {
-    test::run_training_data_repo_test_no_commits(|repo| {
+#[tokio::test]
+async fn test_can_add_merge_conflict() -> Result<(), OxenError> {
+    test::run_training_data_repo_test_no_commits_async(|repo| async move {
         let labels_path = repo.path.join("labels.txt");
         command::add(&repo, &labels_path)?;
         command::commit(&repo, "adding initial labels file")?;
@@ -2084,7 +2114,7 @@ fn test_can_add_merge_conflict() -> Result<(), OxenError> {
         command::commit(&repo, "adding none category")?;
 
         // Add a "person" category on a the main branch
-        command::checkout(&repo, og_branch.name)?;
+        command::checkout(&repo, og_branch.name).await?;
 
         test::modify_txt_file(&labels_path, "cat\ndog\nperson")?;
         command::add(&repo, &labels_path)?;
@@ -2111,11 +2141,12 @@ fn test_can_add_merge_conflict() -> Result<(), OxenError> {
 
         Ok(())
     })
+    .await
 }
 
-#[test]
-fn test_commit_after_merge_conflict() -> Result<(), OxenError> {
-    test::run_training_data_repo_test_no_commits(|repo| {
+#[tokio::test]
+async fn test_commit_after_merge_conflict() -> Result<(), OxenError> {
+    test::run_training_data_repo_test_no_commits_async(|repo| async move {
         let labels_path = repo.path.join("labels.txt");
         command::add(&repo, &labels_path)?;
         command::commit(&repo, "adding initial labels file")?;
@@ -2131,7 +2162,7 @@ fn test_commit_after_merge_conflict() -> Result<(), OxenError> {
         command::commit(&repo, "adding none category")?;
 
         // Add a "person" category on a the main branch
-        command::checkout(&repo, og_branch.name)?;
+        command::checkout(&repo, og_branch.name).await?;
 
         test::modify_txt_file(&labels_path, "cat\ndog\nperson")?;
         command::add(&repo, &labels_path)?;
@@ -2163,6 +2194,7 @@ fn test_commit_after_merge_conflict() -> Result<(), OxenError> {
 
         Ok(())
     })
+    .await
 }
 
 #[test]
@@ -2571,10 +2603,10 @@ fn test_stage_and_commit_schema() -> Result<(), OxenError> {
     })
 }
 
-#[test]
-fn test_command_merge_dataframe_conflict_both_added_rows_checkout_theirs() -> Result<(), OxenError>
-{
-    test::run_training_data_repo_test_fully_committed(|repo| {
+#[tokio::test]
+async fn test_command_merge_dataframe_conflict_both_added_rows_checkout_theirs(
+) -> Result<(), OxenError> {
+    test::run_training_data_repo_test_fully_committed_async(|repo| async move {
         let og_branch = command::current_branch(&repo)?.unwrap();
 
         // Add a more rows on this branch
@@ -2595,7 +2627,7 @@ fn test_command_merge_dataframe_conflict_both_added_rows_checkout_theirs() -> Re
         command::commit(&repo, "Adding new annotation as an Ox on a branch.")?;
 
         // Add a more rows on the main branch
-        command::checkout(&repo, og_branch.name)?;
+        command::checkout(&repo, og_branch.name).await?;
 
         let bbox_file =
             test::append_line_txt_file(bbox_file, "train/dog_4.jpg,dog,52.0,62.5,256,429")?;
@@ -2621,11 +2653,13 @@ fn test_command_merge_dataframe_conflict_both_added_rows_checkout_theirs() -> Re
 
         Ok(())
     })
+    .await
 }
 
-#[test]
-fn test_command_merge_dataframe_conflict_both_added_rows_combine_uniq() -> Result<(), OxenError> {
-    test::run_training_data_repo_test_fully_committed(|repo| {
+#[tokio::test]
+async fn test_command_merge_dataframe_conflict_both_added_rows_combine_uniq(
+) -> Result<(), OxenError> {
+    test::run_training_data_repo_test_fully_committed_async(|repo| async move {
         let og_branch = command::current_branch(&repo)?.unwrap();
 
         let bbox_filename = Path::new("annotations")
@@ -2646,7 +2680,7 @@ fn test_command_merge_dataframe_conflict_both_added_rows_combine_uniq() -> Resul
         command::commit(&repo, "Adding new annotation as an Ox on a branch.")?;
 
         // Add a more rows on the main branch
-        command::checkout(&repo, og_branch.name)?;
+        command::checkout(&repo, og_branch.name).await?;
 
         let row_from_main = "train/dog_4.jpg,dog,52.0,62.5,256,429";
         let bbox_file = test::append_line_txt_file(bbox_file, row_from_main)?;
@@ -2670,11 +2704,12 @@ fn test_command_merge_dataframe_conflict_both_added_rows_combine_uniq() -> Resul
 
         Ok(())
     })
+    .await
 }
 
-#[test]
-fn test_command_merge_dataframe_conflict_error_added_col() -> Result<(), OxenError> {
-    test::run_training_data_repo_test_fully_committed(|repo| {
+#[tokio::test]
+async fn test_command_merge_dataframe_conflict_error_added_col() -> Result<(), OxenError> {
+    test::run_training_data_repo_test_fully_committed_async(|repo| async move {
         let og_branch = command::current_branch(&repo)?.unwrap();
 
         let bbox_filename = Path::new("annotations")
@@ -2699,7 +2734,7 @@ fn test_command_merge_dataframe_conflict_error_added_col() -> Result<(), OxenErr
         command::commit(&repo, "Adding new column as an Ox on a branch.")?;
 
         // Add a more rows on the main branch
-        command::checkout(&repo, og_branch.name)?;
+        command::checkout(&repo, og_branch.name).await?;
 
         let row_from_main = "train/dog_4.jpg,dog,52.0,62.5,256,429";
         let bbox_file = test::append_line_txt_file(bbox_file, row_from_main)?;
@@ -2721,6 +2756,7 @@ fn test_command_merge_dataframe_conflict_error_added_col() -> Result<(), OxenErr
 
         Ok(())
     })
+    .await
 }
 
 #[test]
@@ -3260,6 +3296,47 @@ async fn test_cannot_push_two_separate_cloned_repos() -> Result<(), OxenError> {
         .await?;
 
         Ok(remote_repo_1_copy)
+    })
+    .await
+}
+
+/*
+Checks workflow:
+
+$ oxen clone <URL>
+
+$ oxen checkout f412d166be1bead8 # earlier commit
+$ oxen checkout 55a4df7cd5d00eee # later commit
+
+Checkout commit: 55a4df7cd5d00eee
+Setting working directory to 55a4df7cd5d00eee
+IO(Os { code: 2, kind: NotFound, message: "No such file or directory" })
+
+*/
+#[tokio::test]
+async fn test_clone_checkout_old_commit_checkout_new_commit() -> Result<(), OxenError> {
+    test::run_training_data_fully_sync_remote(|_, remote_repo| async move {
+        let remote_repo_copy = remote_repo.clone();
+
+        test::run_empty_dir_test_async(|repo_dir| async move {
+            let shallow = false;
+            let cloned_repo = command::clone(&remote_repo.remote.url, &repo_dir, shallow).await?;
+
+            let commits = command::log(&cloned_repo)?;
+            // iterate over commits in reverse order and checkout each one
+            for commit in commits.iter().rev() {
+                println!(
+                    "TEST checking out commit: {} -> '{}'",
+                    commit.id, commit.message
+                );
+                command::checkout(&cloned_repo, &commit.id).await?;
+            }
+
+            Ok(repo_dir)
+        })
+        .await?;
+
+        Ok(remote_repo_copy)
     })
     .await
 }


### PR DESCRIPTION
This fixes the workflow

oxen clone <URL>
oxen log
oxen checkout <FIRST_COMMIT>
oxen checkout <LATER_COMMIT>

We progressively download commits that are not synced locally so that we can save on not cloning the entire repo if we just want to work with a small branch.

Now we fetch the data associated with the commit on checkout if it does not exist locally yet.