### PR TITLE
Re-hash files on commit

### DIFF
--- a/tests/test_commit.rs
+++ b/tests/test_commit.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use liboxen::api;
 use liboxen::command;
 use liboxen::core::index::CommitEntryReader;
@@ -5,7 +7,6 @@ use liboxen::error::OxenError;
 use liboxen::model::StagedEntryStatus;
 use liboxen::test;
 use liboxen::util;
-
 
 #[test]
 fn test_command_commit_file() -> Result<(), OxenError> {
@@ -237,42 +238,38 @@ async fn test_commit_after_merge_conflict() -> Result<(), OxenError> {
 #[tokio::test]
 async fn test_commit_hash_on_modified_file() -> Result<(), OxenError> {
     test::run_training_data_repo_test_no_commits(|repo| {
-        // Add a text file 
+        // Add a text file
         let text_path = repo.path.join("text.txt");
         util::fs::write_to_path(&text_path, "Hello World")?;
 
-        // Get the hash of the file at this timestamp 
+        // Get the hash of the file at this timestamp
         let hash_when_add = util::hasher::hash_file_contents(&text_path)?;
+        command::add(&repo, &text_path)?;
 
-        // Modify the text file 
+        // Modify the text file
         util::fs::write_to_path(&text_path, "Goodbye, world!")?;
 
-        // Get the new hash 
+        // Get the new hash
         let hash_after_modification = util::hasher::hash_file_contents(&text_path)?;
 
-        // Commit the file 
+        // Commit the file
         command::commit(&repo, "My message")?;
 
-        // Get the most recent commit - the new head commit 
+        // Get the most recent commit - the new head commit
         let head = api::local::commits::head_commit(&repo)?;
 
-        // Initialize a commit entry reader here 
+        // Initialize a commit entry reader here
         let commit_reader = CommitEntryReader::new(&repo, &head)?;
 
-        // Get the commit entry for the text file 
-        let text_entry = commit_reader.get_entry(&text_path)?.unwrap();
+        // Get the commit entry for the text file
+        let text_entry = commit_reader.get_entry(Path::new("text.txt"))?.unwrap();
 
-        // Hashes should be different 
+        // Hashes should be different
         assert_ne!(hash_when_add, hash_after_modification);
 
-        // Hash should match new hash  
+        // Hash should match new hash
         assert_eq!(text_entry.hash, hash_after_modification);
 
         Ok(())
     })
 }
-
-// What will keep people from signing up in the first place? 
-
-// 
-


### PR DESCRIPTION
This PR re-hashes _every_ entry—we _could_ look at the file metadata for modification timestamps if we want, but I wasn't sure how reliable those are + the actual hashing step doesn't seem too costly (since `oxen add` is typically very fast) - but open to handling differently! 