### PR TITLE
Dedupe directories for column aggregations

### DIFF
--- a/src/lib/src/core/cache/cachers/content_stats.rs
+++ b/src/lib/src/core/cache/cachers/content_stats.rs
@@ -37,6 +37,7 @@ pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError>
     let reader = CommitEntryReader::new(repo, commit)?;
     let dirs = reader.list_dirs()?;
     log::debug!("Computing size of {} dirs", dirs.len());
+    log::debug!("in here computing content statistics!!!!!");
     let columns = vec!["data_type", "mime_type"];
     for dir in dirs {
         for column in columns.iter() {

--- a/src/lib/src/core/cache/cachers/content_stats.rs
+++ b/src/lib/src/core/cache/cachers/content_stats.rs
@@ -37,7 +37,6 @@ pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError>
     let reader = CommitEntryReader::new(repo, commit)?;
     let dirs = reader.list_dirs()?;
     log::debug!("Computing size of {} dirs", dirs.len());
-    log::debug!("in here computing content statistics!!!!!");
     let columns = vec!["data_type", "mime_type"];
     for dir in dirs {
         for column in columns.iter() {

--- a/src/lib/src/core/cache/cachers/repo_size.rs
+++ b/src/lib/src/core/cache/cachers/repo_size.rs
@@ -111,7 +111,9 @@ pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError>
                     latest_commit = commit.clone();
                 } else {
                     // log::debug!("CONSIDERING COMMIT PARENT TIMESTAMP {:?} {:?} < {:?}", entry.path, latest_commit.as_ref().unwrap().timestamp, commit.as_ref().unwrap().timestamp);
-                    if latest_commit.as_ref().unwrap().timestamp < commit.as_ref().unwrap().timestamp {
+                    if latest_commit.as_ref().unwrap().timestamp
+                        < commit.as_ref().unwrap().timestamp
+                    {
                         // log::debug!("FOUND LATEST COMMIT PARENT TIMESTAMP {:?} -> {:?}", entry.path, commit);
                         latest_commit = commit.clone();
                     }

--- a/src/lib/src/core/index/commit_metadata_db.rs
+++ b/src/lib/src/core/index/commit_metadata_db.rs
@@ -176,7 +176,7 @@ pub fn aggregate_col(
     if combined_df.is_none() {
         return Ok(DataFrame::default());
     }
-    log::debug!("COMBINED df {:?}", combined_df);
+
     Ok(combined_df.unwrap())
 }
 

--- a/src/lib/src/core/index/commit_metadata_db.rs
+++ b/src/lib/src/core/index/commit_metadata_db.rs
@@ -108,7 +108,6 @@ pub fn aggregate_col(
     let mut dirs = CommitEntryReader::new(repo, commit)?.list_dir_children(directory)?;
     dirs.push(directory.to_path_buf());
 
-
     if dirs.is_empty() {
         return Err(OxenError::path_does_not_exist(directory));
     }
@@ -148,7 +147,7 @@ pub fn aggregate_col(
             .unwrap();
 
         // log::debug!("SORTED df for dir {:?}: {:?}", dir, df);
-        
+
         if let Some(cdf) = combined_df {
             // log::debug!("START for dir {:?}: {:?}", dir, cdf);
 

--- a/src/server/src/controllers/metadata.rs
+++ b/src/server/src/controllers/metadata.rs
@@ -137,7 +137,6 @@ pub async fn agg_dir(
 
     if cached_path.exists() {
         let mut df = core::df::tabular::read_df(&cached_path, DFOpts::empty())?;
-
         let response = JsonDataFrameSliceResponse {
             status: StatusMessage::resource_found(),
             full_size: JsonDataSize {


### PR DESCRIPTION
Root directory was getting added to the `dirs` vec twice, causing any files in root to be double-counted in file counts