### PR TITLE
Push new remote branch on non-deep cloned repo

### DIFF
--- a/src/lib/src/api/local/commits.rs
+++ b/src/lib/src/api/local/commits.rs
@@ -278,6 +278,20 @@ pub fn list_all(repo: &LocalRepository) -> Result<Vec<Commit>, OxenError> {
     Ok(commits)
 }
 
+pub fn list_all_paginated(
+    repo: &LocalRepository,
+    page_number: usize,
+    page_size: usize,
+) -> Result<PaginatedCommits, OxenError> {
+    let commits = list_all(repo)?;
+    let (commits, pagination) = util::paginate(commits, page_number, page_size);
+    Ok(PaginatedCommits {
+        status: StatusMessage::resource_found(),
+        commits,
+        pagination,
+    })
+}
+
 /// Get commit history given options
 pub async fn list_with_opts(
     repo: &LocalRepository,

--- a/src/lib/src/core/index/pusher.rs
+++ b/src/lib/src/core/index/pusher.rs
@@ -317,9 +317,6 @@ async fn get_commit_objects_to_sync(
                 .any(|remote_commit| remote_commit.id == commit.id)
         });
     } else {
-        // TODO: This logic was already run as a check in cannot_push_incomplete history -
-        // could likely get it down to 1x w/ a moderate refactor but it is not expensive
-
         // Remote branch does not exist. Find commits to push with reference to whatever
         // remote branch head comes first in the local newbranch history, aka what it was branched off of.
         let branches: Vec<Branch> = api::remote::branches::list(remote_repo).await?;

--- a/src/lib/src/core/index/schema_reader.rs
+++ b/src/lib/src/core/index/schema_reader.rs
@@ -182,42 +182,6 @@ impl SchemaReader {
 
     pub fn list_schema_entries(&self) -> Result<Vec<SchemaEntry>, OxenError> {
         log::debug!("trying to get root hash for commit {:?}", self.commit_id);
-        // Print out all the entries of dir_hashes db
-        // let iter = self.dir_hashes_db.iterator(rocksdb::IteratorMode::Start);
-
-        // log::debug!(
-        //     "iterating over dir_hashes_db for commit {:?}",
-        //     self.commit_id
-        // );
-        // for item in iter {
-        //     match item {
-        //         Ok((key, value)) => {
-        //             let key = match std::str::from_utf8(&key) {
-        //                 Ok(k) => k,
-        //                 Err(e) => {
-        //                     log::error!("Failed to convert key to string: {:?}", e);
-        //                     continue;
-        //                 }
-        //             };
-        //             let value = match std::str::from_utf8(&value) {
-        //                 Ok(v) => v,
-        //                 Err(e) => {
-        //                     log::error!("Failed to convert value to string: {:?}", e);
-        //                     continue;
-        //                 }
-        //             };
-        //             log::debug!("key {:?} value {:?}", key, value);
-        //         }
-        //         Err(e) => {
-        //             log::error!("Iterator error: {:?}", e);
-        //         }
-        //     }
-        // }
-
-        // log::debug!("done iterating");
-
-        // log::debug!("done iterating round 2");
-
         let root_hash: String = path_db::get_entry(&self.dir_hashes_db, "")?.ok_or(
             OxenError::basic_str("Could not find root hash in dir hashes db"),
         )?;

--- a/src/server/src/routes.rs
+++ b/src/server/src/routes.rs
@@ -57,6 +57,10 @@ pub fn config(cfg: &mut web::ServiceConfig) {
             web::get().to(controllers::commits::download_objects_db),
         )
         .route(
+            "/{namespace}/{repo_name}/commits/all",
+            web::get().to(controllers::commits::list_all),
+        )
+        .route(
             "/{namespace}/{repo_name}/commits/{commit_id}/latest_synced",
             web::get().to(controllers::commits::latest_synced),
         )


### PR DESCRIPTION
Previously, we rejected any pushes to new remote branches unless the commit history on the local branch was fully complete. 

Now, if we run into this scenario, we get a list of all repo commits from the remote, then traverse the local commit history backwards from head until we find the the latest ancestor of the local head that also exists on the remote. 

We then use this to calculate what commits need to be pushed, check if those commits are fully synced locally, and push if we can / error if we can't. 
