### PR TITLE
Add clone started/completed callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,7 @@ dependencies = [
  "lofty",
  "log",
  "minus",
+ "mockito",
  "mp4",
  "nom",
  "num_cpus",
@@ -761,6 +762,16 @@ name = "askama_escape"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "async-channel"
@@ -2795,6 +2806,7 @@ dependencies = [
  "lazy_static",
  "lofty",
  "log",
+ "mockito",
  "mp4",
  "nom",
  "num_cpus",
@@ -3050,6 +3062,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "mockito"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c762b6267c4593555bb38f1df19e9318985bc4de60b5e8462890856a9a5b4c"
+dependencies = [
+ "assert-json-diff",
+ "colored",
+ "futures",
+ "hyper",
+ "lazy_static",
+ "log",
+ "rand",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
 ]
 
 [[package]]
@@ -4533,6 +4565,12 @@ name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
+name = "similar"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
 
 [[package]]
 name = "simple_asn1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ urlencoding = "2.1.0"
 uuid = { version = "1.3.3", features = ["serde", "v4"] }
 words-count = "0.1.5"
 xxhash-rust = { version = "0.8.5", features = ["xxh3"] }
+mockito = "1.1.0"
 
 [workspace]
 members = ["src/cli", "src/lib", "src/server"]

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -85,6 +85,7 @@ urlencoding = "2.1.0"
 uuid = { version = "1.3.3", features = ["serde", "v4"] }
 words-count = "0.1.5"
 xxhash-rust = { version = "0.8.5", features = ["xxh3"] }
+mockito = "1.1.0"
 
 [lib]
 name = "liboxen"

--- a/src/lib/src/model/repository/local_repository.rs
+++ b/src/lib/src/model/repository/local_repository.rs
@@ -207,6 +207,8 @@ impl LocalRepository {
         repo: RemoteRepository,
         opts: &CloneOpts,
     ) -> Result<LocalRepository, OxenError> {
+        api::remote::repositories::pre_clone(&repo).await?;
+
         // if directory already exists -> return Err
         let repo_path = opts.dst.join(&repo.name);
         if repo_path.exists() {
@@ -260,6 +262,7 @@ impl LocalRepository {
         }
 
         println!("\n🎉 cloned {} to {}/\n", repo.remote.url, repo.name);
+        api::remote::repositories::post_clone(&repo).await?;
 
         Ok(local_repo)
     }

--- a/src/server/src/controllers.rs
+++ b/src/server/src/controllers.rs
@@ -1,3 +1,4 @@
+pub mod action;
 pub mod branches;
 pub mod commits;
 pub mod compare;

--- a/src/server/src/controllers/action.rs
+++ b/src/server/src/controllers/action.rs
@@ -1,0 +1,12 @@
+use crate::errors::OxenHttpError;
+use actix_web::{HttpRequest, HttpResponse};
+
+pub async fn completed(_req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpError> {
+    log::debug!("Clone action completed");
+    Ok(HttpResponse::Ok().finish())
+}
+
+pub async fn started(_req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpError> {
+    log::debug!("Clone action started");
+    Ok(HttpResponse::Ok().finish())
+}

--- a/src/server/src/routes.rs
+++ b/src/server/src/routes.rs
@@ -228,5 +228,14 @@ pub fn config(cfg: &mut web::ServiceConfig) {
         .route(
             "/{namespace}/{repo_name}/schemas/{resource:.*}",
             web::get().to(controllers::schemas::list_or_get),
+        )
+        // ----- Action Callbacks ----- //
+        .route(
+            "/{namespace}/{repo_name}/action/completed/{action}",
+            web::get().to(controllers::action::completed),
+        )
+        .route(
+            "/{namespace}/{repo_name}/action/started/{action}",
+            web::get().to(controllers::action::started),
         );
 }


### PR DESCRIPTION
* Add endpoints for logging when a clone operation starts and ends
* Make sure the CLI clone operation calls the new endpoints when starting and completing