### PR TITLE
Exit with exit code 1 when migration returns an error

### DIFF
--- a/src/cli/src/parse_and_run.rs
+++ b/src/cli/src/parse_and_run.rs
@@ -1072,6 +1072,7 @@ pub async fn migrate(sub_matches: &ArgMatches) {
                             run_migration(&PropagateSchemasMigration, direction, sub_matches)
                         {
                             eprintln!("Error running migration: {}", err);
+                            std::process::exit(1);
                         }
                     } else {
                         eprintln!("Invalid migration: {}", migration);

--- a/src/lib/src/error.rs
+++ b/src/lib/src/error.rs
@@ -50,6 +50,7 @@ pub enum OxenError {
     RevisionNotFound(Box<StringError>),
     RootCommitDoesNotMatch(Box<Commit>),
     NothingToCommit(StringError),
+    HeadNotFound(StringError),
 
     // Resources (paths, uris, etc.)
     ResourceNotFound(StringError),
@@ -205,7 +206,7 @@ impl OxenError {
     }
 
     pub fn head_not_found() -> OxenError {
-        OxenError::basic_str(HEAD_NOT_FOUND)
+        OxenError::HeadNotFound(StringError::from(HEAD_NOT_FOUND))
     }
 
     pub fn home_dir_not_found() -> OxenError {


### PR DESCRIPTION
This makes sure to exit with code `1` when a migration fails.

It also makes sure to not fail if error is `HEAD not found`, we just need to skip the repo.

