### PR TITLE
Improve request structure for compares, add schema diff and compare summary

### DIFF
--- a/src/lib/src/api/local/compare.rs
+++ b/src/lib/src/api/local/compare.rs
@@ -232,7 +232,7 @@ pub fn get_cached_compare_with_update(
         source: source_dfs,
         derived: derived_dfs,
         dupes: read_dupes(repo, compare_id)?,
-        compare_summary: Some(compare_summary),
+        summary: Some(compare_summary),
         schema_diff: Some(schema_diff),
     };
 
@@ -338,7 +338,7 @@ pub fn get_cached_compare(
         derived: derived_dfs,
         dupes: read_dupes(repo, compare_id)?,
         schema_diff: Some(schema_diff),
-        compare_summary: Some(compare_summary),
+        summary: Some(compare_summary),
     };
 
     Ok(Some(compare_results))
@@ -689,7 +689,7 @@ fn build_compare_tabular(
         derived: derived_dfs,
         dupes: compare_tabular_raw.dupes.clone(),
         schema_diff: compare_tabular_raw.schema_diff.clone(),
-        compare_summary: compare_tabular_raw.compare_summary.clone(),
+        summary: compare_tabular_raw.compare_summary.clone(),
     }
 }
 

--- a/src/lib/src/api/local/compare.rs
+++ b/src/lib/src/api/local/compare.rs
@@ -2,14 +2,13 @@ use crate::constants::{CACHE_DIR, COMPARES_DIR, LEFT_COMPARE_COMMIT, RIGHT_COMPA
 use crate::core::df::tabular::{self};
 use crate::error::OxenError;
 use crate::model::entry::commit_entry::CompareEntry;
-use crate::model::{CommitEntry, DataFrameSize, LocalRepository, Schema};
+use crate::model::{CommitEntry, LocalRepository, Schema};
 use crate::opts::DFOpts;
 
 use crate::view::compare::{
-    CompareDerivedDF, CompareDupes, CompareResult, CompareSourceDF, CompareTabular,
-    CompareTabularRaw,
+    CompareDerivedDF, CompareDupes, CompareResult, CompareSchemaDiff, CompareSourceDF,
+    CompareSummary, CompareTabular, CompareTabularRaw,
 };
-use crate::view::schema::SchemaWithPath;
 use crate::{api, util};
 
 use polars::prelude::DataFrame;
@@ -31,8 +30,6 @@ pub struct SchemaDiff {
     unchanged_cols: Vec<String>,
 }
 
-const LEFT: &str = "left";
-const RIGHT: &str = "right";
 const DIFF: &str = "diff";
 const TARGETS_HASH_COL: &str = "_targets_hash";
 const KEYS_HASH_COL: &str = "_keys_hash";
@@ -180,32 +177,39 @@ pub fn get_cached_compare_with_update(
         DFOpts::empty(),
     )?;
 
-    let left_schema = SchemaWithPath {
-        schema: Schema::from_polars(&left_full_df.schema()),
-        path: compare_entry_1.path.to_str().map(|s| s.to_owned()).unwrap(),
-    };
+    let schema_diff = CompareSchemaDiff::from_schemas(
+        &Schema::from_polars(&left_full_df.schema()),
+        &Schema::from_polars(&right_full_df.schema()),
+    )?;
 
-    let right_schema = SchemaWithPath {
-        schema: Schema::from_polars(&right_full_df.schema()),
-        path: compare_entry_2.path.to_str().map(|s| s.to_owned()).unwrap(),
-    };
+    // let left_schema = SchemaWithPath {
+    //     schema: Schema::from_polars(&left_full_df.schema()),
+    //     path: compare_entry_1.path.to_str().map(|s| s.to_owned()).unwrap(),
+    // };
+
+    // let right_schema = SchemaWithPath {
+    //     schema: Schema::from_polars(&right_full_df.schema()),
+    //     path: compare_entry_2.path.to_str().map(|s| s.to_owned()).unwrap(),
+    // };
 
     let diff_df = tabular::read_df(get_compare_diff_path(repo, compare_id), DFOpts::empty())?;
 
     let diff_schema = Schema::from_polars(&diff_df.schema());
 
-    let source_df_left = CompareSourceDF::from_name_df_entry_schema(
-        LEFT,
-        left_full_df,
-        &left_commit,
-        left_schema.schema.clone(),
-    );
-    let source_df_right = CompareSourceDF::from_name_df_entry_schema(
-        RIGHT,
-        right_full_df,
-        &right_commit,
-        right_schema.schema.clone(),
-    );
+    // let source_df_left = CompareSourceDF::from_name_df_entry_schema(
+    //     LEFT,
+    //     left_full_df,
+    //     &left_commit,
+    //     left_schema.schema.clone(),
+    // );
+    // let source_df_right = CompareSourceDF::from_name_df_entry_schema(
+    //     RIGHT,
+    //     right_full_df,
+    //     &right_commit,
+    //     right_schema.schema.clone(),
+    // );
+
+    let compare_summary = CompareSummary::from_diff_df(&diff_df)?;
 
     let derived_df_diff = CompareDerivedDF::from_compare_info(
         DIFF,
@@ -217,8 +221,8 @@ pub fn get_cached_compare_with_update(
     );
 
     let source_dfs: HashMap<String, CompareSourceDF> = HashMap::from([
-        (LEFT.to_string(), source_df_left),
-        (RIGHT.to_string(), source_df_right),
+        // (LEFT.to_string(), source_df_left),
+        // (RIGHT.to_string(), source_df_right),
     ]);
 
     let derived_dfs: HashMap<String, CompareDerivedDF> =
@@ -228,6 +232,8 @@ pub fn get_cached_compare_with_update(
         source: source_dfs,
         derived: derived_dfs,
         dupes: read_dupes(repo, compare_id)?,
+        compare_summary: Some(compare_summary),
+        schema_diff: Some(schema_diff),
     };
 
     Ok(Some(compare_results))
@@ -256,6 +262,7 @@ pub fn get_cached_compare(
     let left_commit = compare_entry_1.commit_entry.unwrap();
     let right_commit = compare_entry_2.commit_entry.unwrap();
 
+    // TODONOW this should be cached
     let left_full_df = tabular::read_df(
         api::local::diff::get_version_file_from_commit_id(
             repo,
@@ -273,32 +280,39 @@ pub fn get_cached_compare(
         DFOpts::empty(),
     )?;
 
-    let left_schema = SchemaWithPath {
-        schema: Schema::from_polars(&left_full_df.schema()),
-        path: compare_entry_1.path.to_str().map(|s| s.to_owned()).unwrap(),
-    };
+    let schema_diff = CompareSchemaDiff::from_schemas(
+        &Schema::from_polars(&left_full_df.schema()),
+        &Schema::from_polars(&right_full_df.schema()),
+    )?;
 
-    let right_schema = SchemaWithPath {
-        schema: Schema::from_polars(&right_full_df.schema()),
-        path: compare_entry_2.path.to_str().map(|s| s.to_owned()).unwrap(),
-    };
+    // let left_schema = SchemaWithPath {
+    //     schema: Schema::from_polars(&left_full_df.schema()),
+    //     path: compare_entry_1.path.to_str().map(|s| s.to_owned()).unwrap(),
+    // };
+
+    // let right_schema = SchemaWithPath {
+    //     schema: Schema::from_polars(&right_full_df.schema()),
+    //     path: compare_entry_2.path.to_str().map(|s| s.to_owned()).unwrap(),
+    // };
 
     let diff_df = tabular::read_df(get_compare_diff_path(repo, compare_id), DFOpts::empty())?;
 
     let diff_schema = Schema::from_polars(&diff_df.schema());
 
-    let source_df_left = CompareSourceDF::from_name_df_entry_schema(
-        LEFT,
-        left_full_df,
-        &left_commit,
-        left_schema.schema.clone(),
-    );
-    let source_df_right = CompareSourceDF::from_name_df_entry_schema(
-        RIGHT,
-        right_full_df,
-        &right_commit,
-        right_schema.schema.clone(),
-    );
+    // let source_df_left = CompareSourceDF::from_name_df_entry_schema(
+    //     LEFT,
+    //     left_full_df,
+    //     &left_commit,
+    //     left_schema.schema.clone(),
+    // );
+    // let source_df_right = CompareSourceDF::from_name_df_entry_schema(
+    //     RIGHT,
+    //     right_full_df,
+    //     &right_commit,
+    //     right_schema.schema.clone(),
+    // );
+
+    let compare_summary = CompareSummary::from_diff_df(&diff_df)?;
 
     let derived_df_diff = CompareDerivedDF::from_compare_info(
         DIFF,
@@ -310,9 +324,11 @@ pub fn get_cached_compare(
     );
 
     let source_dfs: HashMap<String, CompareSourceDF> = HashMap::from([
-        (LEFT.to_string(), source_df_left),
-        (RIGHT.to_string(), source_df_right),
+        // (LEFT.to_string(), source_df_left),
+        // (RIGHT.to_string(), source_df_right),
     ]);
+
+    // TODONOW; schema diffs should probably also be cached.
 
     let derived_dfs: HashMap<String, CompareDerivedDF> =
         HashMap::from([(DIFF.to_string(), derived_df_diff)]);
@@ -321,6 +337,8 @@ pub fn get_cached_compare(
         source: source_dfs,
         derived: derived_dfs,
         dupes: read_dupes(repo, compare_id)?,
+        schema_diff: Some(schema_diff),
+        compare_summary: Some(compare_summary),
     };
 
     Ok(Some(compare_results))
@@ -533,6 +551,7 @@ fn compute_row_comparison(
     Ok(compare)
 }
 
+// TODO: consolidate this - and maybe the entire struct - with CompareSchemaDiff
 fn get_schema_diff(df1: &DataFrame, df2: &DataFrame) -> SchemaDiff {
     let df1_cols = df1.get_column_names();
     let df2_cols = df2.get_column_names();
@@ -610,10 +629,11 @@ fn get_version_file(
     }
 }
 
-// TODONOW clean
+// TODONOW we can take this step out and accomplish
+// what we need to with compare_tabular_raw
 fn build_compare_tabular(
-    df_1: &DataFrame,
-    df_2: &DataFrame,
+    _df_1: &DataFrame,
+    _df_2: &DataFrame,
     compare_entry_1: &CompareEntry,
     compare_entry_2: &CompareEntry,
     compare_tabular_raw: &CompareTabularRaw,
@@ -623,10 +643,6 @@ fn build_compare_tabular(
 
     let diff_schema = Schema::from_polars(&diff_df.schema());
 
-    let df_1_size = DataFrameSize::from_df(df_1);
-    let df_2_size = DataFrameSize::from_df(df_2);
-    let og_schema_1 = Schema::from_polars(&df_1.schema());
-    let og_schema_2 = Schema::from_polars(&df_2.schema());
     let derived_df_diff = CompareDerivedDF::from_compare_info(
         DIFF,
         compare_id,
@@ -636,33 +652,33 @@ fn build_compare_tabular(
         diff_schema,
     );
 
-    let source_df_left = CompareSourceDF {
-        name: LEFT.to_string(),
-        path: compare_entry_1.path.clone(),
-        version: compare_entry_1
-            .clone()
-            .commit_entry
-            .map(|c| c.commit_id)
-            .unwrap_or("".to_owned()),
-        schema: og_schema_1.clone(),
-        size: df_1_size,
-    };
+    // let source_df_left = CompareSourceDF {
+    //     name: LEFT.to_string(),
+    //     path: compare_entry_1.path.clone(),
+    //     version: compare_entry_1
+    //         .clone()
+    //         .commit_entry
+    //         .map(|c| c.commit_id)
+    //         .unwrap_or("".to_owned()),
+    //     schema: og_schema_1.clone(),
+    //     size: df_1_size,
+    // };
 
-    let source_df_right = CompareSourceDF {
-        name: RIGHT.to_string(),
-        path: compare_entry_2.path.clone(),
-        version: compare_entry_2
-            .clone()
-            .commit_entry
-            .map(|c| c.commit_id)
-            .unwrap_or("".to_owned()),
-        schema: og_schema_2.clone(),
-        size: df_2_size,
-    };
+    // let source_df_right = CompareSourceDF {
+    //     name: RIGHT.to_string(),
+    //     path: compare_entry_2.path.clone(),
+    //     version: compare_entry_2
+    //         .clone()
+    //         .commit_entry
+    //         .map(|c| c.commit_id)
+    //         .unwrap_or("".to_owned()),
+    //     schema: og_schema_2.clone(),
+    //     size: df_2_size,
+    // };
 
     let source_dfs: HashMap<String, CompareSourceDF> = HashMap::from([
-        (LEFT.to_string(), source_df_left),
-        (RIGHT.to_string(), source_df_right),
+        // (LEFT.to_string(), source_df_left),
+        // (RIGHT.to_string(), source_df_right),
     ]);
 
     let derived_dfs: HashMap<String, CompareDerivedDF> =
@@ -672,6 +688,8 @@ fn build_compare_tabular(
         source: source_dfs,
         derived: derived_dfs,
         dupes: compare_tabular_raw.dupes.clone(),
+        schema_diff: compare_tabular_raw.schema_diff.clone(),
+        compare_summary: compare_tabular_raw.compare_summary.clone(),
     }
 }
 
@@ -789,7 +807,6 @@ mod tests {
     use polars::lazy::frame::IntoLazy;
 
     use crate::api;
-    use crate::api::local::compare::CompareStrategy;
     use crate::command;
     use crate::core::df::tabular;
     use crate::error::OxenError;
@@ -798,7 +815,6 @@ mod tests {
     use crate::test;
     use crate::view::compare::CompareResult;
 
-    use super::get_cached_compare;
     use super::get_compare_diff_path;
 
     #[test]

--- a/src/lib/src/api/local/compare/join_compare.rs
+++ b/src/lib/src/api/local/compare/join_compare.rs
@@ -1,7 +1,8 @@
 use crate::error::OxenError;
 use crate::model::Schema;
 use crate::view::compare::{
-    CompareDupes, CompareSchemaColumn, CompareSchemaDiff, CompareSummary, CompareTabularRaw,
+    CompareDupes, CompareSchemaColumn, CompareSchemaDiff, CompareSummary, CompareTabularMods,
+    CompareTabularRaw,
 };
 
 use polars::chunked_array::ChunkedArray;
@@ -62,10 +63,12 @@ pub fn compare(
         let modified_rows = modified_df.height();
         let derived_schema = Schema::from_polars(&modified_df.schema());
         CompareSummary {
-            added_rows,
-            removed_rows,
-            modified_rows,
-            derived_schema,
+            modifications: CompareTabularMods {
+                added_rows,
+                removed_rows,
+                modified_rows,
+            },
+            schema: derived_schema,
         }
     };
 

--- a/src/lib/src/api/remote.rs
+++ b/src/lib/src/api/remote.rs
@@ -4,6 +4,7 @@
 pub mod branches;
 pub mod client;
 pub mod commits;
+pub mod compare;
 pub mod df;
 pub mod diff;
 pub mod dir;

--- a/src/lib/src/api/remote/compare.rs
+++ b/src/lib/src/api/remote/compare.rs
@@ -1,0 +1,323 @@
+use crate::{
+    api,
+    error::OxenError,
+    model::{
+        compare::tabular_compare::{
+            self, TabularCompare, TabularCompareBody, TabularCompareDisplayBody,
+            TabularCompareFieldBody, TabularCompareResourceBody,
+        },
+        RemoteRepository,
+    },
+    view::{
+        compare::{CompareTabular, CompareTabularResponse},
+        JsonDataFrameView, JsonDataFrameViewResponse,
+    },
+};
+
+use polars::frame::DataFrame;
+use serde_json::json;
+
+use super::client;
+
+// TODONOW this should probably be cpath
+pub async fn create_compare(
+    remote_repo: &RemoteRepository,
+    compare_id: &str,
+    left_path: &str,
+    left_revision: &str,
+    right_path: &str,
+    right_revision: &str,
+    keys: Vec<TabularCompareFieldBody>,
+    compare: Vec<TabularCompareFieldBody>,
+    display: Vec<TabularCompareDisplayBody>,
+) -> Result<CompareTabular, OxenError> {
+    let req_body = TabularCompareBody {
+        compare_id: compare_id.to_string(),
+        left: TabularCompareResourceBody {
+            path: left_path.to_string(),
+            version: left_revision.to_string(),
+        },
+        right: TabularCompareResourceBody {
+            path: right_path.to_string(),
+            version: right_revision.to_string(),
+        },
+        keys,
+        compare,
+        display,
+    };
+
+    let uri = format!("/compare/data_frame");
+    let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
+
+    let client = client::new_for_url(&url)?;
+
+    // let params =
+
+    if let Ok(res) = client.post(&url).json(&json!(req_body)).send().await {
+        let body = client::parse_json_body(&url, res).await?;
+        let response: Result<CompareTabularResponse, serde_json::Error> =
+            serde_json::from_str(&body);
+        match response {
+            Ok(tabular_compare) => Ok(tabular_compare.dfs),
+            Err(err) => Err(OxenError::basic_str(format!(
+                "create_compare() Could not deserialize response [{err}]\n{body}"
+            ))),
+        }
+    } else {
+        Err(OxenError::basic_str("create_compare() Request failed"))
+    }
+}
+
+pub async fn get_derived_compare_df(
+    remote_repo: &RemoteRepository,
+    compare_id: &str,
+) -> Result<JsonDataFrameView, OxenError> {
+    let uri = format!("/compare/data_frame/{}/diff", compare_id);
+    let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
+
+    let client = client::new_for_url(&url)?;
+
+    if let Ok(res) = client.get(&url).send().await {
+        let body = client::parse_json_body(&url, res).await?;
+        let response: Result<JsonDataFrameViewResponse, serde_json::Error> =
+            serde_json::from_str(&body);
+        match response {
+            Ok(df) => Ok(df.data_frame.view),
+            Err(err) => Err(OxenError::basic_str(format!(
+                "get_derived_compare_df() Could not deserialize response [{err}]\n{body}"
+            ))),
+        }
+    } else {
+        Err(OxenError::basic_str(
+            "get_derived_compare_df() Request failed",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::api;
+    use crate::command;
+    use crate::constants;
+    use crate::constants::COMMITS_DIR;
+    use crate::constants::DEFAULT_BRANCH_NAME;
+    use crate::constants::DIFF_STATUS_COL;
+    use crate::core::db;
+    use crate::core::index::pusher::UnsyncedCommitEntries;
+    use crate::core::index::CommitDBReader;
+    use crate::error::OxenError;
+
+    use crate::model::compare::tabular_compare::TabularCompareFieldBody;
+    use crate::model::entry::commit_entry::Entry;
+    use crate::test;
+    use polars::lazy::dsl::col;
+    use polars::lazy::dsl::lit;
+    use polars::lazy::frame::IntoLazy;
+    use rocksdb::{DBWithThreadMode, MultiThreaded};
+
+    use std::thread;
+
+    #[tokio::test]
+    async fn test_remote_create_compare_get_derived() -> Result<(), OxenError> {
+        test::run_empty_remote_repo_test(|mut local_repo, remote_repo| async move {
+            // Keying on first 3, targeting on d - should be:
+            // 1 modified, 1 added, 1 removed?
+            let csv1 = "a,b,c,d\n1,2,3,4\n4,5,6,7\n9,0,1,2";
+            let csv2 = "a,b,c,d\n1,2,3,4\n4,5,6,8\n0,1,9,2";
+
+            let left_path = "left.csv";
+            let right_path = "right.csv";
+
+            test::write_txt_file_to_path(local_repo.path.join(left_path), csv1)?;
+            test::write_txt_file_to_path(local_repo.path.join(right_path), csv2)?;
+
+            command::add(&local_repo, &local_repo.path)?;
+
+            let commit = command::commit(&local_repo, "committing files")?;
+
+            // set remote
+
+            command::config::set_remote(
+                &mut local_repo,
+                constants::DEFAULT_REMOTE_NAME,
+                &remote_repo.remote.url,
+            )?;
+            command::push(&local_repo).await?;
+
+            let compare_id = "abcdefgh";
+
+            let compare = api::remote::compare::create_compare(
+                &remote_repo,
+                compare_id,
+                left_path,
+                constants::DEFAULT_BRANCH_NAME,
+                right_path,
+                constants::DEFAULT_BRANCH_NAME,
+                vec![
+                    TabularCompareFieldBody {
+                        left: "a".to_string(),
+                        right: "a".to_string(),
+                        alias_as: None,
+                        compare_method: None,
+                    },
+                    TabularCompareFieldBody {
+                        left: "b".to_string(),
+                        right: "b".to_string(),
+                        alias_as: None,
+                        compare_method: None,
+                    },
+                    TabularCompareFieldBody {
+                        left: "c".to_string(),
+                        right: "c".to_string(),
+                        alias_as: None,
+                        compare_method: None,
+                    },
+                ],
+                vec![TabularCompareFieldBody {
+                    left: "d".to_string(),
+                    right: "d".to_string(),
+                    alias_as: None,
+                    compare_method: None,
+                }],
+                vec![],
+            )
+            .await?;
+
+            // Now get the derived df
+            let derived_df =
+                api::remote::compare::get_derived_compare_df(&remote_repo, compare_id).await?;
+
+            let df = derived_df.to_df();
+
+            assert_eq!(df.height(), 3);
+
+            let added_df = df
+                .clone()
+                .lazy()
+                .filter(col(DIFF_STATUS_COL).eq(lit("added")))
+                .collect()?;
+            assert_eq!(added_df.height(), 1);
+
+            let modified_df = df
+                .clone()
+                .lazy()
+                .filter(col(DIFF_STATUS_COL).eq(lit("modified")))
+                .collect()?;
+            assert_eq!(modified_df.height(), 1);
+
+            let removed_df = df
+                .clone()
+                .lazy()
+                .filter(col(DIFF_STATUS_COL).eq(lit("removed")))
+                .collect()?;
+
+            assert_eq!(removed_df.height(), 1);
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_remote_compare_does_not_update_automatically() -> Result<(), OxenError> {
+        test::run_empty_remote_repo_test(|mut local_repo, remote_repo| async move {
+            // Keying on first 3, targeting on d - should be:
+            // 1 modified, 1 added, 1 removed?
+            let csv1 = "a,b,c,d\n1,2,3,4\n4,5,6,7\n9,0,1,2";
+            let csv2 = "a,b,c,d\n1,2,3,4\n4,5,6,8\n0,1,9,2";
+
+            let left_path = "left.csv";
+            let right_path = "right.csv";
+
+            test::write_txt_file_to_path(local_repo.path.join(left_path), csv1)?;
+            test::write_txt_file_to_path(local_repo.path.join(right_path), csv2)?;
+
+            command::add(&local_repo, &local_repo.path)?;
+
+            let commit = command::commit(&local_repo, "committing files")?;
+
+            // set remote
+
+            command::config::set_remote(
+                &mut local_repo,
+                constants::DEFAULT_REMOTE_NAME,
+                &remote_repo.remote.url,
+            )?;
+            command::push(&local_repo).await?;
+
+            let compare_id = "abcdefgh";
+
+            let compare = api::remote::compare::create_compare(
+                &remote_repo,
+                compare_id,
+                left_path,
+                constants::DEFAULT_BRANCH_NAME,
+                right_path,
+                constants::DEFAULT_BRANCH_NAME,
+                vec![
+                    TabularCompareFieldBody {
+                        left: "a".to_string(),
+                        right: "a".to_string(),
+                        alias_as: None,
+                        compare_method: None,
+                    },
+                    TabularCompareFieldBody {
+                        left: "b".to_string(),
+                        right: "b".to_string(),
+                        alias_as: None,
+                        compare_method: None,
+                    },
+                    TabularCompareFieldBody {
+                        left: "c".to_string(),
+                        right: "c".to_string(),
+                        alias_as: None,
+                        compare_method: None,
+                    },
+                ],
+                vec![TabularCompareFieldBody {
+                    left: "d".to_string(),
+                    right: "d".to_string(),
+                    alias_as: None,
+                    compare_method: None,
+                }],
+                vec![],
+            )
+            .await?;
+
+            // Now get the derived df
+            let derived_df =
+                api::remote::compare::get_derived_compare_df(&remote_repo, compare_id).await?;
+
+            let df = derived_df.to_df();
+
+            assert_eq!(df.height(), 3);
+
+            let added_df = df
+                .clone()
+                .lazy()
+                .filter(col(DIFF_STATUS_COL).eq(lit("added")))
+                .collect()?;
+            assert_eq!(added_df.height(), 1);
+
+            let modified_df = df
+                .clone()
+                .lazy()
+                .filter(col(DIFF_STATUS_COL).eq(lit("modified")))
+                .collect()?;
+            assert_eq!(modified_df.height(), 1);
+
+            let removed_df = df
+                .clone()
+                .lazy()
+                .filter(col(DIFF_STATUS_COL).eq(lit("removed")))
+                .collect()?;
+
+            assert_eq!(removed_df.height(), 1);
+
+            // Advance the data and don't change the compare definition
+            let csv1 = "a,b,c,d\n1,2,3,4\n4,5,6,7\n9,0,1,2";
+            let csv2 = "a,b,c,d\n1,2,3,4\n4,5,6,8\n0,1,9,2";
+        })
+        .await
+    }
+}

--- a/src/lib/src/api/remote/compare.rs
+++ b/src/lib/src/api/remote/compare.rs
@@ -3,8 +3,8 @@ use crate::{
     error::OxenError,
     model::{
         compare::tabular_compare::{
-            self, TabularCompare, TabularCompareBody, TabularCompareDisplayBody,
-            TabularCompareFieldBody, TabularCompareResourceBody,
+            TabularCompareBody, TabularCompareDisplayBody, TabularCompareFieldBody,
+            TabularCompareResourceBody,
         },
         RemoteRepository,
     },
@@ -14,12 +14,11 @@ use crate::{
     },
 };
 
-use polars::frame::DataFrame;
+use super::client;
 use serde_json::json;
 
-use super::client;
-
 // TODONOW this should probably be cpath
+#[allow(clippy::too_many_arguments)]
 pub async fn create_compare(
     remote_repo: &RemoteRepository,
     compare_id: &str,
@@ -46,7 +45,7 @@ pub async fn create_compare(
         display,
     };
 
-    let uri = format!("/compare/data_frame");
+    let uri = "/compare/data_frame".to_string();
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
     let client = client::new_for_url(&url)?;
@@ -54,6 +53,55 @@ pub async fn create_compare(
     // let params =
 
     if let Ok(res) = client.post(&url).json(&json!(req_body)).send().await {
+        let body = client::parse_json_body(&url, res).await?;
+        let response: Result<CompareTabularResponse, serde_json::Error> =
+            serde_json::from_str(&body);
+        match response {
+            Ok(tabular_compare) => Ok(tabular_compare.dfs),
+            Err(err) => Err(OxenError::basic_str(format!(
+                "create_compare() Could not deserialize response [{err}]\n{body}"
+            ))),
+        }
+    } else {
+        Err(OxenError::basic_str("create_compare() Request failed"))
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn update_compare(
+    remote_repo: &RemoteRepository,
+    compare_id: &str,
+    left_path: &str,
+    left_revision: &str,
+    right_path: &str,
+    right_revision: &str,
+    keys: Vec<TabularCompareFieldBody>,
+    compare: Vec<TabularCompareFieldBody>,
+    display: Vec<TabularCompareDisplayBody>,
+) -> Result<CompareTabular, OxenError> {
+    let req_body = TabularCompareBody {
+        compare_id: compare_id.to_string(),
+        left: TabularCompareResourceBody {
+            path: left_path.to_string(),
+            version: left_revision.to_string(),
+        },
+        right: TabularCompareResourceBody {
+            path: right_path.to_string(),
+            version: right_revision.to_string(),
+        },
+        keys,
+        compare,
+        display,
+    };
+
+    let uri = format!("/compare/data_frame/{compare_id}");
+    let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
+
+    let client = client::new_for_url(&url)?;
+
+    // let params =
+
+    if let Ok(res) = client.put(&url).json(&json!(req_body)).send().await {
         let body = client::parse_json_body(&url, res).await?;
         let response: Result<CompareTabularResponse, serde_json::Error> =
             serde_json::from_str(&body);
@@ -99,23 +147,14 @@ mod tests {
     use crate::api;
     use crate::command;
     use crate::constants;
-    use crate::constants::COMMITS_DIR;
-    use crate::constants::DEFAULT_BRANCH_NAME;
     use crate::constants::DIFF_STATUS_COL;
-    use crate::core::db;
-    use crate::core::index::pusher::UnsyncedCommitEntries;
-    use crate::core::index::CommitDBReader;
     use crate::error::OxenError;
 
     use crate::model::compare::tabular_compare::TabularCompareFieldBody;
-    use crate::model::entry::commit_entry::Entry;
     use crate::test;
     use polars::lazy::dsl::col;
     use polars::lazy::dsl::lit;
     use polars::lazy::frame::IntoLazy;
-    use rocksdb::{DBWithThreadMode, MultiThreaded};
-
-    use std::thread;
 
     #[tokio::test]
     async fn test_remote_create_compare_get_derived() -> Result<(), OxenError> {
@@ -133,7 +172,7 @@ mod tests {
 
             command::add(&local_repo, &local_repo.path)?;
 
-            let commit = command::commit(&local_repo, "committing files")?;
+            command::commit(&local_repo, "committing files")?;
 
             // set remote
 
@@ -146,7 +185,7 @@ mod tests {
 
             let compare_id = "abcdefgh";
 
-            let compare = api::remote::compare::create_compare(
+            api::remote::compare::create_compare(
                 &remote_repo,
                 compare_id,
                 left_path,
@@ -314,9 +353,73 @@ mod tests {
 
             assert_eq!(removed_df.height(), 1);
 
-            // Advance the data and don't change the compare definition
-            let csv1 = "a,b,c,d\n1,2,3,4\n4,5,6,7\n9,0,1,2";
-            let csv2 = "a,b,c,d\n1,2,3,4\n4,5,6,8\n0,1,9,2";
+            // Advance the data and don't change the compare definition. New will just take away the removed observation
+            let csv1 = "a,b,c,d\n1,2,3,4\n4,5,6,7";
+            // let csv2 = "a,b,c,d\n1,2,3,4\n4,5,6,8\n0,1,9,2";
+
+            test::write_txt_file_to_path(local_repo.path.join(left_path), csv1)?;
+            command::add(&local_repo, &local_repo.path)?;
+            command::commit(&local_repo, "committing files")?;
+            command::push(&local_repo).await?;
+
+            // Now get the derived df
+            let derived_df =
+                api::remote::compare::get_derived_compare_df(&remote_repo, compare_id).await?;
+
+            let new_df = derived_df.to_df();
+
+            // Nothing should've changed! Compare wasn't updated.
+            assert_eq!(new_df, df);
+
+            // Now, update the compare - using the exact same body as before, only the commits have changed
+            // (is now MAIN)
+            let compare = api::remote::compare::update_compare(
+                &remote_repo,
+                compare_id,
+                left_path,
+                constants::DEFAULT_BRANCH_NAME,
+                right_path,
+                constants::DEFAULT_BRANCH_NAME,
+                vec![
+                    TabularCompareFieldBody {
+                        left: "a".to_string(),
+                        right: "a".to_string(),
+                        alias_as: None,
+                        compare_method: None,
+                    },
+                    TabularCompareFieldBody {
+                        left: "b".to_string(),
+                        right: "b".to_string(),
+                        alias_as: None,
+                        compare_method: None,
+                    },
+                    TabularCompareFieldBody {
+                        left: "c".to_string(),
+                        right: "c".to_string(),
+                        alias_as: None,
+                        compare_method: None,
+                    },
+                ],
+                vec![TabularCompareFieldBody {
+                    left: "d".to_string(),
+                    right: "d".to_string(),
+                    alias_as: None,
+                    compare_method: None,
+                }],
+                vec![],
+            )
+            .await?;
+
+            // Get derived df again
+            let derived_df =
+                api::remote::compare::get_derived_compare_df(&remote_repo, compare_id).await?;
+
+            let new_df = derived_df.to_df();
+
+            assert_ne!(new_df, df);
+            assert_eq!(new_df.height(), 2);
+
+            Ok(remote_repo)
         })
         .await
     }

--- a/src/lib/src/constants.rs
+++ b/src/lib/src/constants.rs
@@ -121,6 +121,8 @@ pub const FILE_ROW_NUM_COL_NAME: &str = "_file_row_num";
 pub const TARGETS_HASH_COL: &str = "_targets_hash";
 // Internal Name When Performing Computation
 pub const KEYS_HASH_COL: &str = "_keys_hash";
+// Internal Name When Performing Computation
+pub const DIFF_STATUS_COL: &str = ".oxen.diff.status";
 
 // Data transfer
 // Average chunk size of ~4mb

--- a/src/lib/src/model/compare/tabular_compare.rs
+++ b/src/lib/src/model/compare/tabular_compare.rs
@@ -37,7 +37,8 @@ pub struct TabularCompareResourceBody {
 pub struct TabularCompareFieldBody {
     pub left: String,
     pub right: String,
-    pub alias: Option<String>,
+    pub alias_as: Option<String>,
+    pub compare_method: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/src/lib/src/model/diff/tabular_diff.rs
+++ b/src/lib/src/model/diff/tabular_diff.rs
@@ -22,7 +22,6 @@ pub struct TabularDiffImpl {
 
     pub base_schema: Option<Schema>,
     pub head_schema: Option<Schema>,
-
     pub added_rows: Option<JsonDataFrame>,
     pub added_rows_view: Option<JsonDataFrameView>,
     pub removed_rows: Option<JsonDataFrame>,

--- a/src/lib/src/view/compare.rs
+++ b/src/lib/src/view/compare.rs
@@ -74,7 +74,7 @@ pub struct CompareTabular {
     pub derived: HashMap<String, CompareDerivedDF>,
     pub dupes: CompareDupes,
     pub schema_diff: Option<CompareSchemaDiff>,
-    pub compare_summary: Option<CompareSummary>,
+    pub summary: Option<CompareSummary>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -85,10 +85,15 @@ pub struct CompareSchemaDiff {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CompareSummary {
+    pub modifications: CompareTabularMods,
+    pub schema: Schema,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CompareTabularMods {
     pub added_rows: usize,
     pub removed_rows: usize,
     pub modified_rows: usize,
-    pub derived_schema: Schema,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -243,10 +248,12 @@ impl CompareSummary {
             .count();
 
         Ok(CompareSummary {
-            added_rows,
-            removed_rows,
-            modified_rows,
-            derived_schema: Schema::from_polars(&df.schema()),
+            modifications: CompareTabularMods {
+                added_rows,
+                removed_rows,
+                modified_rows,
+            },
+            schema: Schema::from_polars(&df.schema()),
         })
     }
 }

--- a/src/lib/src/view/compare.rs
+++ b/src/lib/src/view/compare.rs
@@ -4,6 +4,8 @@ use std::path::PathBuf;
 use polars::frame::DataFrame;
 use serde::{Deserialize, Serialize};
 
+use crate::constants::DIFF_STATUS_COL;
+use crate::error::OxenError;
 use crate::message::{MessageLevel, OxenMessage};
 use crate::model::{Commit, CommitEntry, DataFrameSize, DiffEntry, Schema};
 use crate::view::Pagination;
@@ -71,6 +73,22 @@ pub struct CompareTabular {
     pub source: HashMap<String, CompareSourceDF>,
     pub derived: HashMap<String, CompareDerivedDF>,
     pub dupes: CompareDupes,
+    pub schema_diff: Option<CompareSchemaDiff>,
+    pub compare_summary: Option<CompareSummary>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CompareSchemaDiff {
+    pub added_cols: Vec<CompareSchemaColumn>,
+    pub removed_cols: Vec<CompareSchemaColumn>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CompareSummary {
+    pub added_rows: usize,
+    pub removed_rows: usize,
+    pub modified_rows: usize,
+    pub derived_schema: Schema,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -94,6 +112,13 @@ pub struct CompareSourceDF {
     pub size: DataFrameSize,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CompareSchemaColumn {
+    pub name: String,
+    pub key: String,
+    pub dtype: String,
+}
+
 #[derive(Debug)]
 pub enum CompareResult {
     Tabular((CompareTabular, DataFrame)),
@@ -101,10 +126,10 @@ pub enum CompareResult {
 }
 
 pub struct CompareTabularRaw {
-    pub added_cols_df: DataFrame,
-    pub removed_cols_df: DataFrame,
     pub diff_df: DataFrame,
     pub dupes: CompareDupes,
+    pub compare_summary: Option<CompareSummary>,
+    pub schema_diff: Option<CompareSchemaDiff>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -190,5 +215,111 @@ impl CompareDerivedDF {
             schema,
             resource,
         }
+    }
+}
+
+impl CompareSummary {
+    pub fn from_diff_df(df: &DataFrame) -> Result<CompareSummary, OxenError> {
+        // TODO optimization: can this be done in one pass?
+        let added_rows = df
+            .column(DIFF_STATUS_COL)?
+            .utf8()?
+            .into_iter()
+            .filter(|opt| opt.as_ref().map(|s| *s == "added").unwrap_or(false))
+            .count();
+
+        let removed_rows = df
+            .column(DIFF_STATUS_COL)?
+            .utf8()?
+            .into_iter()
+            .filter(|opt| opt.as_ref().map(|s| *s == "removed").unwrap_or(false))
+            .count();
+
+        let modified_rows = df
+            .column(DIFF_STATUS_COL)?
+            .utf8()?
+            .into_iter()
+            .filter(|opt| opt.as_ref().map(|s| *s == "modified").unwrap_or(false))
+            .count();
+
+        Ok(CompareSummary {
+            added_rows,
+            removed_rows,
+            modified_rows,
+            derived_schema: Schema::from_polars(&df.schema()),
+        })
+    }
+}
+
+impl CompareSchemaDiff {
+    pub fn from_dfs(df1: &DataFrame, df2: &DataFrame) -> Result<CompareSchemaDiff, OxenError> {
+        // Assuming CompareSchemaColumn and CompareSchemaDiff are defined elsewhere
+        // and OxenError is a placeholder for error handling in your application.
+
+        // Get added columns
+        let added_cols = df2
+            .schema()
+            .iter_fields()
+            .filter(|field| !df1.schema().contains(field.name()))
+            .map(|field| {
+                Ok(CompareSchemaColumn {
+                    name: field.name().to_owned().to_string(),
+                    key: format!("{}.right", field.name()),
+                    dtype: format!("{:?}", field.data_type()),
+                })
+            })
+            .collect::<Result<Vec<CompareSchemaColumn>, OxenError>>()?;
+
+        // Get removed columns
+        let removed_cols = df1
+            .schema()
+            .iter_fields()
+            .filter(|field| !df2.schema().contains(field.name()))
+            .map(|field| {
+                Ok(CompareSchemaColumn {
+                    name: field.name().to_string(),
+                    key: format!("{}.left", field.name()),
+                    dtype: format!("{:?}", field.data_type()),
+                })
+            })
+            .collect::<Result<Vec<CompareSchemaColumn>, OxenError>>()?;
+
+        Ok(CompareSchemaDiff {
+            added_cols,
+            removed_cols,
+        })
+    }
+
+    pub fn from_schemas(s1: &Schema, s2: &Schema) -> Result<CompareSchemaDiff, OxenError> {
+        let added_cols = s2
+            .fields
+            .iter()
+            .filter(|field| !s1.fields.contains(field))
+            .map(|field| {
+                Ok(CompareSchemaColumn {
+                    name: field.name.to_owned().to_string(),
+                    key: format!("{}.right", field.name),
+                    dtype: field.dtype.to_owned(),
+                })
+            })
+            .collect::<Result<Vec<CompareSchemaColumn>, OxenError>>()?;
+
+        let removed_cols = s1
+            .fields
+            .iter()
+            .filter(|field| !s2.fields.contains(field))
+            .map(|field| {
+                Ok(CompareSchemaColumn {
+                    name: field.name.to_string(),
+                    key: format!("{}.left", field.name),
+                    dtype: field.dtype.to_string(),
+                })
+            })
+            .collect::<Result<Vec<CompareSchemaColumn>, OxenError>>()?;
+
+        Ok(CompareSchemaDiff {
+            added_cols,
+            removed_cols,
+        })
     }
 }

--- a/src/lib/src/view/compare.rs
+++ b/src/lib/src/view/compare.rs
@@ -61,6 +61,7 @@ pub struct CompareEntriesResponse {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CompareTabularResponse {
     pub dfs: CompareTabular,
+    #[serde(flatten)]
     pub status: StatusMessage,
     pub messages: Vec<OxenMessage>,
 }

--- a/src/server/src/controllers/compare.rs
+++ b/src/server/src/controllers/compare.rs
@@ -300,8 +300,6 @@ pub async fn update_df_compare(
 
     log::debug!("display by col is {:?}", display_by_column);
 
-    let compare_id = data.compare_id;
-
     let commit_1 = api::local::revisions::get(&repository, &data.left.version)?
         .ok_or_else(|| OxenError::revision_not_found(data.left.version.into()))?;
     let commit_2 = api::local::revisions::get(&repository, &data.right.version)?
@@ -431,116 +429,6 @@ pub async fn get_df_compare(
         Err(OxenHttpError::NotFound)
     }
 }
-
-// pub async fn get_df_compare(
-//     req: HttpRequest,
-//     body: String,
-// ) -> actix_web::Result<HttpResponse, OxenHttpError> {
-// let app_data = app_data(&req)?;
-// let namespace = path_param(&req, "namespace")?;
-// let name = path_param(&req, "repo_name")?;
-// let compare_id = path_param(&req, "compare_id")?;
-// let repository = get_repo(&app_data.path, namespace, name)?;
-// let base_head = path_param(&req, "base_head")?;
-
-// let data: TabularCompareBody = serde_json::from_str(&body)?;
-
-// let (left, right) = parse_base_head(&base_head)?;
-// let (left_commit, right_commit) = resolve_base_head(&repository, &left, &right)?;
-
-// let left_commit = left_commit.ok_or(OxenError::revision_not_found(left.into()))?;
-// let right_commit = right_commit.ok_or(OxenError::revision_not_found(right.into()))?;
-
-// let left_entry = api::local::entries::get_commit_entry(
-//     &repository,
-//     &left_commit,
-//     &PathBuf::from(data.left.path.clone()),
-// )?
-// .ok_or_else(|| {
-//     OxenError::ResourceNotFound(format!("{}@{}", data.left.path, left_commit).into())
-// })?;
-// let right_entry = api::local::entries::get_commit_entry(
-//     &repository,
-//     &right_commit,
-//     &PathBuf::from(data.right.path.clone()),
-// )?
-// .ok_or_else(|| {
-//     OxenError::ResourceNotFound(format!("{}@{}", data.right.path, right_commit).into())
-// })?;
-
-// let cpath_1 = CompareEntry {
-//     commit_entry: Some(left_entry.clone()),
-//     path: left_entry.path,
-// };
-
-// let cpath_2 = CompareEntry {
-//     commit_entry: Some(right_entry.clone()),
-//     path: right_entry.path,
-// };
-
-//     let maybe_cached_compare = api::local::compare::get_cached_compare(
-//         &repository,
-//         &compare_id,
-//         cpath_1.clone(),
-//         cpath_2.clone(),
-//     )?;
-
-//     let view = match maybe_cached_compare {
-//         Some(compare) => {
-//             let mut messages: Vec<OxenMessage> = vec![];
-
-//             if compare.dupes.left > 0 || compare.dupes.right > 0 {
-//                 messages.push(compare.dupes.clone().to_message());
-//             }
-
-//             log::debug!("cache hit!");
-//             CompareTabularResponse {
-//                 status: StatusMessage::resource_found(),
-//                 dfs: compare,
-//                 messages,
-//             }
-//         }
-//         None => {
-//             log::debug!("cache miss");
-//             // TODO: Remove the next two lines when we want to allow mapping
-//             // different keys and targets from left and right file.
-//             let keys = data.keys.iter().map(|k| k.left.clone()).collect();
-//             let targets = data.compare.iter().map(|t| t.left.clone()).collect();
-//             let display = data.display;
-
-//             let display_by_column = get_display_by_columns(display);
-
-//             let result = api::local::compare::compare_files(
-//                 &repository,
-//                 Some(&compare_id),
-//                 cpath_1,
-//                 cpath_2,
-//                 keys,
-//                 targets,
-//                 display_by_column,
-//                 None,
-//             )?;
-
-//             match result {
-//                 CompareResult::Tabular((compare, _)) => {
-//                     let mut messages: Vec<OxenMessage> = vec![];
-
-//                     if compare.dupes.left > 0 || compare.dupes.right > 0 {
-//                         messages.push(compare.dupes.clone().to_message());
-//                     }
-
-//                     CompareTabularResponse {
-//                         status: StatusMessage::resource_found(),
-//                         dfs: compare,
-//                         messages,
-//                     }
-//                 }
-//                 _ => Err(OxenError::basic_str("Wrong comparison type"))?,
-//             }
-//         }
-//     };
-//     Ok(HttpResponse::Ok().json(view))
-// }
 
 pub async fn get_derived_df(
     req: HttpRequest,

--- a/src/server/src/controllers/compare.rs
+++ b/src/server/src/controllers/compare.rs
@@ -265,6 +265,102 @@ pub async fn create_df_compare(
     Ok(HttpResponse::Ok().json(view))
 }
 
+pub async fn update_df_compare(
+    req: HttpRequest,
+    body: String,
+) -> actix_web::Result<HttpResponse, OxenHttpError> {
+    let app_data = app_data(&req)?;
+    let namespace = path_param(&req, "namespace")?;
+    let name = path_param(&req, "repo_name")?;
+    let compare_id = path_param(&req, "compare_id")?;
+    let repository = get_repo(&app_data.path, namespace, name)?;
+
+    let data: Result<TabularCompareBody, serde_json::Error> = serde_json::from_str(&body);
+    let data = match data {
+        Ok(data) => data,
+        Err(err) => {
+            log::error!(
+                "unable to parse tabular comparison data. Err: {}\n{}",
+                err,
+                body
+            );
+            return Ok(HttpResponse::BadRequest().json(StatusMessage::error(err.to_string())));
+        }
+    };
+
+    let resource_1 = PathBuf::from(data.left.path);
+    let resource_2 = PathBuf::from(data.right.path);
+    let keys = data.keys;
+    let targets = data.compare;
+    let display = data.display;
+
+    log::debug!("display is {:?}", display);
+
+    let display_by_column = get_display_by_columns(display);
+
+    log::debug!("display by col is {:?}", display_by_column);
+
+    let compare_id = data.compare_id;
+
+    let commit_1 = api::local::revisions::get(&repository, &data.left.version)?
+        .ok_or_else(|| OxenError::revision_not_found(data.left.version.into()))?;
+    let commit_2 = api::local::revisions::get(&repository, &data.right.version)?
+        .ok_or_else(|| OxenError::revision_not_found(data.right.version.into()))?;
+
+    let entry_1 = api::local::entries::get_commit_entry(&repository, &commit_1, &resource_1)?
+        .ok_or_else(|| {
+            OxenError::ResourceNotFound(format!("{}@{}", resource_1.display(), commit_1).into())
+        })?;
+    let entry_2 = api::local::entries::get_commit_entry(&repository, &commit_1, &resource_2)?
+        .ok_or_else(|| {
+            OxenError::ResourceNotFound(format!("{}@{}", resource_2.display(), commit_2).into())
+        })?;
+
+    let cpath_1 = CompareEntry {
+        commit_entry: Some(entry_1),
+        path: resource_1,
+    };
+
+    let cpath_2 = CompareEntry {
+        commit_entry: Some(entry_2),
+        path: resource_2,
+    };
+
+    // TODO: Remove the next two lines when we want to allow mapping
+    // different keys and targets from left and right file.
+    let keys = keys.iter().map(|k| k.left.clone()).collect();
+    let targets = targets.iter().map(|t| t.left.clone()).collect();
+
+    let result = api::local::compare::compare_files(
+        &repository,
+        Some(&compare_id),
+        cpath_1,
+        cpath_2,
+        keys,
+        targets,
+        display_by_column, // TODONOW: add display handling here
+        None,
+    )?;
+
+    let view = match result {
+        CompareResult::Tabular((compare, _)) => {
+            let mut messages: Vec<OxenMessage> = vec![];
+
+            if compare.dupes.left > 0 || compare.dupes.right > 0 {
+                messages.push(compare.dupes.clone().to_message());
+            }
+
+            CompareTabularResponse {
+                status: StatusMessage::resource_found(),
+                dfs: compare,
+                messages,
+            }
+        }
+        _ => Err(OxenError::basic_str("Wrong comparison type"))?,
+    };
+    Ok(HttpResponse::Ok().json(view))
+}
+
 pub async fn get_df_compare(
     req: HttpRequest,
     body: String,
@@ -318,62 +414,133 @@ pub async fn get_df_compare(
         cpath_2.clone(),
     )?;
 
-    let view = match maybe_cached_compare {
-        Some(compare) => {
-            let mut messages: Vec<OxenMessage> = vec![];
+    if let Some(compare) = maybe_cached_compare {
+        let mut messages: Vec<OxenMessage> = vec![];
 
-            if compare.dupes.left > 0 || compare.dupes.right > 0 {
-                messages.push(compare.dupes.clone().to_message());
-            }
-
-            log::debug!("cache hit!");
-            CompareTabularResponse {
-                status: StatusMessage::resource_found(),
-                dfs: compare,
-                messages,
-            }
+        if compare.dupes.left > 0 || compare.dupes.right > 0 {
+            messages.push(compare.dupes.clone().to_message());
         }
-        None => {
-            log::debug!("cache miss");
-            // TODO: Remove the next two lines when we want to allow mapping
-            // different keys and targets from left and right file.
-            let keys = data.keys.iter().map(|k| k.left.clone()).collect();
-            let targets = data.compare.iter().map(|t| t.left.clone()).collect();
-            let display = data.display;
 
-            let display_by_column = get_display_by_columns(display);
-
-            let result = api::local::compare::compare_files(
-                &repository,
-                Some(&compare_id),
-                cpath_1,
-                cpath_2,
-                keys,
-                targets,
-                display_by_column,
-                None,
-            )?;
-
-            match result {
-                CompareResult::Tabular((compare, _)) => {
-                    let mut messages: Vec<OxenMessage> = vec![];
-
-                    if compare.dupes.left > 0 || compare.dupes.right > 0 {
-                        messages.push(compare.dupes.clone().to_message());
-                    }
-
-                    CompareTabularResponse {
-                        status: StatusMessage::resource_found(),
-                        dfs: compare,
-                        messages,
-                    }
-                }
-                _ => Err(OxenError::basic_str("Wrong comparison type"))?,
-            }
-        }
-    };
-    Ok(HttpResponse::Ok().json(view))
+        let view = CompareTabularResponse {
+            status: StatusMessage::resource_found(),
+            dfs: compare,
+            messages,
+        };
+        Ok(HttpResponse::Ok().json(view))
+    } else {
+        Err(OxenHttpError::NotFound)
+    }
 }
+
+// pub async fn get_df_compare(
+//     req: HttpRequest,
+//     body: String,
+// ) -> actix_web::Result<HttpResponse, OxenHttpError> {
+// let app_data = app_data(&req)?;
+// let namespace = path_param(&req, "namespace")?;
+// let name = path_param(&req, "repo_name")?;
+// let compare_id = path_param(&req, "compare_id")?;
+// let repository = get_repo(&app_data.path, namespace, name)?;
+// let base_head = path_param(&req, "base_head")?;
+
+// let data: TabularCompareBody = serde_json::from_str(&body)?;
+
+// let (left, right) = parse_base_head(&base_head)?;
+// let (left_commit, right_commit) = resolve_base_head(&repository, &left, &right)?;
+
+// let left_commit = left_commit.ok_or(OxenError::revision_not_found(left.into()))?;
+// let right_commit = right_commit.ok_or(OxenError::revision_not_found(right.into()))?;
+
+// let left_entry = api::local::entries::get_commit_entry(
+//     &repository,
+//     &left_commit,
+//     &PathBuf::from(data.left.path.clone()),
+// )?
+// .ok_or_else(|| {
+//     OxenError::ResourceNotFound(format!("{}@{}", data.left.path, left_commit).into())
+// })?;
+// let right_entry = api::local::entries::get_commit_entry(
+//     &repository,
+//     &right_commit,
+//     &PathBuf::from(data.right.path.clone()),
+// )?
+// .ok_or_else(|| {
+//     OxenError::ResourceNotFound(format!("{}@{}", data.right.path, right_commit).into())
+// })?;
+
+// let cpath_1 = CompareEntry {
+//     commit_entry: Some(left_entry.clone()),
+//     path: left_entry.path,
+// };
+
+// let cpath_2 = CompareEntry {
+//     commit_entry: Some(right_entry.clone()),
+//     path: right_entry.path,
+// };
+
+//     let maybe_cached_compare = api::local::compare::get_cached_compare(
+//         &repository,
+//         &compare_id,
+//         cpath_1.clone(),
+//         cpath_2.clone(),
+//     )?;
+
+//     let view = match maybe_cached_compare {
+//         Some(compare) => {
+//             let mut messages: Vec<OxenMessage> = vec![];
+
+//             if compare.dupes.left > 0 || compare.dupes.right > 0 {
+//                 messages.push(compare.dupes.clone().to_message());
+//             }
+
+//             log::debug!("cache hit!");
+//             CompareTabularResponse {
+//                 status: StatusMessage::resource_found(),
+//                 dfs: compare,
+//                 messages,
+//             }
+//         }
+//         None => {
+//             log::debug!("cache miss");
+//             // TODO: Remove the next two lines when we want to allow mapping
+//             // different keys and targets from left and right file.
+//             let keys = data.keys.iter().map(|k| k.left.clone()).collect();
+//             let targets = data.compare.iter().map(|t| t.left.clone()).collect();
+//             let display = data.display;
+
+//             let display_by_column = get_display_by_columns(display);
+
+//             let result = api::local::compare::compare_files(
+//                 &repository,
+//                 Some(&compare_id),
+//                 cpath_1,
+//                 cpath_2,
+//                 keys,
+//                 targets,
+//                 display_by_column,
+//                 None,
+//             )?;
+
+//             match result {
+//                 CompareResult::Tabular((compare, _)) => {
+//                     let mut messages: Vec<OxenMessage> = vec![];
+
+//                     if compare.dupes.left > 0 || compare.dupes.right > 0 {
+//                         messages.push(compare.dupes.clone().to_message());
+//                     }
+
+//                     CompareTabularResponse {
+//                         status: StatusMessage::resource_found(),
+//                         dfs: compare,
+//                         messages,
+//                     }
+//                 }
+//                 _ => Err(OxenError::basic_str("Wrong comparison type"))?,
+//             }
+//         }
+//     };
+//     Ok(HttpResponse::Ok().json(view))
+// }
 
 pub async fn get_derived_df(
     req: HttpRequest,
@@ -384,7 +551,7 @@ pub async fn get_derived_df(
     let repo_name = path_param(&req, "repo_name")?;
     let repo = get_repo(&app_data.path, namespace, repo_name)?;
     let compare_id = path_param(&req, "compare_id")?;
-    let base_head = path_param(&req, "base_head")?;
+    // let base_head = path_param(&req, "base_head")?;
 
     let compare_dir = api::local::compare::get_compare_dir(&repo, &compare_id);
 
@@ -472,7 +639,7 @@ pub async fn get_derived_df(
             let derived_resource = DerivedDFResource {
                 resource_type: DFResourceType::Compare,
                 resource_id: compare_id.clone(),
-                path: format!("/compare/data_frame/{}/{}", compare_id, base_head),
+                path: format!("/compare/data_frame/{}/diff", compare_id),
             };
 
             let response = JsonDataFrameViewResponse {
@@ -556,4 +723,39 @@ fn get_display_by_columns(display: Vec<TabularCompareDisplayBody>) -> Vec<String
         }
     }
     display_by_column
+}
+
+#[cfg(test)]
+mod tests {
+    use liboxen::{command, error::OxenError};
+
+    use crate::test;
+
+    #[actix_web::test]
+    async fn test_controllers_compare_create() -> Result<(), OxenError> {
+        let sync_dir = test::get_sync_dir()?;
+        let queue = test::init_queue();
+
+        let namepsace = "testing-namespace";
+        let repo_name = "testing-repo";
+
+        let repo = test::create_local_repo(&sync_dir, namepsace, repo_name)?;
+
+        let csv1 = "a,b,c,d\n1,2,3,4\n4,5,6,7\n9,0,1,2";
+        let csv2 = "a,b,c,d\n1,2,3,4\n4,5,6,8\n0,1,9,2";
+
+        let path1 = repo.path.join("file1.csv");
+        let path2 = repo.path.join("file2.csv");
+
+        liboxen::test::write_txt_file_to_path(&path1, csv1)?;
+        liboxen::test::write_txt_file_to_path(&path2, csv2)?;
+
+        command::add(&repo, &repo.path)?;
+
+        let status = command::status(&repo)?;
+
+        let commit = command::commit(&repo, "commit 1")?;
+
+        Ok(())
+    }
 }

--- a/src/server/src/routes.rs
+++ b/src/server/src/routes.rs
@@ -159,7 +159,7 @@ pub fn config(cfg: &mut web::ServiceConfig) {
             web::get().to(controllers::compare::file),
         )
         .route(
-            "/{namespace}/{repo_name}/compare/data_frame/{compare_id}/{path}/{base_head:.*}",
+            "/{namespace}/{repo_name}/compare/data_frame/{compare_id}/{path}",
             web::get().to(controllers::compare::get_derived_df),
         )
         // The below is a POST rather than a GET for two reasons: 1) tesla doesn't allow GET requests to have a body,
@@ -168,6 +168,10 @@ pub fn config(cfg: &mut web::ServiceConfig) {
         .route(
             "/{namespace}/{repo_name}/compare/data_frame/{compare_id}",
             web::post().to(controllers::compare::get_df_compare),
+        )
+        .route(
+            "/{namespace}/{repo_name}/compare/data_frame/{compare_id}",
+            web::put().to(controllers::compare::update_df_compare),
         )
         .route(
             "/{namespace}/{repo_name}/compare/data_frame",


### PR DESCRIPTION
Pending one last reorg and cleanup of the `CompareTabular` struct responses, that's why there's some commented blocks with the old left_only right_only dfs etc. Will be an invisible change to the hub + FE, just a bit of unweaving to do once we sweep back through to optimize