### PR TITLE
Return dir file counts

### DIFF
--- a/src/cli/src/cmd_setup.rs
+++ b/src/cli/src/cmd_setup.rs
@@ -160,6 +160,7 @@ pub fn info() -> Command {
     Command::new(INFO)
         .about("Get metadata information about a file such as the oxen hash, data type, etc.")
         .arg(Arg::new("path").required(false))
+        .arg(Arg::new("revision").required(false))
         .arg(
             Arg::new("verbose")
                 .long("verbose")
@@ -199,9 +200,9 @@ pub fn metadata() -> Command {
 }
 
 pub fn log() -> Command {
-    Command::new(LOG)
-        .about("See log of commits")
-        .arg(arg!([COMMITTISH] "The commit or branch id you want to get history from. Defaults to main."))
+    Command::new(LOG).about("See log of commits").arg(
+        arg!([REVISION] "The commit or branch id you want to get history from. Defaults to main."),
+    )
 }
 
 pub fn ls() -> Command {
@@ -641,8 +642,8 @@ pub fn pull() -> Command {
 
 pub fn diff() -> Command {
     Command::new(DIFF)
-        .about("Compare two files against each other or against versions. The first parameter can be one of three things 1) another file 2) a commit hash 3) a branch name. If the first parameter is a committish it will compare the second parameter path to that version of the file.")
-        .arg(Arg::new("FILE_OR_COMMITTISH").required(true))
+        .about("Compare two files against each other or against versions. The first parameter can be one of three things 1) another file 2) a commit hash 3) a branch name. If the first parameter is a revision it will compare the second parameter path to that version of the file.")
+        .arg(Arg::new("FILE_OR_REVISION").required(true))
         .arg(Arg::new("PATH").required(false))
 }
 
@@ -664,7 +665,7 @@ pub fn commit_cache() -> Command {
                 .help("Force recompute the cache even if it already exists.")
                 .action(clap::ArgAction::SetTrue),
         )
-        .arg(arg!([COMMITTISH] "The commit or branch id you want to compute the cache for. Defaults to main."))
+        .arg(arg!([REVISION] "The commit or branch id you want to compute the cache for. Defaults to main."))
 }
 
 pub fn read_lines() -> Command {

--- a/src/cli/src/dispatch.rs
+++ b/src/cli/src/dispatch.rs
@@ -498,7 +498,7 @@ pub async fn remote_ls(directory: Option<PathBuf>, opts: &PaginateOpts) -> Resul
     let host = get_host_from_repo(&repository)?;
     check_remote_version(host).await?;
 
-    let directory = directory.unwrap_or(PathBuf::from("."));
+    let directory = directory.unwrap_or(PathBuf::from(""));
     let remote_repo = api::remote::repositories::get_default_remote(&repository).await?;
     let branch = api::local::branches::current_branch(&repository)?
         .ok_or_else(OxenError::must_be_on_valid_branch)?;

--- a/src/lib/src/api/local.rs
+++ b/src/lib/src/api/local.rs
@@ -9,4 +9,5 @@ pub mod metadata;
 pub mod namespaces;
 pub mod repositories;
 pub mod resource;
+pub mod revisions;
 pub mod schemas;

--- a/src/lib/src/api/local/entries.rs
+++ b/src/lib/src/api/local/entries.rs
@@ -2,14 +2,15 @@
 //!
 
 use crate::error::OxenError;
+use crate::opts::DFOpts;
 use crate::util;
-use crate::view::entry::ResourceVersion;
+use crate::view::entry::{DirectoryMetadata, ResourceVersion};
 use rayon::prelude::*;
 
 use crate::core;
 use crate::core::index::{CommitDirEntryReader, CommitEntryReader, CommitReader};
 use crate::model::{Commit, CommitEntry, EntryDataType, LocalRepository, MetadataEntry};
-use crate::view::{PaginatedDirEntries, StatusMessage};
+use crate::view::{JsonDataFrame, PaginatedDirEntries};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -313,10 +314,43 @@ pub fn list_directory(
         total_pages,
     );
 
+    let data_types_path = core::cache::cachers::content_stats::dir_column_path(
+        repo,
+        commit,
+        directory,
+        "data_type",
+    );
+
+    let mime_types_path = core::cache::cachers::content_stats::dir_column_path(
+        repo,
+        commit,
+        directory,
+        "mime_type",
+    );
+
+    let metadata = if data_types_path.exists() && mime_types_path.exists() {
+        log::debug!(
+            "list_directory reading data types from {}",
+            data_types_path.display()
+        );
+        log::debug!(
+            "list_directory reading mime types from {}",
+            mime_types_path.display()
+        );
+        let mut data_type_df = core::df::tabular::read_df(&data_types_path, DFOpts::empty())?;
+        let mut mime_type_df = core::df::tabular::read_df(&mime_types_path, DFOpts::empty())?;
+        Some(DirectoryMetadata {
+            data_types: JsonDataFrame::from_df(&mut data_type_df),
+            mime_types: JsonDataFrame::from_df(&mut mime_type_df),
+        })
+    } else {
+        None
+    };
+
     Ok(PaginatedDirEntries {
-        status: StatusMessage::resource_found(),
         entries,
         resource,
+        metadata,
         page_size,
         page_number: page,
         total_pages,

--- a/src/lib/src/api/local/entries.rs
+++ b/src/lib/src/api/local/entries.rs
@@ -314,19 +314,11 @@ pub fn list_directory(
         total_pages,
     );
 
-    let data_types_path = core::cache::cachers::content_stats::dir_column_path(
-        repo,
-        commit,
-        directory,
-        "data_type",
-    );
+    let data_types_path =
+        core::cache::cachers::content_stats::dir_column_path(repo, commit, directory, "data_type");
 
-    let mime_types_path = core::cache::cachers::content_stats::dir_column_path(
-        repo,
-        commit,
-        directory,
-        "mime_type",
-    );
+    let mime_types_path =
+        core::cache::cachers::content_stats::dir_column_path(repo, commit, directory, "mime_type");
 
     let metadata = if data_types_path.exists() && mime_types_path.exists() {
         log::debug!(

--- a/src/lib/src/api/local/repositories.rs
+++ b/src/lib/src/api/local/repositories.rs
@@ -67,7 +67,7 @@ pub fn get_repo_stats(repo: &LocalRepository) -> RepoStats {
                         data_type: data_type.to_owned(),
                         file_count: 1,
                     };
-                    let mut stat = data_types.entry(data_type).or_insert(data_type_stat);
+                    let stat = data_types.entry(data_type).or_insert(data_type_stat);
                     stat.file_count += 1;
                     stat.data_size += entry.num_bytes;
                 }

--- a/src/lib/src/api/local/revisions.rs
+++ b/src/lib/src/api/local/revisions.rs
@@ -1,0 +1,20 @@
+//! Revisions can either be commits by id or head commits on branches by name
+
+use crate::api;
+use crate::error::OxenError;
+use crate::model::{Commit, LocalRepository};
+
+/// Get a commit object from a commit id or branch name
+/// Returns Ok(None) if the revision does not exist
+pub fn get(repo: &LocalRepository, revision: impl AsRef<str>) -> Result<Option<Commit>, OxenError> {
+    let revision = revision.as_ref();
+    if api::local::branches::exists(repo, revision)? {
+        let branch = api::local::branches::get_by_name(repo, revision)?;
+        let branch = branch.ok_or(OxenError::local_branch_not_found(revision))?;
+        let commit = api::local::commits::get_by_id(repo, &branch.commit_id)?;
+        Ok(commit)
+    } else {
+        let commit = api::local::commits::get_by_id(repo, revision)?;
+        Ok(commit)
+    }
+}

--- a/src/lib/src/api/remote/staging.rs
+++ b/src/lib/src/api/remote/staging.rs
@@ -2,7 +2,9 @@ use crate::api;
 use crate::api::remote::client;
 use crate::error::OxenError;
 use crate::model::entry::mod_entry::ModType;
-use crate::model::{Commit, DataFrameDiff, ModEntry, NewCommitBody, ObjectID, RemoteRepository};
+use crate::model::{
+    Branch, Commit, DataFrameDiff, ModEntry, NewCommitBody, ObjectID, RemoteRepository,
+};
 use crate::model::{ContentType, Schema};
 use crate::view::{
     CommitResponse, FilePathsResponse, ListStagedFileModResponseDF, RemoteStagedStatus,
@@ -209,7 +211,12 @@ pub async fn commit_staged(
         Ok(val) => {
             let commit = val.commit;
             // make sure to call our /complete call to kick off the post-push hooks
-            api::remote::commits::post_push_complete(remote_repo, &commit.id).await?;
+            let branch = Branch {
+                name: branch_name.to_string(),
+                commit_id: commit.id.clone(),
+                is_head: false
+            };
+            api::remote::commits::post_push_complete(remote_repo, &branch).await?;
             Ok(commit)
         },
         Err(err) => Err(OxenError::basic_str(format!(

--- a/src/lib/src/command.rs
+++ b/src/lib/src/command.rs
@@ -12,6 +12,7 @@ pub mod config;
 pub mod db_inspect;
 pub mod df;
 pub mod diff;
+pub mod info;
 pub mod init;
 pub mod merge;
 pub mod pull;
@@ -30,6 +31,7 @@ pub use crate::command::clone::{clone, clone_url, deep_clone_url, shallow_clone_
 pub use crate::command::commit::commit;
 pub use crate::command::df::{df, schema};
 pub use crate::command::diff::diff;
+pub use crate::command::info::info;
 pub use crate::command::init::init;
 pub use crate::command::merge::merge;
 pub use crate::command::pull::{pull, pull_remote_branch};

--- a/src/lib/src/command/commit_cache.rs
+++ b/src/lib/src/command/commit_cache.rs
@@ -41,16 +41,16 @@ pub async fn compute_cache_on_all_repos(path: &Path, force: bool) -> Result<(), 
 /// Run the computation cache on all repositories within a directory
 pub async fn compute_cache(
     repo: &LocalRepository,
-    committish: Option<String>,
+    revision: Option<String>,
     force: bool,
 ) -> Result<(), OxenError> {
     println!(
-        "Compute cache for commit given [{committish:?}] on repo {:?}",
+        "Compute cache for commit given [{revision:?}] on repo {:?}",
         repo.path
     );
-    let commits = if let Some(committish) = committish {
+    let commits = if let Some(revision) = revision {
         let opts = LogOpts {
-            committish: Some(committish),
+            revision: Some(revision),
             remote: false,
         };
         api::local::commits::list_with_opts(repo, &opts).await?

--- a/src/lib/src/command/info.rs
+++ b/src/lib/src/command/info.rs
@@ -1,0 +1,41 @@
+//! # oxen info
+//!
+//! Get information about a path in the oxen repository
+//!
+
+use crate::error::OxenError;
+use crate::model::entry::metadata_entry::CLIMetadataEntry;
+use crate::model::LocalRepository;
+use crate::opts::InfoOpts;
+use crate::{api, util};
+
+/// # Get info about a file or directory
+pub fn info(repository: &LocalRepository, opts: InfoOpts) -> Result<CLIMetadataEntry, OxenError> {
+    let path = opts.path;
+
+    if let Some(revision) = opts.revision {
+        let commit = api::local::revisions::get(repository, &revision)?
+            .ok_or(OxenError::revision_not_found(revision.to_owned().into()))?;
+
+        if let Some(entry) = api::local::entries::get_commit_entry(repository, &commit, &path)? {
+            let version_path = util::fs::version_path(repository, &entry);
+            return api::local::metadata::get_cli(repository, path, version_path);
+        } else {
+            eprintln!(
+                "Path does not exist in revision: {}:{}",
+                revision,
+                path.to_string_lossy()
+            );
+            return Err(OxenError::path_does_not_exist(path));
+        }
+    }
+
+    // Fall back to look for the existing path
+    if !path.exists() {
+        eprintln!("Path does not exist: {:?}", path);
+        return Err(OxenError::path_does_not_exist(path));
+    }
+
+    // get file metadata
+    api::local::metadata::get_cli(repository, &path, &path)
+}

--- a/src/lib/src/command/remote/download.rs
+++ b/src/lib/src/command/remote/download.rs
@@ -13,13 +13,13 @@ pub async fn download(
     repo: &RemoteRepository,
     remote_path: impl AsRef<Path>,
     local_path: impl AsRef<Path>,
-    committish: impl AsRef<str>,
+    revision: impl AsRef<str>,
 ) -> Result<(), OxenError> {
     api::remote::entries::download_entry(
         repo,
         remote_path.as_ref(),
         local_path.as_ref(),
-        committish.as_ref(),
+        revision.as_ref(),
     )
     .await
 }
@@ -50,9 +50,9 @@ mod tests {
 
             test::run_empty_dir_test_async(|repo_dir| async move {
                 let local_path = repo_dir.join("new_name.txt");
-                let committish = DEFAULT_BRANCH_NAME;
+                let revision = DEFAULT_BRANCH_NAME;
 
-                download(&remote_repo, file_path, &local_path, committish).await?;
+                download(&remote_repo, file_path, &local_path, revision).await?;
 
                 assert!(local_path.exists());
                 assert_eq!(util::fs::read_from_path(&local_path)?, file_contents);
@@ -78,9 +78,9 @@ mod tests {
 
             test::run_empty_dir_test_async(|repo_dir| async move {
                 let dst_path = repo_dir.join("images");
-                let committish = DEFAULT_BRANCH_NAME;
+                let revision = DEFAULT_BRANCH_NAME;
 
-                download(&remote_repo, src_path, &dst_path, committish).await?;
+                download(&remote_repo, src_path, &dst_path, revision).await?;
 
                 assert!(dst_path.exists());
                 let result_dir = &dst_path.join(src_path);

--- a/src/lib/src/constants.rs
+++ b/src/lib/src/constants.rs
@@ -88,7 +88,7 @@ pub const FILE_ROW_NUM_COL_NAME: &str = "_file_row_num";
 pub const AVG_CHUNK_SIZE: u64 = 1024 * 1024 * 4;
 // Retry and back off of requests N times
 /// Retry and back off of requests N times
-pub const NUM_HTTP_RETRIES: u64 = 6;
+pub const NUM_HTTP_RETRIES: u64 = 10;
 
 /// Pagination page size of 10
 pub const DEFAULT_PAGE_SIZE: usize = 10;

--- a/src/lib/src/core/cache/cachers/content_stats.rs
+++ b/src/lib/src/core/cache/cachers/content_stats.rs
@@ -47,7 +47,7 @@ pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError>
                 std::fs::create_dir_all(parent)?;
             }
             log::debug!("Writing cached df {} to {}", column, path.display());
-            log::debug!("df {}", df);
+            // log::debug!("df {}", df);
             tabular::write_df(&mut df, &path)?;
         }
     }

--- a/src/lib/src/core/cache/cachers/content_stats.rs
+++ b/src/lib/src/core/cache/cachers/content_stats.rs
@@ -47,6 +47,7 @@ pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError>
                 std::fs::create_dir_all(parent)?;
             }
             log::debug!("Writing cached df {} to {}", column, path.display());
+            log::debug!("df {}", df);
             tabular::write_df(&mut df, &path)?;
         }
     }

--- a/src/lib/src/core/cache/cachers/content_validator.rs
+++ b/src/lib/src/core/cache/cachers/content_validator.rs
@@ -8,6 +8,11 @@ use crate::util;
 pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError> {
     log::debug!("Running compute_and_write_hash");
 
+    // sleep to make sure the commit is fully written to disk
+    // Issue was with a lot of text files in this integration test:
+    //     "test_remote_ls_return_data_types_just_top_level_dir"
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
     log::debug!("computing entry hash {} -> {}", commit.id, commit.message);
     let commit_entry_reader = CommitEntryReader::new(repo, commit)?;
     let entries = commit_entry_reader.list_entries()?;

--- a/src/lib/src/core/cache/cachers/repo_size.rs
+++ b/src/lib/src/core/cache/cachers/repo_size.rs
@@ -131,16 +131,18 @@ pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError>
         util::fs::write_to_path(&size_path, &size_str)?;
 
         let latest_commit_path = dir_latest_commit_path(repo, commit, &dir);
-        log::debug!(
-            "Writing latest commit {} to {:?}",
-            latest_commit.as_ref().unwrap().id,
-            latest_commit_path
-        );
-        // create parent directory if not exists
-        if let Some(parent) = latest_commit_path.parent() {
-            util::fs::create_dir_all(parent)?;
+        if let Some(latest_commit) = latest_commit {
+            log::debug!(
+                "Writing latest commit {} to {:?}",
+                latest_commit.id,
+                latest_commit_path
+            );
+            // create parent directory if not exists
+            if let Some(parent) = latest_commit_path.parent() {
+                util::fs::create_dir_all(parent)?;
+            }
+            util::fs::write_to_path(&latest_commit_path, &latest_commit.id)?;
         }
-        util::fs::write_to_path(&latest_commit_path, &latest_commit.unwrap().id)?;
     }
 
     // Cache the full size of the repo

--- a/src/lib/src/core/cache/cachers/repo_size.rs
+++ b/src/lib/src/core/cache/cachers/repo_size.rs
@@ -111,7 +111,9 @@ pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError>
                     latest_commit = commit.clone();
                 } else {
                     // log::debug!("CONSIDERING COMMIT PARENT TIMESTAMP {:?} {:?} < {:?}", entry.path, latest_commit.as_ref().unwrap().timestamp, commit.as_ref().unwrap().timestamp);
-                    if latest_commit.as_ref().unwrap().timestamp < commit.as_ref().unwrap().timestamp {
+                    if latest_commit.as_ref().unwrap().timestamp
+                        < commit.as_ref().unwrap().timestamp
+                    {
                         // log::debug!("FOUND LATEST COMMIT PARENT TIMESTAMP {:?} -> {:?}", entry.path, commit);
                         latest_commit = commit.clone();
                     }

--- a/src/lib/src/core/cache/commit_cacher.rs
+++ b/src/lib/src/core/cache/commit_cacher.rs
@@ -1,8 +1,6 @@
 //! This module goes through a repo and caches values on commits that will never change
 //! but are expensive to compute at runtime
 
-use std::collections::HashMap;
-
 use crate::constants::{CACHE_DIR, HISTORY_DIR};
 use crate::core::cache::cacher_status::{CacherStatus, CacherStatusType};
 use crate::core::db::{self, str_json_db};
@@ -20,14 +18,12 @@ type CommitCacher = fn(&LocalRepository, &Commit) -> Result<(), OxenError>;
 lazy_static! {
     /// These are all the cachers we are going to run in `run_all`
     /// TODO: make this a config file that users can extend or run their own cachers
-    static ref CACHERS: HashMap<String, CommitCacher> = {
-        let mut cachers = HashMap::new();
-        cachers.insert(String::from("COMMIT_CONTENT_IS_VALID"), content_validator::compute as CommitCacher);
-        cachers.insert(String::from("REPO_SIZE"), repo_size::compute as CommitCacher);
-        cachers.insert(String::from("COMMIT_STATS"), content_stats::compute as CommitCacher);
-        // cachers.insert(String::from("ARROW_CONVERSION"), convert_to_arrow::convert_to_arrow as CommitCacher);
-        cachers
-    };
+    static ref CACHERS: Vec<(String, CommitCacher)> = vec![
+        (String::from("COMMIT_CONTENT_IS_VALID"), content_validator::compute as CommitCacher),
+        (String::from("REPO_SIZE"), repo_size::compute as CommitCacher),
+        (String::from("COMMIT_STATS"), content_stats::compute as CommitCacher),
+        // (String::from("ARROW_CONVERSION"), convert_to_arrow::convert_to_arrow as CommitCacher),
+    ];
 }
 
 fn cached_status_db_path(repo: &LocalRepository, commit: &Commit) -> PathBuf {

--- a/src/lib/src/core/index/commit_entry_reader.rs
+++ b/src/lib/src/core/index/commit_entry_reader.rs
@@ -80,7 +80,13 @@ impl CommitEntryReader {
 
     /// Lists all the directories in the commit
     pub fn list_dirs(&self) -> Result<Vec<PathBuf>, OxenError> {
-        path_db::list_paths(&self.dir_db, Path::new(""))
+        let root = PathBuf::from("");
+        let mut paths = path_db::list_paths(&self.dir_db, &root)?;
+        if !paths.contains(&root) {
+            paths.push(root);
+        }
+        paths.sort();
+        Ok(paths)
     }
 
     /// Lists all the parents of directories that are in the commit dir db

--- a/src/lib/src/core/index/commit_entry_writer.rs
+++ b/src/lib/src/core/index/commit_entry_writer.rs
@@ -83,7 +83,7 @@ impl CommitEntryWriter {
         );
         for parent_id in parent_ids {
             let parent_commit = api::local::commits::get_by_id(repo, parent_id)?
-                .ok_or(OxenError::committish_not_found(parent_id.to_owned().into()))?;
+                .ok_or(OxenError::revision_not_found(parent_id.to_owned().into()))?;
             log::debug!(
                 "copy parent {} -> '{}'",
                 parent_commit.id,

--- a/src/lib/src/core/index/commit_metadata_db.rs
+++ b/src/lib/src/core/index/commit_metadata_db.rs
@@ -141,7 +141,7 @@ pub fn aggregate_col(
             .from(&table_name);
 
         let df = df_db::select(&conn, &stmt)?;
-        log::debug!("df for dir {:?}: {:?}", dir, df);
+        // log::debug!("df for dir {:?}: {:?}", dir, df);
 
         if df.is_empty() {
             continue;
@@ -176,8 +176,8 @@ pub fn aggregate_col(
             combined_df = Some(df);
         }
 
-        log::debug!("AGGREGATED df {:?}", combined_df);
-        log::debug!("\n--------------DONE-----------------\n");
+        // log::debug!("AGGREGATED df {:?}", combined_df);
+        // log::debug!("\n--------------DONE-----------------\n");
     }
 
     // Make sure we don't unwrap an empty default

--- a/src/lib/src/core/index/commit_metadata_db.rs
+++ b/src/lib/src/core/index/commit_metadata_db.rs
@@ -67,7 +67,12 @@ pub fn index_commit(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenE
     );
 
     // Connect to db
-    let mut conn = df_db::get_connection(db_path(repo, commit))?;
+    let path = db_path(repo, commit);
+    // Remove db if it is exists, since we might be recomputing
+    if path.exists() {
+        util::fs::remove_file(&path)?;
+    }
+    let mut conn = df_db::get_connection(path)?;
     let table_name = df_db::create_table_if_not_exists(&conn, &DirMetadataItem::schema())?;
 
     // Create an appender transaction

--- a/src/lib/src/core/index/commit_validator.rs
+++ b/src/lib/src/core/index/commit_validator.rs
@@ -51,7 +51,7 @@ fn compute_versions_hash(
             continue;
         }
 
-        let hash = util::hasher::hash_file_contents(&version_path)?;
+        let hash = util::hasher::hash_file_contents_with_retry(&version_path)?;
         // log::debug!("Got hash: {:?} -> {}", entry.path, hash);
 
         hashes.push(SimpleHash { hash })

--- a/src/lib/src/core/index/entry_indexer.rs
+++ b/src/lib/src/core/index/entry_indexer.rs
@@ -111,8 +111,10 @@ impl EntryIndexer {
                 }
                 Ok(commit)
             }
-            _ => {
+            Ok(None) => api::local::commits::head_commit(&self.repository),
+            Err(err) => {
                 // if no commit objects, means repo is empty, so instantiate the local repo
+                log::error!("pull_all error: {}", err);
                 eprintln!("warning: You appear to have cloned an empty repository. Initializing with an empty commit.");
                 api::local::commits::commit_with_no_files(
                     &self.repository,
@@ -134,8 +136,10 @@ impl EntryIndexer {
                     .await?;
                 Ok(commit)
             }
-            _ => {
+            Ok(None) => api::local::commits::head_commit(&self.repository),
+            Err(err) => {
                 // if no commit objects, means repo is empty, so instantiate the local repo
+                log::error!("pull_one error: {}", err);
                 eprintln!("warning: You appear to have cloned an empty repository. Initializing with an empty commit.");
                 api::local::commits::commit_with_no_files(
                     &self.repository,
@@ -202,10 +206,13 @@ impl EntryIndexer {
                 return Ok(Some(commit));
             }
             Ok(None) => {
-                eprintln!("oxen pull error: remote head does not exist");
+                println!("Everything up to date.");
             }
             Err(err) => {
-                log::debug!("oxen pull could not get remote head: {}", err);
+                log::warn!(
+                    "pull_first_commit_object could not get remote commit: {}",
+                    err
+                );
             }
         }
 
@@ -245,7 +252,6 @@ impl EntryIndexer {
         let total_missing = missing_commits.len();
         if total_missing == 0 {
             // Nothing to do
-            println!("Everything up to date.");
             return Ok(None);
         }
         println!("🐂 fetching {} commit objects", total_missing);
@@ -274,10 +280,13 @@ impl EntryIndexer {
                 return Ok(Some(commit));
             }
             Ok(None) => {
-                eprintln!("oxen pull error: remote head does not exist");
+                log::debug!("pull_all_commit_objects commit does not exist");
             }
             Err(err) => {
-                log::debug!("oxen pull could not get remote head: {}", err);
+                log::warn!(
+                    "pull_all_commit_objects could not get remote commit: {}",
+                    err
+                );
             }
         }
 

--- a/src/lib/src/error.rs
+++ b/src/lib/src/error.rs
@@ -44,7 +44,7 @@ pub enum OxenError {
 
     // Branches/Commits
     BranchNotFound(Box<StringError>),
-    CommittishNotFound(Box<StringError>),
+    RevisionNotFound(Box<StringError>),
     RootCommitDoesNotMatch(Box<Commit>),
     NothingToCommit(StringError),
 
@@ -136,8 +136,8 @@ impl OxenError {
         OxenError::RepoAlreadyExists(Box::new(repo))
     }
 
-    pub fn committish_not_found(value: StringError) -> Self {
-        OxenError::CommittishNotFound(Box::new(value))
+    pub fn revision_not_found(value: StringError) -> Self {
+        OxenError::RevisionNotFound(Box::new(value))
     }
 
     pub fn root_commit_does_not_match(commit: Commit) -> Self {

--- a/src/lib/src/model/commit.rs
+++ b/src/lib/src/model/commit.rs
@@ -124,7 +124,7 @@ impl Commit {
     pub fn from_branch(commit_reader: &CommitReader, branch: &Branch) -> Result<Commit, OxenError> {
         commit_reader
             .get_commit_by_id(&branch.commit_id)?
-            .ok_or(OxenError::committish_not_found(
+            .ok_or(OxenError::revision_not_found(
                 branch.commit_id.to_string().into(),
             ))
     }

--- a/src/lib/src/model/entry/entry_data_type.rs
+++ b/src/lib/src/model/entry/entry_data_type.rs
@@ -14,11 +14,25 @@ pub enum EntryDataType {
     Binary,
 }
 
+impl EntryDataType {
+    pub fn to_emoji(&self) -> String {
+        match *self {
+            EntryDataType::Dir => "📁".to_string(),
+            EntryDataType::Text => "📄".to_string(),
+            EntryDataType::Image => "📸".to_string(),
+            EntryDataType::Video => "🎥".to_string(),
+            EntryDataType::Audio => "🎵".to_string(),
+            EntryDataType::Tabular => "📊".to_string(),
+            EntryDataType::Binary => "📦".to_string(),
+        }
+    }
+}
+
 impl FromStr for EntryDataType {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
+        match s.to_lowercase().as_str() {
             "dir" => Ok(EntryDataType::Dir),
             "text" => Ok(EntryDataType::Text),
             "image" => Ok(EntryDataType::Image),

--- a/src/lib/src/opts.rs
+++ b/src/lib/src/opts.rs
@@ -4,6 +4,7 @@
 pub mod add_opts;
 pub mod clone_opts;
 pub mod df_opts;
+pub mod info_opts;
 pub mod log_opts;
 pub mod paginate_opts;
 pub mod restore_opts;
@@ -12,6 +13,7 @@ pub mod rm_opts;
 pub use crate::opts::add_opts::AddOpts;
 pub use crate::opts::clone_opts::CloneOpts;
 pub use crate::opts::df_opts::DFOpts;
+pub use crate::opts::info_opts::InfoOpts;
 pub use crate::opts::log_opts::LogOpts;
 pub use crate::opts::paginate_opts::PaginateOpts;
 pub use crate::opts::restore_opts::RestoreOpts;

--- a/src/lib/src/opts/info_opts.rs
+++ b/src/lib/src/opts/info_opts.rs
@@ -1,0 +1,9 @@
+use std::path::PathBuf;
+
+#[derive(Clone, Debug)]
+pub struct InfoOpts {
+    pub path: PathBuf,
+    pub revision: Option<String>, // commit id or branch
+    pub verbose: bool,
+    pub output_as_json: bool,
+}

--- a/src/lib/src/opts/log_opts.rs
+++ b/src/lib/src/opts/log_opts.rs
@@ -1,5 +1,5 @@
 #[derive(Clone, Debug)]
 pub struct LogOpts {
-    pub committish: Option<String>, // commit id or branch name
+    pub revision: Option<String>, // commit id or branch name
     pub remote: bool,
 }

--- a/src/lib/src/util/fs.rs
+++ b/src/lib/src/util/fs.rs
@@ -71,7 +71,7 @@ pub fn version_path_for_commit_id(
             }
             None => Err(OxenError::path_does_not_exist(filepath)),
         },
-        None => Err(OxenError::committish_not_found(commit_id.into())),
+        None => Err(OxenError::revision_not_found(commit_id.into())),
     }
 }
 

--- a/src/lib/src/view.rs
+++ b/src/lib/src/view.rs
@@ -4,6 +4,7 @@
 pub mod branch;
 pub mod commit;
 pub mod compare;
+pub mod data_type_count;
 pub mod entry;
 pub mod entry_metadata;
 pub mod file_metadata;
@@ -11,6 +12,7 @@ pub mod health;
 pub mod http;
 pub mod json_data_frame;
 pub mod merge;
+pub mod mime_type_count;
 pub mod namespace;
 pub mod oxen_response;
 pub mod pagination;
@@ -20,7 +22,9 @@ pub mod schema;
 pub mod status_message;
 
 pub use crate::view::compare::CompareEntriesResponse;
+pub use crate::view::data_type_count::DataTypeCount;
 pub use crate::view::file_metadata::{FileMetadata, FileMetadataResponse, FilePathsResponse};
+pub use crate::view::mime_type_count::MimeTypeCount;
 pub use crate::view::status_message::{
     IsValidStatusMessage, StatusMessage, StatusMessageDescription,
 };

--- a/src/lib/src/view/data_type_count.rs
+++ b/src/lib/src/view/data_type_count.rs
@@ -1,0 +1,7 @@
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+pub struct DataTypeCount {
+    pub count: usize,
+    pub data_type: String,
+}

--- a/src/lib/src/view/entry.rs
+++ b/src/lib/src/view/entry.rs
@@ -1,7 +1,7 @@
 use crate::model::{CommitEntry, MetadataEntry, RemoteEntry};
 use serde::{Deserialize, Serialize};
 
-use super::StatusMessage;
+use super::{JsonDataFrame, StatusMessage};
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct EntryResponse {
@@ -44,11 +44,16 @@ pub struct PaginatedEntries {
 }
 
 #[derive(Deserialize, Serialize, Debug)]
+pub struct DirectoryMetadata {
+    pub data_types: JsonDataFrame,
+    pub mime_types: JsonDataFrame,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
 pub struct PaginatedDirEntries {
-    #[serde(flatten)]
-    pub status: StatusMessage,
     pub entries: Vec<MetadataEntry>,
     pub resource: Option<ResourceVersion>,
+    pub metadata: Option<DirectoryMetadata>,
     pub page_size: usize,
     pub page_number: usize,
     pub total_pages: usize,
@@ -59,24 +64,15 @@ pub struct PaginatedDirEntries {
 pub struct PaginatedDirEntriesResponse {
     #[serde(flatten)]
     pub status: StatusMessage,
-    pub entries: Vec<MetadataEntry>,
-    pub resource: Option<ResourceVersion>,
-    pub page_size: usize,
-    pub page_number: usize,
-    pub total_pages: usize,
-    pub total_entries: usize,
+    #[serde(flatten)]
+    pub entries: PaginatedDirEntries,
 }
 
 impl PaginatedDirEntriesResponse {
     pub fn ok_from(paginated: PaginatedDirEntries) -> Self {
         Self {
             status: StatusMessage::resource_found(),
-            entries: paginated.entries,
-            resource: paginated.resource,
-            page_size: paginated.page_size,
-            page_number: paginated.page_number,
-            total_pages: paginated.total_pages,
-            total_entries: paginated.total_entries,
+            entries: paginated,
         }
     }
 }

--- a/src/lib/src/view/mime_type_count.rs
+++ b/src/lib/src/view/mime_type_count.rs
@@ -1,0 +1,7 @@
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+pub struct MimeTypeCount {
+    pub count: usize,
+    pub mime_type: String,
+}

--- a/src/lib/src/view/remote_staged_status.rs
+++ b/src/lib/src/view/remote_staged_status.rs
@@ -135,12 +135,12 @@ impl RemoteStagedStatus {
         let (paginated, pagination) = util::paginate(entries, page_number, page_size);
 
         PaginatedDirEntries {
-            status: StatusMessage::resource_found(),
             entries: paginated,
             page_number: pagination.page_number,
             page_size: pagination.page_size,
             total_pages: pagination.total_pages,
             total_entries: pagination.total_entries,
+            metadata: None,
             resource: None,
         }
     }

--- a/src/server/src/controllers/compare.rs
+++ b/src/server/src/controllers/compare.rs
@@ -31,13 +31,13 @@ pub async fn show(
     // Parse the base and head from the base..head string
     let (base, head) = parse_base_head(&base_head)?;
     let (base_branch, head_branch) = resolve_base_head_branches(&repository, &base, &head)?;
-    let base = base_branch.ok_or(OxenError::committish_not_found(base.into()))?;
-    let head = head_branch.ok_or(OxenError::committish_not_found(head.into()))?;
+    let base = base_branch.ok_or(OxenError::revision_not_found(base.into()))?;
+    let head = head_branch.ok_or(OxenError::revision_not_found(head.into()))?;
 
     let base_commit = api::local::commits::get_by_id(&repository, &base.commit_id)?
-        .ok_or(OxenError::committish_not_found(base.commit_id.into()))?;
+        .ok_or(OxenError::revision_not_found(base.commit_id.into()))?;
     let head_commit = api::local::commits::get_by_id(&repository, &head.commit_id)?
-        .ok_or(OxenError::committish_not_found(head.commit_id.into()))?;
+        .ok_or(OxenError::revision_not_found(head.commit_id.into()))?;
 
     let entries = api::local::diff::list_diff_entries(&repository, &base_commit, &head_commit)?;
 
@@ -67,14 +67,14 @@ pub async fn commits(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHt
     // Parse the base and head from the base..head string
     let (base, head) = parse_base_head(&base_head)?;
     let (base_branch, head_branch) = resolve_base_head_branches(&repository, &base, &head)?;
-    let base = base_branch.ok_or(OxenError::committish_not_found(base.into()))?;
-    let head = head_branch.ok_or(OxenError::committish_not_found(head.into()))?;
+    let base = base_branch.ok_or(OxenError::revision_not_found(base.into()))?;
+    let head = head_branch.ok_or(OxenError::revision_not_found(head.into()))?;
 
     let base_commit = api::local::commits::get_by_id(&repository, &base.commit_id)?.ok_or(
-        OxenError::committish_not_found(base.to_owned().commit_id.into()),
+        OxenError::revision_not_found(base.to_owned().commit_id.into()),
     )?;
     let head_commit = api::local::commits::get_by_id(&repository, &head.commit_id)?.ok_or(
-        OxenError::committish_not_found(head.to_owned().commit_id.into()),
+        OxenError::revision_not_found(head.to_owned().commit_id.into()),
     )?;
 
     // Check if mergeable
@@ -112,13 +112,13 @@ pub async fn entities(
     // Parse the base and head from the base..head string
     let (base, head) = parse_base_head(&base_head)?;
     let (base_branch, head_branch) = resolve_base_head_branches(&repository, &base, &head)?;
-    let base = base_branch.ok_or(OxenError::committish_not_found(base.into()))?;
-    let head = head_branch.ok_or(OxenError::committish_not_found(head.into()))?;
+    let base = base_branch.ok_or(OxenError::revision_not_found(base.into()))?;
+    let head = head_branch.ok_or(OxenError::revision_not_found(head.into()))?;
 
     let base_commit = api::local::commits::get_by_id(&repository, &base.commit_id)?
-        .ok_or(OxenError::committish_not_found(base.commit_id.into()))?;
+        .ok_or(OxenError::revision_not_found(base.commit_id.into()))?;
     let head_commit = api::local::commits::get_by_id(&repository, &head.commit_id)?
-        .ok_or(OxenError::committish_not_found(head.commit_id.into()))?;
+        .ok_or(OxenError::revision_not_found(head.commit_id.into()))?;
 
     let entries = api::local::diff::list_diff_entries(&repository, &base_commit, &head_commit)?;
 

--- a/src/server/src/controllers/merger.rs
+++ b/src/server/src/controllers/merger.rs
@@ -21,8 +21,8 @@ pub async fn show(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
     // Parse the base and head from the base..head string
     let (base, head) = parse_base_head(&base_head)?;
     let (base_commit, head_commit) = resolve_base_head_branches(&repository, &base, &head)?;
-    let base = base_commit.ok_or(OxenError::committish_not_found(base.into()))?;
-    let head = head_commit.ok_or(OxenError::committish_not_found(head.into()))?;
+    let base = base_commit.ok_or(OxenError::revision_not_found(base.into()))?;
+    let head = head_commit.ok_or(OxenError::revision_not_found(head.into()))?;
 
     // Check if mergeable
     let merger = Merger::new(&repository)?;
@@ -66,8 +66,8 @@ pub async fn merge(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttp
     // Parse the base and head from the base..head string
     let (base, head) = parse_base_head(&base_head)?;
     let (base_commit, head_commit) = resolve_base_head_branches(&repository, &base, &head)?;
-    let base = base_commit.ok_or(OxenError::committish_not_found(base.into()))?;
-    let head = head_commit.ok_or(OxenError::committish_not_found(head.into()))?;
+    let base = base_commit.ok_or(OxenError::revision_not_found(base.into()))?;
+    let head = head_commit.ok_or(OxenError::revision_not_found(head.into()))?;
 
     // Check if mergeable
     let merger = Merger::new(&repository)?;

--- a/src/server/src/controllers/metadata.rs
+++ b/src/server/src/controllers/metadata.rs
@@ -28,7 +28,7 @@ pub async fn file(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
     );
 
     let latest_commit = api::local::commits::get_by_id(&repo, &resource.commit.id)?.ok_or(
-        OxenError::committish_not_found(resource.commit.id.clone().into()),
+        OxenError::revision_not_found(resource.commit.id.clone().into()),
     )?;
 
     log::debug!(
@@ -61,7 +61,7 @@ pub async fn dir(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpEr
     );
 
     let latest_commit = api::local::commits::get_by_id(&repo, &resource.commit.id)?.ok_or(
-        OxenError::committish_not_found(resource.commit.id.clone().into()),
+        OxenError::revision_not_found(resource.commit.id.clone().into()),
     )?;
 
     log::debug!(
@@ -115,7 +115,7 @@ pub async fn agg_dir(
     );
 
     let latest_commit = api::local::commits::get_by_id(&repo, &resource.commit.id)?.ok_or(
-        OxenError::committish_not_found(resource.commit.id.clone().into()),
+        OxenError::revision_not_found(resource.commit.id.clone().into()),
     )?;
 
     log::debug!(
@@ -172,7 +172,7 @@ pub async fn images(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHtt
     );
 
     let latest_commit = api::local::commits::get_by_id(&repo, &resource.commit.id)?.ok_or(
-        OxenError::committish_not_found(resource.commit.id.clone().into()),
+        OxenError::revision_not_found(resource.commit.id.clone().into()),
     )?;
 
     log::debug!(

--- a/src/server/src/controllers/stager.rs
+++ b/src/server/src/controllers/stager.rs
@@ -170,7 +170,7 @@ pub async fn df_add_row(req: HttpRequest, bytes: Bytes) -> Result<HttpResponse, 
     );
 
     let commit = api::local::commits::get_by_id(&repo, &branch.commit_id)?.ok_or(
-        OxenError::committish_not_found(branch.commit_id.to_owned().into()),
+        OxenError::revision_not_found(branch.commit_id.to_owned().into()),
     )?;
 
     let entry = api::local::entries::get_commit_entry(&repo, &commit, &resource.file_path)?

--- a/src/server/src/errors.rs
+++ b/src/server/src/errors.rs
@@ -99,7 +99,7 @@ impl error::ResponseError for OxenHttpError {
                             branch
                         )))
                     }
-                    OxenError::CommittishNotFound(commit_id) => {
+                    OxenError::RevisionNotFound(commit_id) => {
                         log::debug!("Not found: {}", commit_id);
 
                         HttpResponse::NotFound().json(StatusMessageDescription::not_found(format!(
@@ -162,7 +162,7 @@ impl error::ResponseError for OxenHttpError {
             OxenHttpError::SerdeError(_) => StatusCode::BAD_REQUEST,
             OxenHttpError::InternalOxenError(error) => match error {
                 OxenError::RepoNotFound(_) => StatusCode::NOT_FOUND,
-                OxenError::CommittishNotFound(_) => StatusCode::NOT_FOUND,
+                OxenError::RevisionNotFound(_) => StatusCode::NOT_FOUND,
                 OxenError::InvalidSchema(_) => StatusCode::BAD_REQUEST,
                 OxenError::ParsingError(_) => StatusCode::BAD_REQUEST,
                 _ => StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/server/src/params.rs
+++ b/src/server/src/params.rs
@@ -67,17 +67,17 @@ pub fn resolve_base_head(
     base: &str,
     head: &str,
 ) -> Result<(Option<Commit>, Option<Commit>), OxenError> {
-    let base = resolve_committish(repo, base)?;
-    let head = resolve_committish(repo, head)?;
+    let base = resolve_revision(repo, base)?;
+    let head = resolve_revision(repo, head)?;
     Ok((base, head))
 }
 
-pub fn resolve_committish(
+pub fn resolve_revision(
     repo: &LocalRepository,
-    committish: &str,
+    revision: &str,
 ) -> Result<Option<Commit>, OxenError> {
     // Lookup commit by id or branch name
-    api::local::commits::get_by_revision(repo, committish)
+    api::local::revisions::get(repo, revision)
 }
 
 pub fn resolve_branch(repo: &LocalRepository, name: &str) -> Result<Option<Branch>, OxenError> {


### PR DESCRIPTION
There are 3 main things I added here @benartuso 

1) the /dir API returns data_type counts, which you can test by pushing a fresh repo and doing `oxen remote ls` (we will have to run a migration script on the server to fix the duplicate counts)
2) `oxen info file.txt COMMIT_ID` can now take an optional commit id so you can get the computed hash of the file at that commit
3) We are sending the branch object in the /complete API so that you can see if it is on the default branch on your end