### PR TITLE
Allow asymmetric targets from API

### DIFF
--- a/src/lib/src/api/local/compare.rs
+++ b/src/lib/src/api/local/compare.rs
@@ -603,23 +603,25 @@ fn validate_required_fields(
     keys: Vec<String>,
     targets: Vec<String>,
 ) -> Result<(), OxenError> {
-    // Subset dataframes to "keys" and "targets"
+    // Keys must be in both dfs
     #[allow(clippy::map_clone)]
-    let required_fields = keys
-        .iter()
-        .chain(targets.iter())
-        .cloned()
-        .collect::<Vec<String>>();
-
-    // Make sure both dataframes have all required fields
-
-    if !schema_1.has_field_names(&required_fields) {
-        return Err(OxenError::incompatible_schemas(required_fields, schema_1));
+    if !schema_1.has_field_names(&keys) {
+        return Err(OxenError::incompatible_schemas(keys, schema_1));
     };
 
-    if !schema_2.has_field_names(&required_fields) {
-        return Err(OxenError::incompatible_schemas(required_fields, schema_2));
+    if !schema_2.has_field_names(&keys) {
+        return Err(OxenError::incompatible_schemas(keys, schema_2));
     };
+
+    // Targets must be in either df
+    for target in &targets {
+        if !schema_1.has_field_name(target) && !schema_2.has_field_name(target) {
+            return Err(OxenError::incompatible_schemas(
+                vec![target.to_string()],
+                schema_1,
+            ));
+        }
+    }
 
     Ok(())
 }

--- a/src/lib/src/api/remote/compare.rs
+++ b/src/lib/src/api/remote/compare.rs
@@ -4,7 +4,7 @@ use crate::{
     model::{
         compare::tabular_compare::{
             TabularCompareBody, TabularCompareDisplayBody, TabularCompareFieldBody,
-            TabularCompareResourceBody,
+            TabularCompareResourceBody, TabularCompareTargetBody,
         },
         RemoteRepository,
     },
@@ -27,7 +27,7 @@ pub async fn create_compare(
     right_path: &str,
     right_revision: &str,
     keys: Vec<TabularCompareFieldBody>,
-    compare: Vec<TabularCompareFieldBody>,
+    compare: Vec<TabularCompareTargetBody>,
     display: Vec<TabularCompareDisplayBody>,
 ) -> Result<CompareTabular, OxenError> {
     let req_body = TabularCompareBody {
@@ -76,7 +76,7 @@ pub async fn update_compare(
     right_path: &str,
     right_revision: &str,
     keys: Vec<TabularCompareFieldBody>,
-    compare: Vec<TabularCompareFieldBody>,
+    compare: Vec<TabularCompareTargetBody>,
     display: Vec<TabularCompareDisplayBody>,
 ) -> Result<CompareTabular, OxenError> {
     let req_body = TabularCompareBody {
@@ -152,6 +152,7 @@ mod tests {
     use crate::error::OxenError;
 
     use crate::model::compare::tabular_compare::TabularCompareFieldBody;
+    use crate::model::compare::tabular_compare::TabularCompareTargetBody;
     use crate::test;
     use polars::lazy::dsl::col;
     use polars::lazy::dsl::lit;
@@ -213,9 +214,9 @@ mod tests {
                         compare_method: None,
                     },
                 ],
-                vec![TabularCompareFieldBody {
-                    left: "d".to_string(),
-                    right: "d".to_string(),
+                vec![TabularCompareTargetBody {
+                    left: Some("d".to_string()),
+                    right: Some("d".to_string()),
                     alias_as: None,
                     compare_method: None,
                 }],
@@ -314,9 +315,9 @@ mod tests {
                         compare_method: None,
                     },
                 ],
-                vec![TabularCompareFieldBody {
-                    left: "d".to_string(),
-                    right: "d".to_string(),
+                vec![TabularCompareTargetBody {
+                    left: Some("d".to_string()),
+                    right: Some("d".to_string()),
                     alias_as: None,
                     compare_method: None,
                 }],
@@ -401,9 +402,9 @@ mod tests {
                         compare_method: None,
                     },
                 ],
-                vec![TabularCompareFieldBody {
-                    left: "d".to_string(),
-                    right: "d".to_string(),
+                vec![TabularCompareTargetBody {
+                    left: Some("d".to_string()),
+                    right: Some("d".to_string()),
                     alias_as: None,
                     compare_method: None,
                 }],

--- a/src/lib/src/model/compare/tabular_compare.rs
+++ b/src/lib/src/model/compare/tabular_compare.rs
@@ -23,7 +23,7 @@ pub struct TabularCompareBody {
     pub left: TabularCompareResourceBody,
     pub right: TabularCompareResourceBody,
     pub keys: Vec<TabularCompareFieldBody>,
-    pub compare: Vec<TabularCompareFieldBody>,
+    pub compare: Vec<TabularCompareTargetBody>,
     pub display: Vec<TabularCompareDisplayBody>,
 }
 
@@ -45,5 +45,13 @@ pub struct TabularCompareFieldBody {
 pub struct TabularCompareDisplayBody {
     pub left: Option<String>,
     pub right: Option<String>,
+    pub compare_method: Option<String>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct TabularCompareTargetBody {
+    pub left: Option<String>,
+    pub right: Option<String>,
+    pub alias_as: Option<String>,
     pub compare_method: Option<String>,
 }


### PR DESCRIPTION
We were previously handling asymmetric targets through default behavior only - but Adam needs to be able to manually submit them as well for updates from the frontend 