### PR TITLE
Fetch all branches on clone --all

### DIFF
--- a/src/lib/src/model/repository/local_repository.rs
+++ b/src/lib/src/model/repository/local_repository.rs
@@ -10,6 +10,7 @@ use crate::opts::CloneOpts;
 use crate::opts::PullOpts;
 use crate::util;
 use crate::view::RepositoryView;
+use indicatif::ProgressBar;
 
 use http::Uri;
 use serde::{Deserialize, Serialize};
@@ -236,6 +237,40 @@ impl LocalRepository {
             .maybe_pull_entries(&repo, &indexer, &rb, opts)
             .await?;
 
+        if opts.all {
+            println!("🐂 fetching additional remote branches");
+            let remote_branches = api::remote::branches::list(&repo).await?;
+
+            // All except the target branch
+            let bar = ProgressBar::new(remote_branches.len() as u64 - 1);
+
+            for branch in remote_branches {
+                if branch.name == rb.branch {
+                    // Skip this branch, as it matches the criteria
+                    continue;
+                }
+
+                let remote_branch = RemoteBranch::from_branch(&branch.name);
+                indexer
+                    .pull_most_recent_commit_object(&repo, &remote_branch, false)
+                    .await?;
+                bar.inc(1);
+            }
+            bar.finish();
+        }
+
+        if opts.shallow {
+            println!(
+                "🐂 cloned {} to {}/\n\ncd {}\noxen pull origin {}",
+                repo.remote.url, repo.name, repo.name, opts.branch
+            )
+        } else {
+            println!(
+                "\n🐂 cloned {} to {}/\n\ncd {}\noxen status",
+                repo.remote.url, repo.name, repo.name
+            );
+        }
+
         Ok(local_repo)
     }
 
@@ -252,11 +287,6 @@ impl LocalRepository {
                 .pull_most_recent_commit_object(repo, rb, true)
                 .await?;
             self.write_is_shallow(true)?;
-
-            println!(
-                "🐂 cloned {} to {}/\n\ncd {}\noxen pull origin {}",
-                repo.remote.url, repo.name, repo.name, opts.branch
-            );
         } else {
             // Pull all entries
             indexer
@@ -268,12 +298,7 @@ impl LocalRepository {
                     },
                 )
                 .await?;
-            println!(
-                "\n🐂 cloned {} to {}/\n\ncd {}\noxen status",
-                repo.remote.url, repo.name, repo.name
-            );
         }
-
         Ok(())
     }
 

--- a/src/lib/src/model/repository/local_repository.rs
+++ b/src/lib/src/model/repository/local_repository.rs
@@ -241,12 +241,11 @@ impl LocalRepository {
             println!("🐂 fetching additional remote branches");
             let remote_branches = api::remote::branches::list(&repo).await?;
 
-            // All except the target branch
             let bar = ProgressBar::new(remote_branches.len() as u64 - 1);
 
             for branch in remote_branches {
+                // We've already pulled the target branch in full
                 if branch.name == rb.branch {
-                    // Skip this branch, as it matches the criteria
                     continue;
                 }
 


### PR DESCRIPTION
Pre-fetches all branches on clone --all and adds progress bar.

Needed to rearrange where some of the instructive stdout prints are to make sure they come at the end of an entire clone (rather than just at the end of the pull entries step)