### PR TITLE
Cache data frame sizes after push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
       - uses: actions-rs/cargo@v1
         with:
@@ -73,7 +73,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
       - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1
@@ -113,7 +113,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1
@@ -151,8 +151,8 @@ jobs:
           target: x86_64-apple-darwin
           default: true
           profile: minimal
-          toolchain: nightly
-          override: true 
+          toolchain: stable
+          override: true
 
       - name: Run Tests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Install latest rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           profile: minimal
           default: true
           override: true
@@ -190,7 +190,7 @@ jobs:
       - name: Install latest rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           profile: minimal
           default: true
           override: true
@@ -301,7 +301,7 @@ jobs:
       - name: Install latest rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           default: true
           override: true
 
@@ -407,7 +407,7 @@ jobs:
           target: x86_64-apple-darwin
           default: true
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
 
       # - name: Install mold linker
@@ -477,7 +477,7 @@ jobs:
           target: x86_64-apple-darwin
           default: true
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
 
       # - name: Install mold linker
@@ -547,7 +547,7 @@ jobs:
           target: x86_64-apple-darwin
           default: true
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
 
       # - name: Install mold linker

--- a/src/cli/src/cmd_setup.rs
+++ b/src/cli/src/cmd_setup.rs
@@ -1,5 +1,7 @@
 use clap::{arg, Arg, Command};
-use liboxen::command::migrate::{Migrate, PropagateSchemasMigration, UpdateVersionFilesMigration};
+use liboxen::command::migrate::{
+    CacheDataFrameSizeMigration, Migrate, PropagateSchemasMigration, UpdateVersionFilesMigration,
+};
 use liboxen::constants::{DEFAULT_BRANCH_NAME, DEFAULT_REMOTE_NAME};
 
 pub const ADD: &str = "add";
@@ -802,7 +804,7 @@ pub fn diff() -> Command {
 
 pub fn compare() -> Command {
     Command::new(COMPARE)
-        .about("Compare two tabular files with some schematic overlap. The two resource paramaters can be specified by filepath or `file:revision` syntax.") 
+        .about("Compare two tabular files with some schematic overlap. The two resource paramaters can be specified by filepath or `file:revision` syntax.")
         .arg(Arg::new("RESOURCE1")
             .required(true)
             .help("First resource, in format `file` or `file:revision`")
@@ -898,6 +900,24 @@ pub fn migrate() -> Command {
                                 )
                                 .action(clap::ArgAction::SetTrue),
                         ),
+                )
+                .subcommand(
+                    Command::new(CacheDataFrameSizeMigration.name())
+                        .about("Caches size for existing data frames")
+                        .arg(
+                            Arg::new("PATH")
+                                .help("Directory in which to apply the migration")
+                                .required(true),
+                        )
+                        .arg(
+                            Arg::new("all")
+                                .long("all")
+                                .short('a')
+                                .help(
+                                    "Run the migration for all oxen repositories in this directory",
+                                )
+                                .action(clap::ArgAction::SetTrue),
+                        ),
                 ),
         )
         .subcommand(
@@ -905,8 +925,26 @@ pub fn migrate() -> Command {
                 .about("Apply a named migration backward.")
                 .subcommand_required(true)
                 .subcommand(
+                    Command::new(CacheDataFrameSizeMigration.name())
+                        .about("Caches size for existing data frames")
+                        .arg(
+                            Arg::new("PATH")
+                                .help("Directory in which to apply the migration")
+                                .required(true),
+                        )
+                        .arg(
+                            Arg::new("all")
+                                .long("all")
+                                .short('a')
+                                .help(
+                                    "Run the migration for all oxen repositories in this directory",
+                                )
+                                .action(clap::ArgAction::SetTrue),
+                        ),
+                )
+                .subcommand(
                     Command::new(PropagateSchemasMigration.name())
-                        .about("Propagate the schemas on the HEAD commit")
+                        .about("Propagates schemas to the latest commit")
                         .arg(
                             Arg::new("PATH")
                                 .help("Directory in which to apply the migration")

--- a/src/cli/src/parse_and_run.rs
+++ b/src/cli/src/parse_and_run.rs
@@ -7,8 +7,9 @@
 use crate::cmd_setup::{ADD, COMMIT, DF, DIFF, DOWNLOAD, LOG, LS, METADATA, RESTORE, RM, STATUS};
 use crate::dispatch;
 use clap::ArgMatches;
-use liboxen::command::migrate::UpdateVersionFilesMigration;
-use liboxen::command::migrate::{Migrate, PropagateSchemasMigration};
+use liboxen::command::migrate::{
+    CacheDataFrameSizeMigration, Migrate, PropagateSchemasMigration, UpdateVersionFilesMigration,
+};
 use liboxen::constants::{DEFAULT_BRANCH_NAME, DEFAULT_HOST, DEFAULT_REMOTE_NAME};
 use liboxen::error::OxenError;
 use liboxen::model::staged_data::StagedDataOpts;
@@ -1071,6 +1072,13 @@ pub async fn migrate(sub_matches: &ArgMatches) {
                     } else if migration == PropagateSchemasMigration.name() {
                         if let Err(err) =
                             run_migration(&PropagateSchemasMigration, direction, sub_matches)
+                        {
+                            eprintln!("Error running migration: {}", err);
+                            std::process::exit(1);
+                        }
+                    } else if migration == CacheDataFrameSizeMigration.name() {
+                        if let Err(err) =
+                            run_migration(&CacheDataFrameSizeMigration, direction, sub_matches)
                         {
                             eprintln!("Error running migration: {}", err);
                             std::process::exit(1);

--- a/src/lib/src/api/local/metadata/text.rs
+++ b/src/lib/src/api/local/metadata/text.rs
@@ -3,37 +3,13 @@
 
 use crate::error::OxenError;
 use crate::model::metadata::MetadataText;
+use crate::util;
 
-use std::fs::File;
-use std::io::BufRead;
-use std::io::BufReader;
 use std::path::Path;
 
 /// Detects the text metadata for the given file.
 pub fn get_metadata(path: impl AsRef<Path>) -> Result<MetadataText, OxenError> {
-    let path = path.as_ref();
-    let file = File::open(path)?;
-
-    let metadata = p_compute_metadata(file)?;
-    Ok(metadata)
-}
-
-fn p_compute_metadata<R: std::io::Read>(handle: R) -> Result<MetadataText, std::io::Error> {
-    let mut reader = BufReader::with_capacity(1024 * 32, handle);
-    let mut line_count = 1;
-    let mut char_count = 0;
-    loop {
-        let len = {
-            let buf = reader.fill_buf()?;
-            if buf.is_empty() {
-                break;
-            }
-            line_count += bytecount::count(buf, b'\n');
-            char_count += bytecount::num_chars(buf);
-            buf.len()
-        };
-        reader.consume(len);
-    }
+    let (line_count, char_count) = util::fs::count_lines_and_chars(path)?;
     Ok(MetadataText::new(line_count, char_count))
 }
 

--- a/src/lib/src/api/local/metadata/text.rs
+++ b/src/lib/src/api/local/metadata/text.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 
 /// Detects the text metadata for the given file.
 pub fn get_metadata(path: impl AsRef<Path>) -> Result<MetadataText, OxenError> {
-    let mut opts = CountLinesOpts::default();
+    let mut opts = CountLinesOpts::empty();
     opts.with_chars = true;
 
     let (lines_count, chars_count) = util::fs::count_lines(path, opts)?;

--- a/src/lib/src/api/local/metadata/text.rs
+++ b/src/lib/src/api/local/metadata/text.rs
@@ -3,14 +3,20 @@
 
 use crate::error::OxenError;
 use crate::model::metadata::MetadataText;
+use crate::opts::CountLinesOpts;
 use crate::util;
 
 use std::path::Path;
 
 /// Detects the text metadata for the given file.
 pub fn get_metadata(path: impl AsRef<Path>) -> Result<MetadataText, OxenError> {
-    let (line_count, char_count) = util::fs::count_lines_and_chars(path)?;
-    Ok(MetadataText::new(line_count, char_count))
+    let mut opts = CountLinesOpts::default();
+    opts.with_chars = true;
+
+    let (lines_count, chars_count) = util::fs::count_lines(path, opts)?;
+    let chars_count = chars_count.unwrap_or(0);
+
+    Ok(MetadataText::new(lines_count, chars_count))
 }
 
 #[cfg(test)]

--- a/src/lib/src/command/migrate.rs
+++ b/src/lib/src/command/migrate.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use jwalk::WalkDir;
 
 use crate::constants::{HASH_FILE, VERSIONS_DIR, VERSION_FILE_NAME};
+use crate::core::cache::cachers;
 use crate::core::index::{CommitEntryReader, CommitReader, SchemaWriter};
 use crate::error::OxenError;
 use crate::model::LocalRepository;
@@ -22,6 +23,35 @@ pub struct UpdateVersionFilesMigration;
 impl UpdateVersionFilesMigration {}
 pub struct PropagateSchemasMigration;
 impl PropagateSchemasMigration {}
+
+pub struct CacheDataFrameSizeMigration;
+impl CacheDataFrameSizeMigration {}
+
+impl Migrate for CacheDataFrameSizeMigration {
+    fn name(&self) -> &'static str {
+        "cache_data_frame_size"
+    }
+    fn up(&self, path: &Path, all: bool) -> Result<(), OxenError> {
+        if all {
+            cache_data_frame_size_for_all_repos_up(path)?;
+        } else {
+            let repo = LocalRepository::new(path)?;
+            cache_data_frame_size_up(&repo)?;
+        }
+        Ok(())
+    }
+
+    fn down(&self, path: &Path, all: bool) -> Result<(), OxenError> {
+        if all {
+            cache_data_frame_size_for_all_repos_down(path)?;
+        } else {
+            println!("Running down migration");
+            let repo = LocalRepository::new(path)?;
+            cache_data_frame_size_down(&repo)?;
+        }
+        Ok(())
+    }
+}
 
 impl Migrate for PropagateSchemasMigration {
     fn name(&self) -> &'static str {
@@ -309,6 +339,63 @@ pub fn propagate_schemas_down(_repo: &LocalRepository) -> Result<(), OxenError> 
     Ok(())
 }
 pub fn propagate_schemas_for_all_repos_down(_path: &Path) -> Result<(), OxenError> {
+    println!("There are no operations to be run");
+    Ok(())
+}
+
+pub fn cache_data_frame_size_for_all_repos_up(path: &Path) -> Result<(), OxenError> {
+    println!("🐂 Collecting namespaces to migrate...");
+    let namespaces = api::local::repositories::list_namespaces(path)?;
+    let bar = oxen_progress_bar(namespaces.len() as u64, ProgressBarType::Counter);
+    println!("🐂 Migrating {} namespaces", namespaces.len());
+    for namespace in namespaces {
+        let namespace_path = path.join(namespace);
+        // Show the canonical namespace path
+        log::debug!(
+            "This is the namespace path we're walking: {:?}",
+            namespace_path.canonicalize()?
+        );
+        let repos = api::local::repositories::list_repos_in_namespace(&namespace_path);
+        for repo in repos {
+            match cache_data_frame_size_up(&repo) {
+                Ok(_) => {}
+                Err(err) => {
+                    log::error!(
+                        "Could not migrate version files for repo {:?}\nErr: {}",
+                        repo.path.canonicalize(),
+                        err
+                    )
+                }
+            }
+        }
+        bar.inc(1);
+    }
+
+    Ok(())
+}
+
+pub fn cache_data_frame_size_up(repo: &LocalRepository) -> Result<(), OxenError> {
+    // Traverses commits from BASE to HEAD and write all schemas for all history leading up to HEAD.
+    let mut lock_file = api::local::repositories::get_lock_file(repo)?;
+    let _mutex = api::local::repositories::get_exclusive_lock(&mut lock_file)?;
+
+    let reader = CommitReader::new(repo)?;
+    let mut all_commits = reader.list_all()?;
+    // Sort by timestamp from oldest to newest
+    all_commits.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+
+    for current_commit in &all_commits {
+        cachers::df_size::compute(repo, current_commit)?;
+    }
+
+    Ok(())
+}
+
+pub fn cache_data_frame_size_down(_repo: &LocalRepository) -> Result<(), OxenError> {
+    println!("There are no operations to be run");
+    Ok(())
+}
+pub fn cache_data_frame_size_for_all_repos_down(_path: &Path) -> Result<(), OxenError> {
     println!("There are no operations to be run");
     Ok(())
 }

--- a/src/lib/src/constants.rs
+++ b/src/lib/src/constants.rs
@@ -35,6 +35,8 @@ pub const REPOSITORY_LOCK_FILE: &str = "LOCK";
 pub const ROWS_DIR: &str = "rows";
 /// prefix for the commit entry files
 pub const FILES_DIR: &str = "files";
+/// prefix for the cached dataframes
+pub const DATA_FRAMES_DIR: &str = "data_frames";
 /// prefix for the commit entry dirs
 pub const DIRS_DIR: &str = "dirs";
 /// prefix for the cached stats dirs

--- a/src/lib/src/core/cache/cachers.rs
+++ b/src/lib/src/core/cache/cachers.rs
@@ -1,4 +1,5 @@
 pub mod content_stats;
 pub mod content_validator;
 pub mod convert_to_arrow;
+pub mod df_size;
 pub mod repo_size;

--- a/src/lib/src/core/cache/cachers/df_size.rs
+++ b/src/lib/src/core/cache/cachers/df_size.rs
@@ -1,0 +1,114 @@
+use crate::constants::{CACHE_DIR, DATA_FRAMES_DIR, HISTORY_DIR};
+use crate::core::df::tabular;
+use crate::core::index::CommitEntryReader;
+use crate::error::OxenError;
+use crate::model::{Commit, DataFrameSize, LocalRepository};
+use crate::opts::DFOpts;
+use crate::util;
+use polars::lazy::dsl::{col, lit};
+use polars::prelude::*;
+use std::path::Path;
+use std::path::PathBuf;
+
+pub const COL_PATH: &str = "path";
+pub const COL_WIDTH: &str = "width";
+pub const COL_HEIGHT: &str = "height";
+
+pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError> {
+    log::debug!(
+        "Running compute_df_sizes on {:?} for commit {}",
+        repo.path,
+        commit.id
+    );
+
+    let cache_path = df_size_cache_path(repo, commit);
+    let reader = CommitEntryReader::new(repo, commit)?;
+    let entries = reader.list_entries()?;
+
+    let mut df = get_cache_df(&cache_path)?;
+
+    for entry in entries {
+        let path = util::fs::version_path(repo, &entry);
+
+        if util::fs::is_tabular(&path) {
+            let data_frame_size = tabular::get_size(&path)?;
+
+            let new_df = df!(
+                COL_PATH => [path.to_str()],
+                COL_WIDTH => [data_frame_size.width.to_string()],
+                COL_HEIGHT => [data_frame_size.height.to_string()])?;
+
+            df = df.vstack(&new_df)?;
+        }
+    }
+
+    tabular::write_df(&mut df, cache_path)
+}
+
+pub fn get_cache_for_version(
+    repo: &LocalRepository,
+    commit: &Commit,
+    version_path: &PathBuf,
+) -> Result<DataFrameSize, OxenError> {
+    match get_from_cache(repo, commit, version_path) {
+        Ok(result) => match result {
+            Some(size) => Ok(size),
+            None => tabular::get_size(version_path),
+        },
+        Err(e) => Err(e),
+    }
+}
+
+fn get_from_cache(
+    repo: &LocalRepository,
+    commit: &Commit,
+    version_path: &Path,
+) -> Result<Option<DataFrameSize>, OxenError> {
+    let cache_path = df_size_cache_path(repo, commit);
+
+    if !cache_path.exists() {
+        return Ok(None);
+    }
+
+    if let Ok(df) = tabular::scan_df(cache_path, &DFOpts::empty()) {
+        let df_for_path = df
+            .select([
+                col(COL_PATH),
+                col(COL_WIDTH).cast(DataType::UInt64),
+                col(COL_HEIGHT).cast(DataType::UInt64),
+            ])
+            .filter(col(COL_PATH).eq(lit(version_path.to_string_lossy().to_string())))
+            .collect()?;
+
+        let column_width = df_for_path.column(COL_WIDTH)?.u64()?;
+        let column_height = df_for_path.column(COL_HEIGHT)?.u64()?;
+
+        if let (Some(width), Some(height)) = (column_width.get(0), column_height.get(0)) {
+            // Converts to usize since Polars deals mostly with usize
+            // TODO: Check if there is a better way to do handle the size while
+            // keeping compatibility with Polars.
+            let width: usize = width.try_into().unwrap();
+            let height: usize = height.try_into().unwrap();
+            return Ok(Some(DataFrameSize { width, height }));
+        }
+    }
+
+    Ok(None)
+}
+
+fn get_cache_df(cache_path: &Path) -> Result<DataFrame, OxenError> {
+    if let Some(parent) = cache_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    Ok(DataFrame::default())
+}
+
+fn df_size_cache_path(repo: &LocalRepository, commit: &Commit) -> PathBuf {
+    util::fs::oxen_hidden_dir(&repo.path)
+        .join(HISTORY_DIR)
+        .join(&commit.id)
+        .join(CACHE_DIR)
+        .join(DATA_FRAMES_DIR)
+        .join("df_size.parquet")
+}

--- a/src/lib/src/core/cache/commit_cacher.rs
+++ b/src/lib/src/core/cache/commit_cacher.rs
@@ -8,7 +8,7 @@ use crate::error::OxenError;
 use crate::model::{Commit, LocalRepository};
 use crate::util;
 
-use super::cachers::{content_stats, content_validator, repo_size};
+use super::cachers::{content_stats, content_validator, df_size, repo_size};
 use lazy_static::lazy_static;
 use rocksdb::{DBWithThreadMode, MultiThreaded};
 use std::path::PathBuf;
@@ -22,6 +22,7 @@ lazy_static! {
         (String::from("COMMIT_CONTENT_IS_VALID"), content_validator::compute as CommitCacher),
         (String::from("REPO_SIZE"), repo_size::compute as CommitCacher),
         (String::from("COMMIT_STATS"), content_stats::compute as CommitCacher),
+        (String::from("DF_SIZE"), df_size::compute as CommitCacher),
         // (String::from("ARROW_CONVERSION"), convert_to_arrow::convert_to_arrow as CommitCacher),
     ];
 

--- a/src/lib/src/core/df/tabular.rs
+++ b/src/lib/src/core/df/tabular.rs
@@ -834,7 +834,7 @@ pub fn get_size<P: AsRef<Path>>(path: P) -> Result<DataFrameSize, OxenError> {
     match extension {
         Some(extension) => match extension {
             "csv" | "tsv" | "data" | "jsonl" | "ndjson" => {
-                let mut opts = CountLinesOpts::default();
+                let mut opts = CountLinesOpts::empty();
                 opts.remove_trailing_blank_line = true;
 
                 // Remove one line to account for CSV headers

--- a/src/lib/src/opts.rs
+++ b/src/lib/src/opts.rs
@@ -3,6 +3,7 @@
 
 pub mod add_opts;
 pub mod clone_opts;
+pub mod count_lines_opts;
 pub mod df_opts;
 pub mod download_opts;
 pub mod helpers;
@@ -16,6 +17,7 @@ pub mod rm_opts;
 
 pub use crate::opts::add_opts::AddOpts;
 pub use crate::opts::clone_opts::CloneOpts;
+pub use crate::opts::count_lines_opts::CountLinesOpts;
 pub use crate::opts::df_opts::DFOpts;
 pub use crate::opts::download_opts::DownloadOpts;
 pub use crate::opts::info_opts::InfoOpts;

--- a/src/lib/src/opts/count_lines_opts.rs
+++ b/src/lib/src/opts/count_lines_opts.rs
@@ -1,0 +1,14 @@
+#[derive(Clone, Debug)]
+pub struct CountLinesOpts {
+    pub with_chars: bool,
+    pub remove_trailing_blank_line: bool,
+}
+
+impl CountLinesOpts {
+    pub fn default() -> CountLinesOpts {
+        CountLinesOpts {
+            with_chars: false,
+            remove_trailing_blank_line: false,
+        }
+    }
+}

--- a/src/lib/src/opts/count_lines_opts.rs
+++ b/src/lib/src/opts/count_lines_opts.rs
@@ -5,7 +5,7 @@ pub struct CountLinesOpts {
 }
 
 impl CountLinesOpts {
-    pub fn default() -> CountLinesOpts {
+    pub fn empty() -> CountLinesOpts {
         CountLinesOpts {
             with_chars: false,
             remove_trailing_blank_line: false,

--- a/src/lib/src/view/json_data_frame_view.rs
+++ b/src/lib/src/view/json_data_frame_view.rs
@@ -67,12 +67,12 @@ pub struct DerivedDFResource {
 }
 
 impl JsonDataFrameSource {
-    pub fn from_df(df: &DataFrame, schema: &Schema) -> JsonDataFrameSource {
+    pub fn from_df(data_frame_size: &DataFrameSize, schema: &Schema) -> JsonDataFrameSource {
         JsonDataFrameSource {
             schema: schema.to_owned(),
             size: DataFrameSize {
-                height: df.height(),
-                width: df.width(),
+                height: data_frame_size.height,
+                width: data_frame_size.width,
             },
         }
     }
@@ -82,18 +82,16 @@ impl JsonDataFrameView {
     pub fn view_from_pagination(
         df: DataFrame,
         og_schema: Schema,
+        data_frame_size: DataFrameSize,
         opts: &PaginateOpts,
     ) -> JsonDataFrameView {
-        let full_width = df.width();
-        let full_height = df.height();
-
         let page_size = opts.page_size;
         let page = opts.page_num;
 
         let start = if page == 0 { 0 } else { page_size * (page - 1) };
         let end = page_size * page;
 
-        let total_pages = (full_height as f64 / page_size as f64).ceil() as usize;
+        let total_pages = (data_frame_size.height as f64 / page_size as f64).ceil() as usize;
 
         let mut opts = DFOpts::empty();
         opts.slice = Some(format!("{}..{}", start, end));
@@ -110,15 +108,15 @@ impl JsonDataFrameView {
         JsonDataFrameView {
             schema: slice_schema,
             size: DataFrameSize {
-                height: full_height,
-                width: full_width,
+                height: data_frame_size.height,
+                width: data_frame_size.width,
             },
             data: JsonDataFrameView::json_data(&mut sliced_df),
             pagination: Pagination {
                 page_number: page,
                 page_size,
                 total_pages,
-                total_entries: full_height,
+                total_entries: data_frame_size.height,
             },
             opts: opts_view,
         }

--- a/src/server/src/controllers/commits.rs
+++ b/src/server/src/controllers/commits.rs
@@ -764,7 +764,7 @@ fn check_if_upload_complete_and_unpack(
         }
 
         // Cleanup tmp files
-        util::fs::remove_dir_all(tmp_dir).unwrap();
+        // util::fs::remove_dir_all(tmp_dir).unwrap();
         // });
     }
 }

--- a/src/server/src/controllers/commits.rs
+++ b/src/server/src/controllers/commits.rs
@@ -764,7 +764,7 @@ fn check_if_upload_complete_and_unpack(
         }
 
         // Cleanup tmp files
-        // util::fs::remove_dir_all(tmp_dir).unwrap();
+        util::fs::remove_dir_all(tmp_dir).unwrap();
         // });
     }
 }

--- a/src/server/src/controllers/data_frames.rs
+++ b/src/server/src/controllers/data_frames.rs
@@ -4,6 +4,7 @@ use crate::params::df_opts_query::{self, DFOptsQuery};
 use crate::params::{app_data, parse_resource, path_param};
 
 use liboxen::api;
+use liboxen::core::cache::cachers;
 use liboxen::error::OxenError;
 use liboxen::model::Schema;
 use liboxen::view::entry::ResourceVersion;
@@ -40,8 +41,12 @@ pub async fn get(
         util::fs::version_path_for_commit_id(&repo, &resource.commit.id, &resource.file_path)?;
     log::debug!("Reading version file {:?}", version_path);
 
-    // Have to read full df to get the full size, may be able to optimize later
-    let df = tabular::read_df(&version_path, DFOpts::empty())?;
+    let mut data_frame_size =
+        cachers::df_size::get_cache_for_version(&repo, &resource.commit, &version_path)?;
+
+    let mut opts = DFOpts::empty();
+    opts = df_opts_query::parse_opts(&query, &mut opts);
+    let mut df = tabular::scan_df(&version_path, &DFOpts::empty())?;
 
     // Try to get the schema from disk
     let og_schema = if let Some(schema) =
@@ -49,41 +54,72 @@ pub async fn get(
     {
         schema
     } else {
-        Schema::from_polars(&df.schema())
+        match df.schema() {
+            Ok(schema) => Ok(Schema::from_polars(&schema.to_owned())),
+            Err(e) => {
+                log::error!("Error reading df: {}", e);
+                Err(OxenHttpError::InternalServerError)
+            }
+        }?
     };
 
-    let mut opts = DFOpts::empty();
-    opts = df_opts_query::parse_opts(&query, &mut opts);
     // Clear these for the first transform
     opts.page = None;
     opts.page_size = None;
-
-    log::debug!("Full df {:?}", df);
 
     let page_size = query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);
     let page = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
 
     // We have to run the query param transforms, then paginate separately
-    let og_df_json = JsonDataFrameSource::from_df(&df, &og_schema);
-    match tabular::transform(df, opts) {
+    let og_df_json = JsonDataFrameSource::from_df(&data_frame_size, &og_schema);
+
+    let mut page_opts = PaginateOpts {
+        page_num: page,
+        page_size,
+    };
+
+    // If there are no transforms, get a slice of the dataframe of size `page_size`
+    // for building the response more efficiently on large files. If there are more
+    // transforms ie. sorting, then we process on the whole df.
+    let mut process_on_slice = false;
+
+    if !opts.has_transform() {
+        process_on_slice = true;
+        page_opts.page_num = 1;
+        page_opts.page_size = page_size;
+
+        let page: i64 = page.try_into().unwrap();
+        let page_size: i64 = page_size.try_into().unwrap();
+        let page_size_u32: u32 = page_size.try_into().unwrap();
+
+        df = df.slice((page - 1) * page_size, page_size_u32);
+    }
+
+    match tabular::transform_lazy(df, data_frame_size.height, opts) {
         Ok(df_view) => {
             log::debug!("DF view {:?}", df_view);
+
+            // If there were transforms such as a filter, the pagination total entries
+            // must be from the filtered df, not the original df.
+            if !process_on_slice {
+                data_frame_size.height = df_view.height();
+            }
 
             let resource_version = ResourceVersion {
                 path: resource.file_path.to_string_lossy().into(),
                 version: resource.version().to_owned(),
             };
 
-            let page_opts = PaginateOpts {
-                page_num: page,
-                page_size,
-            };
-
             let response = JsonDataFrameViewResponse {
                 status: StatusMessage::resource_found(),
                 data_frame: JsonDataFrameViews {
                     source: og_df_json,
-                    view: JsonDataFrameView::view_from_pagination(df_view, og_schema, &page_opts),
+                    view: JsonDataFrameView::view_from_pagination(
+                        df_view,
+                        og_schema,
+                        data_frame_size,
+                        &page_opts,
+                    ),
                 },
                 commit: Some(resource.commit.clone()),
                 resource: Some(resource_version),


### PR DESCRIPTION
This creates a cache of the size of data frames after a successful push.

This enables the fast displaying of large data frames without having to read the whole file.

