### PR TITLE
Lock at the repo level when running migrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "duckdb",
  "dunce",
  "env_logger",
+ "fd-lock",
  "filetime",
  "flate2",
  "fs_extra",
@@ -1973,6 +1974,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
+name = "fd-lock"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93f7a0db71c99f68398f80653ed05afb0b00e062e1a20c7ff849c4edfabbbcc"
+dependencies = [
+ "cfg-if",
+ "rustix 0.38.21",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "fdeflate"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2840,6 +2852,7 @@ dependencies = [
  "duckdb",
  "dunce",
  "env_logger",
+ "fd-lock",
  "filetime",
  "flate2",
  "fs_extra",
@@ -5540,6 +5553,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5570,6 +5592,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5580,6 +5617,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5594,6 +5637,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5604,6 +5653,12 @@ name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5618,6 +5673,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5628,6 +5689,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5642,6 +5709,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5652,6 +5725,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ dotenv = "0.15.0"
 dunce = "1.0.4"
 env_logger = "0.10.0"
 # ffmpeg-next = { version = "6.0.0", features = ["codec", "format"] }
+fd-lock = "4.0.1"
 filetime = "0.2.22"
 flate2 = "1.0.27"
 fs_extra = "1.3.0"

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -37,6 +37,7 @@ dunce = "1"
 duckdb =  { version = "0.8.1", features = ["bundled"] }
 env_logger = "0.10.0"
 # ffmpeg-next = { version = "6.0.0", features = ["codec", "format"] }
+fd-lock = "4.0.1"
 filetime = "0.2.16"
 flate2 = "1.0.23"
 fs_extra = "1.2.0"

--- a/src/lib/src/api/local/branches.rs
+++ b/src/lib/src/api/local/branches.rs
@@ -185,7 +185,7 @@ pub fn lock(repo: &LocalRepository, name: &str) -> Result<(), OxenError> {
         branch_lock_file.display()
     );
 
-    if branch_lock_file.exists() {
+    if branch_lock_file.exists() || api::local::repositories::is_locked(repo) {
         return Err(OxenError::remote_branch_locked());
     }
 

--- a/src/lib/src/command/migrate.rs
+++ b/src/lib/src/command/migrate.rs
@@ -107,6 +107,9 @@ pub fn update_version_files_for_all_repos_up(path: &Path) -> Result<(), OxenErro
 }
 
 pub fn update_version_files_up(repo: &LocalRepository) -> Result<(), OxenError> {
+    let mut lock_file = api::local::repositories::get_lock_file(repo)?;
+    let _mutex = api::local::repositories::get_exclusive_lock(&mut lock_file)?;
+
     let hidden_dir = util::fs::oxen_hidden_dir(&repo.path);
     let versions_dir = hidden_dir.join(VERSIONS_DIR);
 
@@ -278,33 +281,27 @@ pub fn propagate_schemas_up(repo: &LocalRepository) -> Result<(), OxenError> {
     let mut lock_file = api::local::repositories::get_lock_file(repo)?;
     let _mutex = api::local::repositories::get_exclusive_lock(&mut lock_file)?;
 
-    match api::local::commits::list(repo) {
-        Ok(mut commits) => {
-            commits.reverse();
+    let reader = CommitReader::new(repo)?;
+    let mut all_commits = reader.list_all()?;
+    // Sort by timestamp from oldest to newest
+    all_commits.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
 
-            for (i, commit) in commits.iter().enumerate() {
-                for newer_commit in &commits[i + 1..commits.len()] {
-                    let schemas = api::local::schemas::list(repo, Some(&commit.id))?;
-                    let schema_writer = SchemaWriter::new(repo, &newer_commit.id)?;
+    for current_commit in &all_commits {
+        for parent_commit_id in &current_commit.parent_ids {
+            let schemas = api::local::schemas::list(repo, Some(parent_commit_id))?;
+            let schema_writer = SchemaWriter::new(repo, &current_commit.id)?;
 
-                    for (path, schema) in schemas {
-                        if !schema_writer.has_schema(&schema) {
-                            schema_writer.put_schema(&schema)?;
-                        }
-
-                        schema_writer.put_schema_for_file(&path, &schema)?;
-                    }
+            for (path, schema) in schemas {
+                if !schema_writer.has_schema(&schema) {
+                    schema_writer.put_schema(&schema)?;
                 }
-            }
 
-            Ok(())
+                schema_writer.put_schema_for_file(&path, &schema)?;
+            }
         }
-        Err(OxenError::HeadNotFound(_)) => {
-            println!("No HEAD found, skipping repo.");
-            Ok(())
-        }
-        Err(err) => Err(err),
     }
+
+    Ok(())
 }
 
 pub fn propagate_schemas_down(_repo: &LocalRepository) -> Result<(), OxenError> {

--- a/src/lib/src/command/migrate.rs
+++ b/src/lib/src/command/migrate.rs
@@ -138,6 +138,10 @@ pub fn update_version_files_up(repo: &LocalRepository) -> Result<(), OxenError> 
 }
 
 pub fn update_version_files_down(repo: &LocalRepository) -> Result<(), OxenError> {
+    // Traverses commits from BASE to HEAD and write all schemas for all history leading up to HEAD.
+    let mut lock_file = api::local::repositories::get_lock_file(repo)?;
+    let _mutex = api::local::repositories::get_exclusive_lock(&mut lock_file)?;
+
     // Hash map of entry hash (string) to path to write (commit id + extension)
     // (hash, extension) -> Vec<CommitId>
 
@@ -271,6 +275,9 @@ pub fn propagate_schemas_for_all_repos_up(path: &Path) -> Result<(), OxenError> 
 
 pub fn propagate_schemas_up(repo: &LocalRepository) -> Result<(), OxenError> {
     // Traverses commits from BASE to HEAD and write all schemas for all history leading up to HEAD.
+    let mut lock_file = api::local::repositories::get_lock_file(repo)?;
+    let _mutex = api::local::repositories::get_exclusive_lock(&mut lock_file)?;
+
     match api::local::commits::list(repo) {
         Ok(mut commits) => {
             commits.reverse();

--- a/src/lib/src/constants.rs
+++ b/src/lib/src/constants.rs
@@ -29,6 +29,8 @@ pub const COMMITS_DIR: &str = "commits";
 pub const SCHEMAS_DIR: &str = "schemas";
 // name of dir for locking branches during push
 pub const BRANCH_LOCKS_DIR: &str = "locks";
+// name of file for locking repository during push
+pub const REPOSITORY_LOCK_FILE: &str = "LOCK";
 /// prefix for the commit rows
 pub const ROWS_DIR: &str = "rows";
 /// prefix for the commit entry files


### PR DESCRIPTION
This adds the mechanism for locking pushes at the repository level. It uses `fd-lock` to create and acquire an advisory lock on a file. It works by using the `flock` system call on POSIX systems. It should also work on Windows but I haven't tested it.

This will be useful when running migrations in the background, to make sure no new pushes are made at the same time.