### PR TITLE
update /merge api to return commits between base and head LCA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "arrow2"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c63cf31f1416ed2fab8f91e8488e10129f47bd89c553ec354a06751d5697f3"
+checksum = "15ae0428d69ab31d7b2adad22a752d6f11fef2e901d2262d0cad4f5cb08b7093"
 dependencies = [
  "ahash 0.8.3",
  "arrow-format",
@@ -1801,9 +1801,9 @@ dependencies = [
 
 [[package]]
 name = "halfbrown"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ab7d9233262d3b74ae4c4a7a090fc4379b07c6eb9b02ecab7cbb12ad67a58"
+checksum = "f985624e90f861184145c13b736873a0f83cdb998a292dbb0653598ab03aecbf"
 dependencies = [
  "hashbrown 0.13.2",
  "rustc-hash",
@@ -3172,7 +3172,7 @@ dependencies = [
  "once_cell",
  "rayon",
  "smartstring",
- "sysinfo 0.28.2",
+ "sysinfo 0.28.4",
 ]
 
 [[package]]
@@ -3861,9 +3861,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.28.2"
+version = "0.28.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e847e2de7a137c8c2cede5095872dbb00f4f9bf34d061347e36b43322acd56"
+checksum = "b4c2f3ca6693feb29a89724516f016488e9aafc7f37264f898593ee4b942f31b"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -4271,9 +4271,9 @@ dependencies = [
 
 [[package]]
 name = "value-trait"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733e1909354ceff16f7e1f7ddebc063455b8fda4968d91760a7c6115b96647a5"
+checksum = "09a5b6c8ceb01263b969cac48d4a6705134d490ded13d889e52c0cfc80c6945e"
 dependencies = [
  "float-cmp",
  "halfbrown",

--- a/src/lib/src/api/remote.rs
+++ b/src/lib/src/api/remote.rs
@@ -7,6 +7,7 @@ pub mod commits;
 pub mod df;
 pub mod dir;
 pub mod entries;
+pub mod merger;
 pub mod repositories;
 pub mod staging;
 pub mod version;

--- a/src/lib/src/api/remote/merger.rs
+++ b/src/lib/src/api/remote/merger.rs
@@ -1,0 +1,182 @@
+//! Interact with the remote repository to get information about mergability of branches
+//!
+
+use crate::api;
+use crate::api::remote::client;
+use crate::error::OxenError;
+use crate::model::RemoteRepository;
+use crate::view::merge::{Mergeable, MergeableResponse};
+
+/// Can check the mergability of base into head
+/// base or head are strings that can be branch names or commit ids
+pub async fn mergability(
+    remote_repo: &RemoteRepository,
+    base: &str,
+    head: &str,
+) -> Result<Mergeable, OxenError> {
+    let uri = format!("/merge/{base}..{head}");
+    let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
+    log::debug!("url: {url}");
+
+    let client = client::new_for_url(&url)?;
+    match client.get(&url).send().await {
+        Ok(res) => {
+            let body = client::parse_json_body(&url, res).await?;
+            log::debug!("got body: {}", body);
+            let response: Result<MergeableResponse, serde_json::Error> =
+                serde_json::from_str(&body);
+            match response {
+                Ok(val) => Ok(val.mergeable),
+                Err(err) => Err(OxenError::basic_str(format!(
+                    "api::remote::merger::mergability error parsing response from {url}\n\nErr {err:?} \n\n{body}"
+                ))),
+            }
+        }
+        Err(err) => {
+            let err =
+                format!("api::remote::merger::mergability Request failed: {url}\nErr {err:?}");
+            Err(OxenError::basic_str(err))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::constants::DEFAULT_REMOTE_NAME;
+    use crate::error::OxenError;
+    use crate::test;
+    use crate::{api, command};
+
+    #[tokio::test]
+    async fn test_remote_merger_no_commits() -> Result<(), OxenError> {
+        test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
+            let base = "main";
+            let head = "add-data";
+
+            command::create_checkout(&local_repo, head)?;
+            command::push_remote_branch(&local_repo, DEFAULT_REMOTE_NAME, head).await?;
+
+            let mergability = api::remote::merger::mergability(&remote_repo, &base, &head).await?;
+
+            assert!(mergability.is_mergeable);
+            assert_eq!(mergability.commits.len(), 0);
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_remote_merger_base_is_ahead() -> Result<(), OxenError> {
+        test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
+            let base = "main";
+            let head = "add-data";
+
+            command::create_checkout(&local_repo, head)?;
+            command::push_remote_branch(&local_repo, DEFAULT_REMOTE_NAME, head).await?;
+
+            // Checkout main and add a file to be ahead
+            command::checkout(&local_repo, base).await?;
+            let path = local_repo.path.join("file_1.txt");
+            test::write_txt_file_to_path(&path, "hello")?;
+            command::add(&local_repo, &path)?;
+            command::commit(&local_repo, "adding file 1")?;
+            command::push_remote_branch(&local_repo, DEFAULT_REMOTE_NAME, base).await?;
+
+            let mergability = api::remote::merger::mergability(&remote_repo, &base, &head).await?;
+
+            assert!(mergability.is_mergeable);
+            assert_eq!(mergability.commits.len(), 0);
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_remote_merger_mergable_multiple_commits() -> Result<(), OxenError> {
+        test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
+            let base = "main";
+            let head = "add-data";
+
+            command::create_checkout(&local_repo, head)?;
+            command::push_remote_branch(&local_repo, DEFAULT_REMOTE_NAME, head).await?;
+
+            // Modify README.md
+            let path = local_repo.path.join("README.md");
+            test::write_txt_file_to_path(&path, "I am the README now")?;
+            command::add(&local_repo, &path)?;
+
+            // Commit twice
+            let path = local_repo.path.join("file_1.txt");
+            test::write_txt_file_to_path(&path, "hello")?;
+            command::add(&local_repo, &path)?;
+            command::commit(&local_repo, "adding file 1")?;
+
+            let path = local_repo.path.join("file_2.txt");
+            test::write_txt_file_to_path(&path, "world")?;
+            command::add(&local_repo, &path)?;
+            command::commit(&local_repo, "adding file 2")?;
+
+            // Push commits
+            command::push_remote_branch(&local_repo, DEFAULT_REMOTE_NAME, head).await?;
+
+            let mergability = api::remote::merger::mergability(&remote_repo, &base, &head).await?;
+
+            assert_eq!(mergability.is_mergeable, true);
+            assert_eq!(mergability.commits.len(), 2);
+            assert_eq!(mergability.conflicts.len(), 0);
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_remote_merger_multiple_commits_conflict_head_is_ahead() -> Result<(), OxenError> {
+        test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
+            let base = "main";
+            let head = "add-data";
+
+            command::create_checkout(&local_repo, head)?;
+            command::push_remote_branch(&local_repo, DEFAULT_REMOTE_NAME, head).await?;
+
+            // Modify README.md to have a conflict
+            let path = local_repo.path.join("README.md");
+            test::write_txt_file_to_path(&path, "I am the README now")?;
+            command::add(&local_repo, &path)?;
+
+            // Commit twice
+            let path = local_repo.path.join("file_1.txt");
+            test::write_txt_file_to_path(&path, "hello")?;
+            command::add(&local_repo, &path)?;
+            command::commit(&local_repo, "adding file 1")?;
+
+            let path = local_repo.path.join("file_2.txt");
+            test::write_txt_file_to_path(&path, "world")?;
+            command::add(&local_repo, &path)?;
+            command::commit(&local_repo, "adding file 2")?;
+
+            // Push commits
+            command::push_remote_branch(&local_repo, DEFAULT_REMOTE_NAME, head).await?;
+
+            // Checkout main and modify README.md to have a conflict
+            command::checkout(&local_repo, base).await?;
+            let path = local_repo.path.join("README.md");
+            test::write_txt_file_to_path(&path, "I am on main conflicting the README")?;
+            command::add(&local_repo, &path)?;
+            command::commit(&local_repo, "modifying readme on main")?;
+            command::push_remote_branch(&local_repo, DEFAULT_REMOTE_NAME, base).await?;
+
+            let mergability = api::remote::merger::mergability(&remote_repo, &base, &head).await?;
+
+            assert_eq!(mergability.is_mergeable, false);
+            assert_eq!(mergability.commits.len(), 2);
+            assert_eq!(mergability.conflicts.len(), 1);
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+}

--- a/src/lib/src/command.rs
+++ b/src/lib/src/command.rs
@@ -23,7 +23,9 @@ pub mod schemas;
 pub mod status;
 
 pub use crate::command::add::add;
-pub use crate::command::checkout::{checkout, checkout_combine, checkout_ours, checkout_theirs};
+pub use crate::command::checkout::{
+    checkout, checkout_combine, checkout_ours, checkout_theirs, create_checkout,
+};
 pub use crate::command::clone::{clone, clone_url, shallow_clone_url};
 pub use crate::command::commit::commit;
 pub use crate::command::df::{df, schema};

--- a/src/lib/src/command/checkout.rs
+++ b/src/lib/src/command/checkout.rs
@@ -45,6 +45,14 @@ pub async fn checkout<S: AsRef<str>>(
     }
 }
 
+/// Create and checkout a branch
+pub fn create_checkout<S: AsRef<str>>(
+    repo: &LocalRepository,
+    value: S,
+) -> Result<Branch, OxenError> {
+    api::local::branches::create_checkout(repo, value.as_ref())
+}
+
 /// # Checkout a file and take their changes
 /// This overwrites the current file with the changes in the branch we are merging in
 pub fn checkout_theirs(repo: &LocalRepository, path: impl AsRef<Path>) -> Result<(), OxenError> {

--- a/src/lib/src/core/index/commit_reader.rs
+++ b/src/lib/src/core/index/commit_reader.rs
@@ -68,6 +68,7 @@ impl CommitReader {
             head_commit_id,
             &mut commits,
         )?;
+
         let mut commits: Vec<Commit> = commits.into_iter().collect();
         commits.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
         Ok(commits)

--- a/src/lib/src/view/merge.rs
+++ b/src/lib/src/view/merge.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::model::Commit;
+
 use super::StatusMessage;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -8,9 +10,16 @@ pub struct MergeConflictFile {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Mergeable {
+    pub is_mergeable: bool,
+    pub conflicts: Vec<MergeConflictFile>,
+    pub commits: Vec<Commit>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MergeableResponse {
     #[serde(flatten)]
     pub status: StatusMessage,
-    pub is_mergeable: bool,
-    pub conflicts: Vec<MergeConflictFile>,
+    #[serde(flatten)]
+    pub mergeable: Mergeable,
 }

--- a/src/server/src/controllers/merger.rs
+++ b/src/server/src/controllers/merger.rs
@@ -6,7 +6,7 @@ use actix_web::{HttpRequest, HttpResponse};
 
 use liboxen::core::index::{CommitReader, Merger};
 use liboxen::error::OxenError;
-use liboxen::view::merge::{MergeConflictFile, MergeableResponse};
+use liboxen::view::merge::{MergeConflictFile, Mergeable, MergeableResponse};
 use liboxen::view::StatusMessage;
 
 pub async fn show(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpError> {
@@ -38,11 +38,17 @@ pub async fn show(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
         })
         .collect();
 
+    // Get commits
+    let commits = merger.list_commits_between_branches(&commit_reader, &base, &head)?;
+
     // Create response object
     let response = MergeableResponse {
         status: StatusMessage::resource_found(),
-        is_mergeable,
-        conflicts,
+        mergeable: Mergeable {
+            is_mergeable,
+            conflicts,
+            commits,
+        },
     };
 
     Ok(HttpResponse::Ok().json(response))


### PR DESCRIPTION
@jcelliott Can you test this out and verify it is working as expected for MRs? We traverse back to the lowest common ancestor, and return the number of commits between base and head.