### PR TITLE
compare derived url tweak

### DIFF
--- a/src/lib/src/view/compare.rs
+++ b/src/lib/src/view/compare.rs
@@ -148,7 +148,7 @@ impl CompareDerivedDF {
     ) -> CompareDerivedDF {
         let resource = compare_id.map(|compare_id| CompareVirtualResource {
             url: format!(
-                "/compare/df/{}/{}/{}..{}",
+                "/compare/data_frame/{}/{}/{}..{}",
                 compare_id, name, left_commit_id, right_commit_id
             ),
             base: left_commit_id.to_owned(),


### PR DESCRIPTION
tiny fix - df -> data_frame in derived urls since df is deprecated