### PR TITLE
Feature/pull all branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,21 @@ rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/ld64.mold"]
 
 [target.x86_64-apple-darwin]
 rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/ld64.mold"]
+
+```
+
+**For macOS with Apple Silicon**, you can use the [lld](https://lld.llvm.org/) linker.
+
+```
+brew install llvm
+```
+
+Then create `.cargo/config.toml` in your Oxen repo root with the following:
+
+```
+[target.aarch64-apple-darwin]
+rustflags = [ "-C", "link-arg=-fuse-ld=/opt/homebrew/opt/llvm/bin/ld64.lld", ]
+
 ```
 
 ## Run

--- a/src/lib/src/model/repository/local_repository.rs
+++ b/src/lib/src/model/repository/local_repository.rs
@@ -10,6 +10,7 @@ use crate::opts::CloneOpts;
 use crate::opts::PullOpts;
 use crate::util;
 use crate::view::RepositoryView;
+use indicatif::ProgressBar;
 
 use http::Uri;
 use serde::{Deserialize, Serialize};
@@ -232,19 +233,43 @@ impl LocalRepository {
         let rb = RemoteBranch::from_branch(&opts.branch);
         let indexer = EntryIndexer::new(&local_repo)?;
 
+        local_repo
+            .maybe_pull_entries(&repo, &indexer, &rb, opts)
+            .await?;
+
         if opts.all {
+            println!("🐂 fetching additional remote branches");
             let remote_branches = api::remote::branches::list(&repo).await?;
+
+            // All except the target branch
+            let bar = ProgressBar::new(remote_branches.len() as u64 - 1);
+
             for branch in remote_branches {
+                if branch.name == rb.branch {
+                    // Skip this branch, as it matches the criteria
+                    continue;
+                }
+
                 let remote_branch = RemoteBranch::from_branch(&branch.name);
                 indexer
                     .pull_most_recent_commit_object(&repo, &remote_branch, false)
                     .await?;
+                bar.inc(1);
             }
+            bar.finish();
         }
 
-        local_repo
-            .maybe_pull_entries(&repo, &indexer, &rb, opts)
-            .await?;
+        if opts.shallow {
+            println!(
+                "🐂 cloned {} to {}/\n\ncd {}\noxen pull origin {}",
+                repo.remote.url, repo.name, repo.name, opts.branch
+            )
+        } else {
+            println!(
+                "\n🐂 cloned {} to {}/\n\ncd {}\noxen status",
+                repo.remote.url, repo.name, repo.name
+            );
+        }
 
         Ok(local_repo)
     }
@@ -262,11 +287,6 @@ impl LocalRepository {
                 .pull_most_recent_commit_object(repo, rb, true)
                 .await?;
             self.write_is_shallow(true)?;
-
-            println!(
-                "🐂 cloned {} to {}/\n\ncd {}\noxen pull origin {}",
-                repo.remote.url, repo.name, repo.name, opts.branch
-            );
         } else {
             // Pull all entries
             indexer
@@ -278,12 +298,7 @@ impl LocalRepository {
                     },
                 )
                 .await?;
-            println!(
-                "\n🐂 cloned {} to {}/\n\ncd {}\noxen status",
-                repo.remote.url, repo.name, repo.name
-            );
         }
-
         Ok(())
     }
 

--- a/src/lib/src/model/repository/local_repository.rs
+++ b/src/lib/src/model/repository/local_repository.rs
@@ -228,13 +228,26 @@ impl LocalRepository {
         let toml = toml::to_string(&local_repo)?;
         util::fs::write_to_path(&repo_config_file, &toml)?;
 
-        // Pull all commit objects, but not entries
-        let rb = RemoteBranch::from_branch(&opts.branch);
-        let indexer = EntryIndexer::new(&local_repo)?;
+        // If opts.all is true, pull all branches, otherwise just the specified or default
+        let remote_branches: Vec<RemoteBranch> = if opts.all {
+            let branches = api::remote::branches::list(&repo).await?;
+            log::debug!("Here are the branches we've found: {:?}", branches);
+            branches
+                .iter()
+                .map(|b| RemoteBranch::from_branch(&b.name))
+                .collect()
+        } else {
+            vec![RemoteBranch::from_branch(&opts.branch)]
+        };
 
-        local_repo
-            .maybe_pull_entries(&repo, &indexer, &rb, opts)
-            .await?;
+        // Pull all commit objects, but not entries;
+        let indexer = EntryIndexer::new(&local_repo)?;
+        for rb in &remote_branches {
+            log::debug!("pulling branch: {}", rb.branch);
+            local_repo
+                .maybe_pull_entries(&repo, &indexer, &rb, opts)
+                .await?;
+        }
 
         Ok(local_repo)
     }

--- a/src/server/src/controllers/commits.rs
+++ b/src/server/src/controllers/commits.rs
@@ -1,11 +1,11 @@
 use liboxen::api;
 use liboxen::constants;
 use liboxen::constants::COMMITS_DIR;
+use liboxen::constants::DIRS_DIR;
+use liboxen::constants::FILES_DIR;
 use liboxen::constants::HASH_FILE;
 use liboxen::constants::HISTORY_DIR;
-use liboxen::constants::FILES_DIR;
 use liboxen::constants::SCHEMAS_DIR;
-use liboxen::constants::DIRS_DIR;
 use liboxen::core::cache::cacher_status::CacherStatusType;
 use liboxen::core::cache::cachers::content_validator;
 use liboxen::core::cache::commit_cacher;
@@ -316,16 +316,16 @@ fn compress_commit(repository: &LocalRepository, commit: &Commit) -> Result<Vec<
     let enc = GzEncoder::new(Vec::new(), Compression::default());
     let mut tar = tar::Builder::new(enc);
 
-    // Ignore cache and other dirs, only take what we need 
+    // Ignore cache and other dirs, only take what we need
     let dirs_to_compress = vec![DIRS_DIR, FILES_DIR, SCHEMAS_DIR];
 
     for dir in &dirs_to_compress {
-         let full_path = commit_dir.join(dir);
-         let tar_path = tar_subdir.join(dir);
-         if full_path.exists() {
-             tar.append_dir_all(&tar_path, full_path)?;
-         }
-     }
+        let full_path = commit_dir.join(dir);
+        let tar_path = tar_subdir.join(dir);
+        if full_path.exists() {
+            tar.append_dir_all(&tar_path, full_path)?;
+        }
+    }
 
     tar.finish()?;
 

--- a/tests/test_clone.rs
+++ b/tests/test_clone.rs
@@ -1,6 +1,7 @@
 use liboxen::api;
 use liboxen::command;
 use liboxen::constants;
+use liboxen::constants::DEFAULT_BRANCH_NAME;
 use liboxen::error::OxenError;
 use liboxen::test;
 use liboxen::util;
@@ -9,8 +10,13 @@ use liboxen::util;
 #[tokio::test]
 async fn test_clone_all() -> Result<(), OxenError> {
     test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
+        // Create additional branch on remote repo before clone
+        let branch_name = "test-branch";
+        api::remote::branches::create_from_or_get(&remote_repo, &branch_name, DEFAULT_BRANCH_NAME).await?;
+
         let cloned_remote = remote_repo.clone();
         let og_commits = api::local::commits::list_all(&local_repo)?;
+        let og_branches = api::remote::branches::list(&remote_repo).await?;
 
         // Clone with the --all flag
         test::run_empty_dir_test_async(|new_repo_dir| async move {
@@ -20,6 +26,11 @@ async fn test_clone_all() -> Result<(), OxenError> {
             // Make sure we have all the commit objects
             let cloned_commits = api::local::commits::list_all(&cloned_repo)?;
             assert_eq!(og_commits.len(), cloned_commits.len());
+
+            // Make sure we have all branches 
+            let cloned_branches = api::local::branches::list(&cloned_repo)?;
+            assert_eq!(og_branches.len(), cloned_branches.len());
+            assert_eq!(cloned_branches.len(), 2);
 
             // Make sure we set the HEAD file
             let head_commit = api::local::commits::head_commit(&cloned_repo);

--- a/tests/test_clone.rs
+++ b/tests/test_clone.rs
@@ -12,7 +12,8 @@ async fn test_clone_all() -> Result<(), OxenError> {
     test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
         // Create additional branch on remote repo before clone
         let branch_name = "test-branch";
-        api::remote::branches::create_from_or_get(&remote_repo, &branch_name, DEFAULT_BRANCH_NAME).await?;
+        api::remote::branches::create_from_or_get(&remote_repo, &branch_name, DEFAULT_BRANCH_NAME)
+            .await?;
 
         let cloned_remote = remote_repo.clone();
         let og_commits = api::local::commits::list_all(&local_repo)?;
@@ -27,7 +28,7 @@ async fn test_clone_all() -> Result<(), OxenError> {
             let cloned_commits = api::local::commits::list_all(&cloned_repo)?;
             assert_eq!(og_commits.len(), cloned_commits.len());
 
-            // Make sure we have all branches 
+            // Make sure we have all branches
             let cloned_branches = api::local::branches::list(&cloned_repo)?;
             assert_eq!(og_branches.len(), cloned_branches.len());
             assert_eq!(cloned_branches.len(), 2);


### PR DESCRIPTION
Pre-fetches all branches on `clone --all` and adds progress bar. 

Needed to rearrange where some of the instructive stdout prints are to make sure they come at the end of an entire `clone` (rather than just at the end of the pull entries step) 