### PR TITLE
Feature/commit history given basehead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3134,9 +3134,9 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "reqwest"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
 dependencies = [
  "async-compression",
  "base64 0.21.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ polars = { version = "0.27.2", features = ["lazy", "parquet", "csv-file", "json"
 rand = "0.8.5"
 rand_core = "0.5"
 rayon = "1.5.1"
-reqwest = { version = "0.11.14", features = ["multipart", "json", "gzip", "stream"] }
+reqwest = { version = "0.11.16", features = ["multipart", "json", "gzip", "stream"] }
 rocksdb = { version = "0.20.1", default-features = false, features = ["lz4"] }
 rpassword = "6.0"
 sanitize-filename = "0.4.0"

--- a/src/cli/src/dispatch.rs
+++ b/src/cli/src/dispatch.rs
@@ -424,8 +424,6 @@ pub fn schema_list_indices(schema_ref: &str) -> Result<(), OxenError> {
 }
 
 pub fn schema_list(staged: bool) -> Result<(), OxenError> {
-    println!("schema_list staged? {staged}");
-
     let repo_dir = env::current_dir().unwrap();
     let repository = LocalRepository::from_dir(&repo_dir)?;
     let schemas = if staged {

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -42,7 +42,7 @@ pluralizer = "0.3.1"
 polars = { version = "0.27.2", features = ["lazy", "parquet", "csv-file", "json", "ipc", "dtype-struct"] }
 rand = "0.8.5"
 rayon = "1.5.1"
-reqwest = { version = "0.11.14", features = ["multipart", "json", "gzip", "stream"] }
+reqwest = { version = "0.11.16", features = ["multipart", "json", "gzip", "stream"] }
 rocksdb = { version = "0.20.1", default-features = false, features = ["lz4"] }
 rpassword = "6.0"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/src/lib/src/api/endpoint.rs
+++ b/src/lib/src/api/endpoint.rs
@@ -13,22 +13,38 @@ pub fn remote_url_from_host(host: &str, namespace: &str, name: &str) -> String {
 }
 
 pub fn url_from_remote_url(url: &str) -> Result<String, OxenError> {
-    let mut parsed_url = Url::parse(url)?;
-    let new_path = format!("{}{}", API_NAMESPACE, parsed_url.path());
-    parsed_url.set_path(&new_path);
-    Ok(parsed_url.to_string())
+    log::debug!("creating url_from_remote_url {url:?}");
+    match Url::parse(url) {
+        Ok(mut parsed_url) => {
+            let new_path = format!("{}{}", API_NAMESPACE, parsed_url.path());
+            parsed_url.set_path(&new_path);
+            Ok(parsed_url.to_string())
+        }
+        Err(e) => {
+            log::warn!("Invalid remote url: {:?}\n{:?}", url, e);
+            Err(OxenError::invalid_set_remote_url(url))
+        }
+    }
 }
 
 pub fn url_from_remote(remote: &Remote, uri: &str) -> Result<String, OxenError> {
-    let mut parsed_url = Url::parse(&remote.url)?;
-    let new_path = format!("{}{}{}", API_NAMESPACE, parsed_url.path(), uri);
-    // TODO: this is a workaround because to_string was URL encoding characters that we didn't want encoded
-    // parsed_url.set_path(&new_path);
-    // Ok(parsed_url.to_string())
-    parsed_url.set_path("");
-    let mut remote_url = parsed_url.to_string();
-    remote_url.pop(); // to_string adds a trailing slash we don't want
-    Ok(format!("{remote_url}{new_path}"))
+    log::debug!("creating url_from_remote {remote:?} -> {uri:?}");
+    match Url::parse(&remote.url) {
+        Ok(mut parsed_url) => {
+            let new_path = format!("{}{}{}", API_NAMESPACE, parsed_url.path(), uri);
+            // TODO: this is a workaround because to_string was URL encoding characters that we didn't want encoded
+            // parsed_url.set_path(&new_path);
+            // Ok(parsed_url.to_string())
+            parsed_url.set_path("");
+            let mut remote_url = parsed_url.to_string();
+            remote_url.pop(); // to_string adds a trailing slash we don't want
+            Ok(format!("{remote_url}{new_path}"))
+        }
+        Err(e) => {
+            log::warn!("Invalid remote url: {:?}\n{:?}", remote.url, e);
+            Err(OxenError::invalid_set_remote_url(&remote.url))
+        }
+    }
 }
 
 pub fn url_from_repo(repo: &RemoteRepository, uri: &str) -> Result<String, OxenError> {

--- a/src/lib/src/api/local/commits.rs
+++ b/src/lib/src/api/local/commits.rs
@@ -111,7 +111,8 @@ pub fn create_commit_object(repo_dir: &Path, commit: &Commit) -> Result<(), Oxen
     // If we have a root, and we are trying to push a new one, don't allow it
     if let Ok(root) = command::root_commit(&repo) {
         if commit.parent_ids.is_empty() && root.id != commit.id {
-            return Err(OxenError::basic_str("Root commit id does not match"));
+            log::error!("Root commit does not match {} != {}", root.id, commit.id);
+            return Err(OxenError::RootCommitDoesNotMatch(commit.id.to_owned()));
         }
     }
 

--- a/src/lib/src/api/local/repositories.rs
+++ b/src/lib/src/api/local/repositories.rs
@@ -158,8 +158,8 @@ pub fn create_empty(
         .join(&new_repo.namespace)
         .join(Path::new(&new_repo.name));
     if repo_dir.exists() {
-        let err = format!("Repository already exists {repo_dir:?}");
-        return Err(OxenError::basic_str(err));
+        log::error!("Repository already exists {repo_dir:?}");
+        return Err(OxenError::RepoAlreadyExists(repo_dir));
     }
 
     // Create the repo dir

--- a/src/lib/src/api/remote/commits.rs
+++ b/src/lib/src/api/remote/commits.rs
@@ -686,9 +686,9 @@ mod tests {
             assert!(commit_history.len() >= 7);
 
             // Log comes out in reverse order, so we want the 5th commit as the base,
-            // and will end up with the 2nd,3rd,4th,5th commits (4 commits total)
-            let base_commit = &commit_history[5];
+            // and will end up with the 2nd,3rd,4th commits (3 commits total)
             let head_commit = &commit_history[2];
+            let base_commit = &commit_history[5];
 
             let committish = format!("{}..{}", base_commit.id, head_commit.id);
             println!("committish: {}", committish);
@@ -701,7 +701,7 @@ mod tests {
                 println!("got commit: {} -> {}", commit.id, commit.message);
             }
 
-            assert_eq!(remote_commits.len(), 4);
+            assert_eq!(remote_commits.len(), 3);
 
             api::remote::repositories::delete(&remote_repo).await?;
 

--- a/src/lib/src/command.rs
+++ b/src/lib/src/command.rs
@@ -1048,6 +1048,10 @@ pub async fn create_remote<S: AsRef<str>>(
 /// # Set the remote for a repository
 /// Tells the CLI where to push the changes to
 pub fn add_remote(repo: &mut LocalRepository, name: &str, url: &str) -> Result<(), OxenError> {
+    if url::Url::parse(url).is_err() {
+        return Err(OxenError::invalid_set_remote_url(url));
+    }
+
     repo.add_remote(name, url);
     repo.save_default()?;
     Ok(())

--- a/src/lib/src/error.rs
+++ b/src/lib/src/error.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::fmt::Debug;
 use std::io;
 use std::path::Path;
+use std::path::PathBuf;
 
 use crate::model::Schema;
 
@@ -30,6 +31,7 @@ pub enum OxenError {
     Encoding(std::str::Utf8Error),
     DB(rocksdb::Error),
     ENV(std::env::VarError),
+    RepoAlreadyExists(PathBuf),
 }
 
 impl OxenError {
@@ -198,6 +200,11 @@ impl OxenError {
 
     pub fn invalid_agg_query<S: AsRef<str>>(query: S) -> OxenError {
         let err = format!("Invalid aggregate opt: {:?}", query.as_ref());
+        OxenError::basic_str(err)
+    }
+
+    pub fn invalid_set_remote_url<S: AsRef<str>>(url: S) -> OxenError {
+        let err = format!("\nRemote invalid, must be fully qualified URL, got: {:?}\n\n  oxen config --set-remote origin https://hub.oxen.ai/<namespace>/<reponame>\n", url.as_ref());
         OxenError::basic_str(err)
     }
 

--- a/src/lib/src/error.rs
+++ b/src/lib/src/error.rs
@@ -32,6 +32,7 @@ pub enum OxenError {
     DB(rocksdb::Error),
     ENV(std::env::VarError),
     RepoAlreadyExists(PathBuf),
+    RootCommitDoesNotMatch(String),
 }
 
 impl OxenError {

--- a/src/lib/src/index/commit_db_reader.rs
+++ b/src/lib/src/index/commit_db_reader.rs
@@ -143,15 +143,14 @@ impl CommitDBReader {
         head_commit_id: &str,
         commits: &mut HashSet<Commit>,
     ) -> Result<(), OxenError> {
+        // End recursion, we found all the commits from base to head
+        if base_commit_id == head_commit_id {
+            return Ok(());
+        }
+
         match CommitDBReader::get_commit_by_id(db, head_commit_id) {
             Ok(Some(commit)) => {
-                // Need to add the commit to the set before ending the recursion
                 commits.insert(commit.to_owned());
-
-                // End recursion, we found all the commits from base to head
-                if base_commit_id == head_commit_id {
-                    return Ok(());
-                }
 
                 for parent_id in commit.parent_ids.iter() {
                     CommitDBReader::history_from_base_to_head(

--- a/src/lib/src/index/commit_reader.rs
+++ b/src/lib/src/index/commit_reader.rs
@@ -169,7 +169,7 @@ mod tests {
             let new_file = repo.path.join("new_2.txt");
             test::write_txt_file_to_path(&new_file, "new 2")?;
             command::add(&repo, new_file)?;
-            command::commit(&repo, "commit 2")?;
+            let first_new_commit = command::commit(&repo, "commit 2")?.unwrap();
 
             let new_file = repo.path.join("new_3.txt");
             test::write_txt_file_to_path(&new_file, "new 3")?;
@@ -184,10 +184,10 @@ mod tests {
             let commit_reader = CommitReader::new(&repo)?;
             let history =
                 commit_reader.history_from_base_to_head(&base_commit.id, &head_commit.id)?;
-            assert_eq!(history.len(), 3);
+            assert_eq!(history.len(), 2);
 
             assert_eq!(history.first().unwrap().message, head_commit.message);
-            assert_eq!(history.last().unwrap().message, base_commit.message);
+            assert_eq!(history.last().unwrap().message, first_new_commit.message);
 
             Ok(())
         })

--- a/src/lib/src/model/staged_data.rs
+++ b/src/lib/src/model/staged_data.rs
@@ -20,7 +20,7 @@ pub const MSG_OXEN_RESTORE_FILE: &str =
 pub const MSG_OXEN_RESTORE_STAGED_FILE: &str =
     "  (use \"oxen restore --staged <file> ...\" to unstage)\n";
 pub const MSG_OXEN_SHOW_SCHEMA_STAGED: &str =
-    "  (use \"oxen schemas show <HASH> --staged\" to view staged schema)\n";
+    "  (use \"oxen schemas show --staged <HASH>\" to view staged schema)\n";
 
 #[derive(Debug, Clone)]
 pub struct StagedDataOpts {

--- a/src/server/src/controllers/commits.rs
+++ b/src/server/src/controllers/commits.rs
@@ -393,6 +393,10 @@ pub async fn create(req: HttpRequest, body: String) -> HttpResponse {
                     status_message: String::from(MSG_RESOURCE_CREATED),
                     commit: commit.to_owned(),
                 }),
+                Err(OxenError::RootCommitDoesNotMatch(commit_id)) => {
+                    log::error!("Err create_commit: RootCommitDoesNotMatch {}", commit_id);
+                    HttpResponse::InternalServerError().json(StatusMessage::error("Remote commit history does not match local commit history. Make sure you are pushing to the correct remote."))
+                }
                 Err(err) => {
                     log::error!("Err create_commit: {}", err);
                     HttpResponse::InternalServerError().json(StatusMessage::internal_server_error())

--- a/src/server/src/controllers/commits.rs
+++ b/src/server/src/controllers/commits.rs
@@ -78,7 +78,7 @@ pub async fn commit_history(req: HttpRequest) -> HttpResponse {
         match p_index_commit_or_branch_history(&repo_dir, commit_or_branch) {
             Ok(response) => HttpResponse::Ok().json(response),
             Err(err) => {
-                let msg = format!("api err: {err}");
+                let msg = format!("{err}");
                 HttpResponse::NotFound().json(StatusMessage::error(msg))
             }
         }

--- a/src/server/src/controllers/repositories.rs
+++ b/src/server/src/controllers/repositories.rs
@@ -1,6 +1,7 @@
 use crate::app_data::OxenAppData;
 
 use liboxen::api;
+use liboxen::error::OxenError;
 use liboxen::util;
 use liboxen::view::http::{
     MSG_RESOURCE_CREATED, MSG_RESOURCE_DELETED, MSG_RESOURCE_FOUND, STATUS_SUCCESS,
@@ -130,11 +131,14 @@ pub async fn create(req: HttpRequest, body: String) -> HttpResponse {
                     name: data.name.clone(),
                 },
             }),
-
+            Err(OxenError::RepoAlreadyExists(path)) => {
+                log::debug!("Repo already exists: {:?}", path);
+                HttpResponse::Conflict().json(StatusMessage::error("Repo already exists."))
+            }
             Err(err) => {
                 println!("Err api::local::repositories::create: {err:?}");
                 log::error!("Err api::local::repositories::create: {:?}", err);
-                HttpResponse::InternalServerError().json(StatusMessage::internal_server_error())
+                HttpResponse::InternalServerError().json(StatusMessage::error("Invalid body."))
             }
         },
         Err(err) => {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -415,6 +415,27 @@ async fn test_command_checkout_current_branch_name_does_nothing() -> Result<(), 
     .await
 }
 
+#[tokio::test]
+async fn test_cannot_checkout_branch_with_dots_in_name() -> Result<(), OxenError> {
+    test::run_empty_local_repo_test_async(|repo| async move {
+        // Write the first file
+        let hello_file = repo.path.join("hello.txt");
+        util::fs::write_to_path(&hello_file, "Hello")?;
+
+        // Track & commit the file
+        command::add(&repo, &hello_file)?;
+        command::commit(&repo, "Added hello.txt")?;
+
+        // Create and checkout branch
+        let branch_name = "test..ing";
+        let result = command::create_checkout_branch(&repo, branch_name);
+        assert!(result.is_err());
+
+        Ok(())
+    })
+    .await
+}
+
 #[test]
 fn test_rename_current_branch() -> Result<(), OxenError> {
     test::run_empty_local_repo_test(|repo| {


### PR DESCRIPTION
Steps to test in fish shell:

```
mkdir test
cd test
oxen init
for i in (seq 0 10) ; echo "test$i" > file$i.txt ; oxen add file$i.txt ; oxen commit -m "adding file$i" ; end
oxen log
oxen create-remote test base-head 0.0.0.0:3000
oxen config --set-remote origin http://0.0.0.0:3000/test/base-head
oxen push origin main
curl -X GET "http://0.0.0.0:3000/api/repos/test/base-head/commits/COMMIT_ID_BASE..COMMIT_ID_HEAD/history"
```