### PR TITLE
Fix - stop sending cache directory etc. in clones

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,21 @@ rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/ld64.mold"]
 
 [target.x86_64-apple-darwin]
 rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/ld64.mold"]
+
+```
+
+**For macOS with Apple Silicon**, you can use the [lld](https://lld.llvm.org/) linker.
+
+```
+brew install llvm
+```
+
+Then create `.cargo/config.toml` in your Oxen repo root with the following:
+
+```
+[target.aarch64-apple-darwin]
+rustflags = [ "-C", "link-arg=-fuse-ld=/opt/homebrew/opt/llvm/bin/ld64.lld", ]
+
 ```
 
 ## Run

--- a/src/server/src/controllers/commits.rs
+++ b/src/server/src/controllers/commits.rs
@@ -3,6 +3,9 @@ use liboxen::constants;
 use liboxen::constants::COMMITS_DIR;
 use liboxen::constants::HASH_FILE;
 use liboxen::constants::HISTORY_DIR;
+use liboxen::constants::FILES_DIR;
+use liboxen::constants::SCHEMAS_DIR;
+use liboxen::constants::DIRS_DIR;
 use liboxen::core::cache::cacher_status::CacherStatusType;
 use liboxen::core::cache::cachers::content_validator;
 use liboxen::core::cache::commit_cacher;
@@ -313,7 +316,17 @@ fn compress_commit(repository: &LocalRepository, commit: &Commit) -> Result<Vec<
     let enc = GzEncoder::new(Vec::new(), Compression::default());
     let mut tar = tar::Builder::new(enc);
 
-    tar.append_dir_all(&tar_subdir, commit_dir)?;
+    // Ignore cache and other dirs, only take what we need 
+    let dirs_to_compress = vec![DIRS_DIR, FILES_DIR, SCHEMAS_DIR];
+
+    for dir in &dirs_to_compress {
+         let full_path = commit_dir.join(dir);
+         let tar_path = tar_subdir.join(dir);
+         if full_path.exists() {
+             tar.append_dir_all(&tar_path, full_path)?;
+         }
+     }
+
     tar.finish()?;
 
     let buffer: Vec<u8> = tar.into_inner()?.finish()?;

--- a/src/server/src/controllers/commits.rs
+++ b/src/server/src/controllers/commits.rs
@@ -1,11 +1,11 @@
 use liboxen::api;
 use liboxen::constants;
 use liboxen::constants::COMMITS_DIR;
+use liboxen::constants::DIRS_DIR;
+use liboxen::constants::FILES_DIR;
 use liboxen::constants::HASH_FILE;
 use liboxen::constants::HISTORY_DIR;
-use liboxen::constants::FILES_DIR;
 use liboxen::constants::SCHEMAS_DIR;
-use liboxen::constants::DIRS_DIR;
 use liboxen::core::cache::cacher_status::CacherStatusType;
 use liboxen::core::cache::cachers::content_validator;
 use liboxen::core::cache::commit_cacher;
@@ -316,16 +316,16 @@ fn compress_commit(repository: &LocalRepository, commit: &Commit) -> Result<Vec<
     let enc = GzEncoder::new(Vec::new(), Compression::default());
     let mut tar = tar::Builder::new(enc);
 
-    // Ignore cache and other dirs, only take what we need 
+    // Ignore cache and other dirs, only take what we need
     let dirs_to_compress = vec![DIRS_DIR, FILES_DIR, SCHEMAS_DIR];
 
     for dir in &dirs_to_compress {
-         let full_path = commit_dir.join(dir);
-         let tar_path = tar_subdir.join(dir);
-         if full_path.exists() {
-             tar.append_dir_all(&tar_path, full_path)?;
-         }
-     }
+        let full_path = commit_dir.join(dir);
+        let tar_path = tar_subdir.join(dir);
+        if full_path.exists() {
+            tar.append_dir_all(&tar_path, full_path)?;
+        }
+    }
 
     tar.finish()?;
 


### PR DESCRIPTION
Also adding `lld` linker instructions as a backup for anyone who can't get `sold` working on M1