### PR TITLE
Adding get schema by hash route + add schema hash to list versions

### DIFF
--- a/src/lib/src/api/local/schemas.rs
+++ b/src/lib/src/api/local/schemas.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use crate::api;
+use crate::{api, util};
 
 use crate::core::index::SchemaReader;
 use crate::error::OxenError;
@@ -67,5 +67,16 @@ pub fn get_by_path_from_ref(
         schema_reader.get_schema_for_file(path)
     } else {
         Err(OxenError::revision_not_found(revision.into()))
+    }
+}
+
+pub fn get_by_hash(repo: &LocalRepository, hash: String) -> Result<Option<Schema>, OxenError> {
+    let version_path = util::fs::version_path_from_schema_hash(repo.path.clone(), hash);
+    // Read schema from that path
+    if version_path.exists() {
+        let schema: Schema = serde_json::from_reader(std::fs::File::open(version_path)?)?;
+        Ok(Some(schema))
+    } else {
+        Ok(None)
     }
 }

--- a/src/lib/src/view/entry.rs
+++ b/src/lib/src/view/entry.rs
@@ -100,6 +100,7 @@ pub struct BranchEntryVersion {
 pub struct CommitEntryVersion {
     pub commit: crate::model::Commit,
     pub resource: ResourceVersion,
+    pub schema_hash: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/src/lib/src/view/schema.rs
+++ b/src/lib/src/view/schema.rs
@@ -26,3 +26,10 @@ pub struct ListSchemaResponse {
     pub commit: Option<Commit>,
     pub resource: Option<ResourceVersion>,
 }
+
+/* For getting schemas directly by hash - no path associated */
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SchemaResponse {
+    pub status: StatusMessage,
+    pub schema: Schema,
+}

--- a/src/server/src/routes.rs
+++ b/src/server/src/routes.rs
@@ -281,6 +281,10 @@ pub fn config(cfg: &mut web::ServiceConfig) {
         )
         // ----- Schemas ----- //
         .route(
+            "/{namespace}/{repo_name}/schemas/hash/{hash}",
+            web::get().to(controllers::schemas::get_by_hash),
+        )
+        .route(
             "/{namespace}/{repo_name}/schemas/{resource:.*}",
             web::get().to(controllers::schemas::list_or_get),
         )


### PR DESCRIPTION
Context: 

[](https://oxenai.slack.com/archives/C03EBLD4B7W/p1706024609205999
)

Adds 1 new endpoint: 
- /api/repos/{namespace}/{repo_name}/schemas/hash/{schema_hash} - for direct lookup of a schema hash within a repo, regardless of commit, yay merkle

Modifies the list file versions endpoint: 
- now returns an optional `schema_hash`