### PR TITLE
Fix stuck pushes due to orphaned commit locks

### DIFF
--- a/src/lib/src/core/cache/commit_cacher.rs
+++ b/src/lib/src/core/cache/commit_cacher.rs
@@ -147,6 +147,15 @@ fn get_db_connection(
     Err(OxenError::basic_str("Could not open db"))
 }
 
+pub fn force_remove_lock(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError> {
+    let lock_path = cached_status_lock_path(repo, commit);
+    if lock_path.exists() {
+        log::warn!("force_remove_lock Deleting lock file {:?}", lock_path);
+        util::fs::remove_file(lock_path)?;
+    }
+    Ok(())
+}
+
 /// Run all the cachers and update their status's as you go
 pub fn run_all(repo: &LocalRepository, commit: &Commit, force: bool) -> Result<(), OxenError> {
     // Write the LOCK file and delete when we are done processing

--- a/src/server/src/controllers/commits.rs
+++ b/src/server/src/controllers/commits.rs
@@ -871,7 +871,6 @@ pub async fn complete(req: HttpRequest) -> Result<HttpResponse, Error> {
 
 // Bulk complete
 pub async fn complete_bulk(req: HttpRequest, body: String) -> Result<HttpResponse, OxenHttpError> {
-    log::debug!("In the commits controller");
     let app_data = req.app_data::<OxenAppData>().unwrap();
     let mut queue = app_data.queue.clone();
 
@@ -891,6 +890,32 @@ pub async fn complete_bulk(req: HttpRequest, body: String) -> Result<HttpRespons
             .ok_or(OxenError::repo_not_found(RepositoryNew::new(
                 namespace, repo_name,
             )))?;
+
+    // List commits for this repo
+    let all_commits = api::local::commits::list(&repo)?;
+
+    // Read through existing commits and find any with pending status stuck from previous pushes.
+    // This shouldn't be a super common case, but can freeze the repo on commits from old versions
+
+    for commit in all_commits {
+        log::debug!("Checking commit {:?}", commit.id);
+        if commit_cacher::get_status(&repo, &commit)? == Some(CacherStatusType::Pending) {
+            // Append a task to the queue
+            log::debug!(
+                "complete_bulk found stuck pending commit {:?}, adding to queue",
+                commit.clone()
+            );
+
+            // Need to force remove errantly left locks
+            commit_cacher::force_remove_lock(&repo, &commit)?;
+            let task = PostPushComplete {
+                commit: commit.clone(),
+                repo: repo.clone(),
+            };
+
+            queue.push(tasks::Task::PostPushComplete(task))
+        }
+    }
 
     let commit_reader = CommitReader::new(&repo)?;
 

--- a/src/server/src/controllers/commits.rs
+++ b/src/server/src/controllers/commits.rs
@@ -900,18 +900,17 @@ pub async fn complete_bulk(req: HttpRequest, body: String) -> Result<HttpRespons
     for commit in all_commits {
         log::debug!("Checking commit {:?}", commit.id);
         if commit_cacher::get_status(&repo, &commit)? == Some(CacherStatusType::Pending) {
-            // Append a task to the queue
-            log::debug!(
-                "complete_bulk found stuck pending commit {:?}, adding to queue",
-                commit.clone()
-            );
-
             // Need to force remove errantly left locks
             commit_cacher::force_remove_lock(&repo, &commit)?;
             let task = PostPushComplete {
                 commit: commit.clone(),
                 repo: repo.clone(),
             };
+            // Append a task to the queue
+            log::debug!(
+                "complete_bulk found stuck pending commit {:?}, adding to queue",
+                commit.clone()
+            );
 
             queue.push(tasks::Task::PostPushComplete(task))
         }


### PR DESCRIPTION
New flow on push: 
- do all the stuff we currently do up until bulk post-push complete 
- call bulk post-push complete: 
- --- find any of these zombie locked commits 
- --- unlock their cachers and add them to the queue to be processed again 
- continue 

This doesn't fix the issue if they are for some reason still stuck in the "pending" status, just gives them another shot at being processed correctly. But **there is no reason they should ever get stuck in pending status other than through zombie lock files**, which this handles (and we have fixed out in previous versions).

All commit cacher runs should now either Succeed, Fail, or Error, none of which choke the push operation like Pending does.