### PR TITLE
Fixing merge of reassing-repo-namespace into main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,16 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Install mold linker
+        run: |
+          git clone git@github.com:bluewhalesystems/sold.git
+
+          mkdir sold/build
+          cd sold/build
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=c++ ..
+          cmake --build . -j $(nproc)
+          sudo cmake --install .
+
       - name: Install latest rust toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,11 @@ on:
 jobs:
   release_ubuntu_latest:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      
+
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
 
@@ -46,7 +46,16 @@ jobs:
           ruby ruby-dev rubygems build-essential \
           && sudo gem install fpm
 
-      
+      - name: Install mold linker
+        run: |
+          git clone https://github.com/rui314/mold.git
+          mkdir mold/build
+          cd mold/build
+          git checkout v2.0.0
+          ../install-build-deps.sh
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=c++ ..
+          cmake --build . -j $(nproc)
+          sudo cmake --install .
 
       # - name: Install imagemagick
       #   run: |
@@ -120,7 +129,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      
+
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
 
@@ -155,6 +164,17 @@ jobs:
           libswscale-dev libswresample-dev libpostproc-dev libssl-dev pkg-config \
           ruby ruby-dev rubygems build-essential \
           && sudo gem install fpm
+
+      - name: Install mold linker
+        run: |
+          git clone https://github.com/rui314/mold.git
+          mkdir mold/build
+          cd mold/build
+          git checkout v2.0.0
+          ../install-build-deps.sh
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=c++ ..
+          cmake --build . -j $(nproc)
+          sudo cmake --install .
 
       # - name: Install imagemagick
       #   run: |
@@ -324,6 +344,16 @@ jobs:
           toolchain: stable
           override: true
 
+      - name: Install mold linker
+        run: |
+          git clone git@github.com:bluewhalesystems/sold.git
+
+          mkdir sold/build
+          cd sold/build
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=c++ ..
+          cmake --build . -j $(nproc)
+          sudo cmake --install .
+
       - name: Build oxen for mac
         run: cargo build --release
 
@@ -384,6 +414,16 @@ jobs:
           toolchain: stable
           override: true
 
+      - name: Install mold linker
+        run: |
+          git clone git@github.com:bluewhalesystems/sold.git
+
+          mkdir sold/build
+          cd sold/build
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=c++ ..
+          cmake --build . -j $(nproc)
+          sudo cmake --install .
+
       - name: Build oxen for mac
         run: cargo build --release
 
@@ -443,6 +483,16 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+
+      - name: Install mold linker
+        run: |
+          git clone git@github.com:bluewhalesystems/sold.git
+
+          mkdir sold/build
+          cd sold/build
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=c++ ..
+          cmake --build . -j $(nproc)
+          sudo cmake --install .
 
       - name: Build oxen for mac
         run: cargo build --release

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ cli-test/.env
 
 # rspec failure tracking
 cli-test.rspec_status
+
+# Per-project Cargo config
+# We're currently only using this for configuring mold/sold for local
+# development, so we don't want to track those changes
+.cargo/config.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,15 @@ RUN apt-get update \
 #  && cd .. \
 #  && rm -r ImageMagick-${MAGICK_VERSION}*
 
+RUN git clone https://github.com/rui314/mold.git \
+    && mkdir mold/build \
+    && cd mold/build \
+    && git checkout v2.0.0 \
+    && ../install-build-deps.sh \
+    && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=c++ .. \
+    && cmake --build . -j $(nproc) \
+    && cmake --install .
+
 RUN cargo install cargo-build-deps
 
 # create an empty project to install dependencies

--- a/README.md
+++ b/README.md
@@ -33,6 +33,36 @@ $ rustup target install x86_64-apple-darwin
 $ cargo build --target x86_64-apple-darwin
 ```
 
+### Speed up the build process
+
+You can use
+the [mold](https://github.com/rui314/mold) linker to speed up builds (The
+commercial Mac OS version is [sold](https://github.com/bluewhalesystems/sold)).
+
+Assuming you have purchased a license, you can use the following instructions to
+install sold and configure cargo to use it for building Oxen:
+
+```
+git clone git@github.com:bluewhalesystems/sold.git
+
+mkdir sold/build
+cd sold/build
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=c++ ..
+cmake --build . -j $(nproc)
+sudo cmake --install .
+```
+
+Then create `.cargo/config.toml` in your Oxen repo root with the following
+content:
+
+```
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/ld64.mold"]
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/ld64.mold"]
+```
+
 ## Run
 
 Generate a config file and token to give user access to the server

--- a/src/lib/src/api/endpoint.rs
+++ b/src/lib/src/api/endpoint.rs
@@ -11,6 +11,10 @@ pub fn url_from_host(host: &str, uri: &str) -> String {
     format!("http://{host}{API_NAMESPACE}{uri}")
 }
 
+pub fn remote_url_from_host(host: &str, namespace: &str, name: &str) -> String {
+    format!("http://{host}/{namespace}/{name}")
+}
+
 pub fn remote_url_from_namespace_name(host: &str, namespace: &str, name: &str) -> String {
     format!("http://{host}/{namespace}/{name}")
 }

--- a/src/lib/src/api/endpoint.rs
+++ b/src/lib/src/api/endpoint.rs
@@ -11,10 +11,6 @@ pub fn url_from_host(host: &str, uri: &str) -> String {
     format!("http://{host}{API_NAMESPACE}{uri}")
 }
 
-pub fn remote_url_from_host(host: &str, namespace: &str, name: &str) -> String {
-    format!("http://{host}/{namespace}/{name}")
-}
-
 pub fn remote_url_from_namespace_name(host: &str, namespace: &str, name: &str) -> String {
     format!("http://{host}/{namespace}/{name}")
 }

--- a/src/lib/src/api/remote/repositories.rs
+++ b/src/lib/src/api/remote/repositories.rs
@@ -210,7 +210,7 @@ pub async fn transfer_namespace(
             Ok(response) => {
                 // Update remote to reflect new namespace
                 let host = api::remote::client::get_host_from_url(&repository.remote.url)?;
-                let new_remote_url = api::endpoint::remote_url_from_host(
+                let new_remote_url = api::endpoint::remote_url_from_namespace_name(
                     &host,
                     &response.repository.namespace,
                     &repository.name,

--- a/src/lib/src/opts/helpers.rs
+++ b/src/lib/src/opts/helpers.rs
@@ -22,7 +22,7 @@ pub async fn remote_commit_id(
     // Then see if the branch exists
     if let Some(branch_name) = branch_name {
         if let Some(branch) = api::remote::branches::get_by_name(repo, branch_name).await? {
-            return Ok(branch.commit_id.to_string());
+            return Ok(branch.commit_id);
         }
     }
 
@@ -31,5 +31,5 @@ pub async fn remote_commit_id(
     if main_branch.is_none() {
         return Err(OxenError::basic_str("No main branch found on remote."));
     }
-    Ok(main_branch.unwrap().commit_id.to_string())
+    Ok(main_branch.unwrap().commit_id)
 }


### PR DESCRIPTION
`api::endpoint::remote_url_from_host` was somehow dropped when this branch was merged into main, so it couldn't build. No idea how this happened, but fixing it here. Changes to `helpers` are just at clippy's request