### PR TITLE
Fix out of memory error on hash_file_contents

### DIFF
--- a/src/lib/src/util/hasher.rs
+++ b/src/lib/src/util/hasher.rs
@@ -107,8 +107,8 @@ fn hash_small_file_contents(path: &Path) -> Result<String, OxenError> {
                     Ok(result)
                 }
                 Err(_) => {
-                    eprintln!("Could not read file to end {path:?}");
-                    Err(OxenError::basic_str("Could not read file to end"))
+                    eprintln!("Could not read file for hashing {path:?}");
+                    Err(OxenError::basic_str("Could not read file for hashing"))
                 }
             }
         }
@@ -132,8 +132,8 @@ fn hash_large_file_contents(path: &Path) -> Result<String, OxenError> {
 
     loop {
         let count = reader.read(&mut buffer).map_err(|_| {
-            eprintln!("Could not read file to end {:?}", path);
-            OxenError::basic_str("Could not read file to end")
+            eprintln!("Could not read file for hashing {:?}", path);
+            OxenError::basic_str("Could not read file for hashing")
         })?;
 
         if count == 0 {

--- a/src/server/src/controllers/commits.rs
+++ b/src/server/src/controllers/commits.rs
@@ -1215,7 +1215,6 @@ fn unpack_entry_tarball(hidden_dir: &Path, archive: &mut Archive<GzDecoder<&[u8]
                         let hash_dir = version_path.parent().unwrap();
                         let hash_file = hash_dir.join(HASH_FILE);
                         let hash = util::hasher::hash_file_contents(&version_path).unwrap();
-
                         util::fs::write_to_path(&hash_file, &hash)
                             .expect("Could not write hash file");
                     } else if path.starts_with(OBJECTS_DIR) {

--- a/src/server/src/controllers/commits.rs
+++ b/src/server/src/controllers/commits.rs
@@ -1215,6 +1215,7 @@ fn unpack_entry_tarball(hidden_dir: &Path, archive: &mut Archive<GzDecoder<&[u8]
                         let hash_dir = version_path.parent().unwrap();
                         let hash_file = hash_dir.join(HASH_FILE);
                         let hash = util::hasher::hash_file_contents(&version_path).unwrap();
+
                         util::fs::write_to_path(&hash_file, &hash)
                             .expect("Could not write hash file");
                     } else if path.starts_with(OBJECTS_DIR) {


### PR DESCRIPTION
Re: #244.

Adapts `hash_file_contents` implementation to stream-hash if > 1GB, one-shot if < 1GB - should fix out of memory errors for files exceeding a user's RAM