### PR TITLE
add text2sql param that will hit the api and convert natural language…

### DIFF
--- a/src/cli/src/cmd_setup.rs
+++ b/src/cli/src/cmd_setup.rs
@@ -378,6 +378,18 @@ pub fn df() -> Command {
                 .action(clap::ArgAction::Set),
         )
         .arg(
+            Arg::new("text2sql")
+                .long("text2sql")
+                .help("Run a text query that translates to sql on the data frame.")
+                .action(clap::ArgAction::Set),
+        )
+        .arg(
+            Arg::new("host")
+                .long("host")
+                .help("What remote host to run the query against. Ie: hub.oxen.ai")
+                .action(clap::ArgAction::Set),
+        )
+        .arg(
             Arg::new("unique")
                 .long("unique")
                 .short('u')

--- a/src/cli/src/parse_and_run.rs
+++ b/src/cli/src/parse_and_run.rs
@@ -519,6 +519,8 @@ fn parse_df_sub_matches(sub_matches: &ArgMatches) -> liboxen::opts::DFOpts {
             .map(String::from),
         sort_by: sub_matches.get_one::<String>("sort").map(String::from),
         sql: sub_matches.get_one::<String>("sql").map(String::from),
+        text2sql: sub_matches.get_one::<String>("text2sql").map(String::from),
+        host: sub_matches.get_one::<String>("host").map(String::from),
         unique: sub_matches.get_one::<String>("unique").map(String::from),
         content_type: ContentType::from_str(content_type).unwrap(),
         should_randomize: sub_matches.get_flag("randomize"),

--- a/src/lib/src/api/remote.rs
+++ b/src/lib/src/api/remote.rs
@@ -12,4 +12,5 @@ pub mod merger;
 pub mod metadata;
 pub mod repositories;
 pub mod staging;
+pub mod text2sql;
 pub mod version;

--- a/src/lib/src/api/remote/text2sql.rs
+++ b/src/lib/src/api/remote/text2sql.rs
@@ -1,0 +1,38 @@
+use crate::error::OxenError;
+use crate::{api::remote::client, constants::DEFAULT_HOST};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SqlResponse {
+    pub sql: String,
+}
+
+pub async fn convert(query: &str, schema: &str, host: Option<String>) -> Result<String, OxenError> {
+    let query = urlencoding::encode(query);
+    let schema = urlencoding::encode(schema);
+    let host = match host {
+        Some(host) => host,
+        None => DEFAULT_HOST.to_string(),
+    };
+    let url = format!("http://{host}/api/df/text2sql?query={query}&schema={schema}");
+    log::debug!("text2sql url: {}", url);
+    let client = client::new_for_url(&url)?;
+    match client.get(&url).send().await {
+        Ok(res) => {
+            let err_msg = "You must create an account on https://oxen.ai to enable this feature.\n\nOnce your account is created, set your auth token with the command:\n\n  oxen config --auth hub.oxen.ai YOUR_AUTH_TOKEN\n";
+            let body = client::parse_json_body_with_err_msg(&url, res, Some(err_msg)).await?;
+            log::debug!("text2sql got body: {}", body);
+            let response: Result<SqlResponse, serde_json::Error> = serde_json::from_str(&body);
+            match response {
+                Ok(val) => Ok(val.sql),
+                Err(err) => Err(OxenError::basic_str(format!(
+                    "text2sql error parsing response from {url}\n\nErr {err:?} \n\n{body}"
+                ))),
+            }
+        }
+        Err(err) => {
+            let err = format!("text2sql Err {err:?} request failed: {url}");
+            Err(OxenError::basic_str(err))
+        }
+    }
+}

--- a/src/lib/src/api/remote/text2sql.rs
+++ b/src/lib/src/api/remote/text2sql.rs
@@ -19,8 +19,11 @@ pub async fn convert(query: &str, schema: &str, host: Option<String>) -> Result<
     let client = client::new_for_url(&url)?;
     match client.get(&url).send().await {
         Ok(res) => {
+            let type_override = "unauthenticated";
             let err_msg = "You must create an account on https://oxen.ai to enable this feature.\n\nOnce your account is created, set your auth token with the command:\n\n  oxen config --auth hub.oxen.ai YOUR_AUTH_TOKEN\n";
-            let body = client::parse_json_body_with_err_msg(&url, res, Some(err_msg)).await?;
+            let body =
+                client::parse_json_body_with_err_msg(&url, res, Some(type_override), Some(err_msg))
+                    .await?;
             log::debug!("text2sql got body: {}", body);
             let response: Result<SqlResponse, serde_json::Error> = serde_json::from_str(&body);
             match response {

--- a/src/lib/src/opts/df_opts.rs
+++ b/src/lib/src/opts/df_opts.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::constants::{FILE_ROW_NUM_COL_NAME, ROW_HASH_COL_NAME, ROW_NUM_COL_NAME};
+use crate::constants::{DEFAULT_HOST, FILE_ROW_NUM_COL_NAME, ROW_HASH_COL_NAME, ROW_NUM_COL_NAME};
 use crate::core::df::agg::{self, DFAggregation};
 use crate::error::OxenError;
 use crate::model::schema::Field;
@@ -33,6 +33,7 @@ pub struct DFOpts {
     pub delimiter: Option<String>,
     pub filter: Option<String>,
     pub head: Option<usize>,
+    pub host: Option<String>,
     pub output: Option<PathBuf>,
     pub page_size: Option<usize>,
     pub page: Option<usize>,
@@ -41,6 +42,7 @@ pub struct DFOpts {
     pub slice: Option<String>,
     pub sort_by: Option<String>,
     pub sql: Option<String>,
+    pub text2sql: Option<String>,
     pub tail: Option<usize>,
     pub take: Option<String>,
     pub unique: Option<String>,
@@ -60,6 +62,7 @@ impl DFOpts {
             delimiter: None,
             filter: None,
             head: None,
+            host: None,
             output: None,
             page_size: None,
             page: None,
@@ -68,6 +71,7 @@ impl DFOpts {
             slice: None,
             sort_by: None,
             sql: None,
+            text2sql: None,
             tail: None,
             take: None,
             unique: None,
@@ -139,6 +143,7 @@ impl DFOpts {
             || self.sql.is_some()
             || self.tail.is_some()
             || self.take.is_some()
+            || self.text2sql.is_some()
             || self.unique.is_some()
             || self.vstack.is_some()
     }
@@ -192,6 +197,13 @@ impl DFOpts {
             return Some(split);
         }
         None
+    }
+
+    pub fn get_host(&self) -> String {
+        match &self.host {
+            Some(host) => host.to_owned(),
+            None => String::from(DEFAULT_HOST),
+        }
     }
 
     pub fn get_filter(&self) -> Result<Option<DFFilterExp>, OxenError> {


### PR DESCRIPTION
… to a sql query we run on a dataframe

Depends on [#195](https://github.com/Oxen-AI/OxenHub/pull/195)

You must pass in --host to route it to your local oxen server instance, but defaults to hub. Right now it uses the api to convert text2sql and then runs the sql command on the local dataframe.

```
oxen df COVID-19_Diagnostic_Laboratory_Testing__PCR_Testing__Time_Series.csv --text2sql "find all new_results_reported greater than 2" --host localhost:3001
```