### PR TITLE
File tree endpoint for files changed view

### DIFF
--- a/src/lib/src/api/local/diff.rs
+++ b/src/lib/src/api/local/diff.rs
@@ -1,9 +1,6 @@
-use rayon::vec;
 use rocksdb::{DBWithThreadMode, MultiThreaded};
 use serde::{Deserialize, Serialize};
 
-use crate::constants::MAX_DISPLAY_DIRS;
-use crate::core::db::tree_db::{TreeObject, TreeObjectChild};
 use crate::core::db::{self, path_db};
 use crate::core::df::tabular;
 use crate::core::index::object_db_reader::ObjectDBReader;
@@ -14,7 +11,6 @@ use crate::model::diff::generic_diff::GenericDiff;
 use crate::model::{Commit, CommitEntry, DataFrameDiff, DiffEntry, LocalRepository, Schema};
 use crate::opts::DFOpts;
 use crate::view::compare::AddRemoveModifyCounts;
-use crate::view::diff::{DirDiffChildrenSummary, DirDiffStatus};
 use crate::view::Pagination;
 use crate::{constants, util};
 
@@ -660,14 +656,12 @@ pub fn list_diff_entries_in_dir(
 // direct traversal of the merkle tree to only get changed dirs and the fact that they were added,
 // removed, or modified.
 
-pub fn get_changed_dirs_tree(
+pub fn list_changed_dirs(
     repo: &LocalRepository,
     base_commit: &Commit,
     head_commit: &Commit,
-    page: usize,
-    page_size: usize,
-) -> Result<Vec<DirDiffChildrenSummary>, OxenError> {
-    let mut changed_dirs: Vec<DirDiffStatus> = vec![];
+) -> Result<Vec<(PathBuf, DiffEntryStatus)>, OxenError> {
+    let mut changed_dirs: Vec<(PathBuf, DiffEntryStatus)> = vec![];
     let object_reader = ObjectDBReader::new(repo)?;
 
     let base_entry_reader =
@@ -698,17 +692,11 @@ pub fn get_changed_dirs_tree(
     let modified_or_unchanged_dirs = head_dirs.intersection(&base_dirs).collect::<HashSet<_>>();
 
     for dir in added_dirs.iter() {
-        changed_dirs.push(DirDiffStatus {
-            name: dir.to_path_buf(),
-            status: DiffEntryStatus::Added,
-        });
+        changed_dirs.push((dir.to_path_buf(), DiffEntryStatus::Added));
     }
 
     for dir in removed_dirs.iter() {
-        changed_dirs.push(DirDiffStatus {
-            name: dir.to_path_buf(),
-            status: DiffEntryStatus::Removed,
-        });
+        changed_dirs.push((dir.to_path_buf(), DiffEntryStatus::Removed));
     }
 
     for dir in modified_or_unchanged_dirs.iter() {
@@ -739,203 +727,15 @@ pub fn get_changed_dirs_tree(
         let head_dir_hash = head_dir_hash.to_string();
 
         if base_dir_hash != head_dir_hash {
-            changed_dirs.push(DirDiffStatus {
-                name: dir.to_path_buf(),
-                status: DiffEntryStatus::Modified,
-            });
+            changed_dirs.push((dir.to_path_buf(), DiffEntryStatus::Modified));
         }
     }
 
-    let mut dir_diff_map: HashMap<PathBuf, Vec<DirDiffStatus>> = HashMap::new();
-    for dir_with_status in changed_dirs {
-        // Only root has no parent
-        if dir_with_status.name == Path::new("") {
-            continue;
-        }
+    // Sort by path for consistency
+    changed_dirs.sort_by(|a, b| a.0.cmp(&b.0));
 
-        let parent = dir_with_status.name.parent().unwrap_or(Path::new(""));
-        let parent = parent.to_path_buf();
-        if !dir_diff_map.contains_key(&parent) {
-            dir_diff_map.insert(parent.clone(), vec![]);
-        }
-        dir_diff_map.get_mut(&parent).unwrap().push(dir_with_status);
-    }
-
-    let mut dir_tree: Vec<DirDiffChildrenSummary> = vec![];
-    for (dir, entries) in dir_diff_map {
-        let num_subdirs = entries.len();
-        let can_display = num_subdirs > MAX_DISPLAY_DIRS;
-        let summary = DirDiffChildrenSummary {
-            name: dir.clone(),
-            num_subdirs,
-            can_display,
-            children: entries,
-        };
-        dir_tree.push(summary);
-    }
-
-    Ok(dir_tree)
+    Ok(changed_dirs)
 }
-
-// pub fn r_get_changed_dirs_tree(
-//     dir: PathBuf,
-//     maybe_base_node: Option<TreeObject>,
-//     maybe_head_node: Option<TreeObject>,
-//     changed_dirs: &mut Vec<(PathBuf, &str)>,
-//     object_reader: &ObjectDBReader,
-// ) -> Result<(), OxenError> {
-//     match (maybe_base_node, maybe_head_node) {
-//         // ADDED
-//         (None, Some(head_node)) => match head_node {
-//             TreeObject::Dir { hash, children } => {
-//                 changed_dirs.push((dir, "added"));
-//                 for child_node in children.iter() {
-//                     let child_dir = child_node.path().clone();
-//                     let maybe_child_head_node = object_reader.get_node_from_child(child_node)?;
-//                     r_get_changed_dirs_tree(
-//                         child_dir,
-//                         None,
-//                         maybe_child_head_node,
-//                         changed_dirs,
-//                         object_reader,
-//                     )?;
-//                 }
-//             }
-//             _ => {}
-//         },
-//         // REMOVED
-//         (Some(base_node), None) => match base_node {
-//             TreeObject::Dir { hash, children } => {
-//                 changed_dirs.push((dir, "removed"));
-//                 for child_node in children.iter() {
-//                     let child_dir = child_node.path().clone();
-//                     let maybe_child_base_node = object_reader.get_node_from_child(child_node)?;
-//                     r_get_changed_dirs_tree(
-//                         child_dir,
-//                         maybe_child_base_node,
-//                         None,
-//                         changed_dirs,
-//                         object_reader,
-//                     )?;
-//                 }
-//             }
-//             _ => {}
-//         },
-//         // MODIFIED OR UNCHANGED
-//         (Some(base_node), Some(head_node)) => match (base_node, head_node) {
-//             (
-//                 TreeObject::Dir {
-//                     hash: base_hash,
-//                     children: base_children,
-//                 },
-//                 TreeObject::Dir {
-//                     hash: head_hash,
-//                     children: head_children,
-//                 },
-//             ) => {
-//                 if base_hash == head_hash {
-//                     return Ok(());
-//                 }
-//                 changed_dirs.push((dir, "modified"));
-//                 let mut base_children_map: HashMap<PathBuf, TreeObjectChild> = HashMap::new();
-//                 for child in base_children.iter() {
-//                     base_children_map.insert(child.path().clone(), child.clone());
-//                 }
-//                 for child in head_children.iter() {
-//                     let child_dir = child.path().clone();
-//                     let maybe_child_base_node = base_children_map.get(&child_dir);
-//                     let maybe_child_head_node = object_reader.get_node_from_child(child)?;
-//                     r_get_changed_dirs_tree(
-//                         child_dir,
-//                         maybe_child_base_node.cloned(),
-//                         maybe_child_head_node,
-//                         changed_dirs,
-//                         object_reader,
-//                     )?;
-//                 }
-//             }
-//             _ => {}
-//         },
-//     }
-
-//     Ok(())
-// }
-
-// pub fn get_changed_dirs_tree(
-//     repo: &LocalRepository,
-//     base_commit: &Commit,
-//     head_commit: &Commit,
-//     page: usize,
-//     page_size: usize,
-// ) -> Result<Vec<DirDiffChildrenSummary>, OxenError> {
-//     log::debug!(
-//         "list_diff_entries base_commit: '{}', head_commit: '{}'",
-//         base_commit,
-//         head_commit
-//     );
-
-//     let head_dirs = read_dirs_from_commit(repo, head_commit)?;
-//     log::debug!("Got {} head_dirs", head_dirs.len());
-
-//     let base_dirs = read_dirs_from_commit(repo, base_commit)?;
-//     log::debug!("Got {} base_dirs", base_dirs.len());
-
-//     let mut dir_entries: Vec<DiffEntry> = vec![];
-//     collect_added_directories(
-//         repo,
-//         &base_dirs,
-//         base_commit,
-//         &head_dirs,
-//         head_commit,
-//         &mut dir_entries,
-//     )?;
-//     log::debug!("Collected {} added_dirs dir_entries", dir_entries.len());
-//     collect_removed_directories(
-//         repo,
-//         &base_dirs,
-//         base_commit,
-//         &head_dirs,
-//         head_commit,
-//         &mut dir_entries,
-//     )?;
-//     log::debug!("Collected {} removed_dirs dir_entries", dir_entries.len());
-//     collect_modified_directories(
-//         repo,
-//         &base_dirs,
-//         base_commit,
-//         &head_dirs,
-//         head_commit,
-//         &mut dir_entries,
-//     )?;
-
-//     // Group the diff entries into a tree structure
-//     let mut dir_diff_map: HashMap<PathBuf, Vec<DiffEntry>> = HashMap::new();
-//     for entry in dir_entries {
-//         let path = PathBuf::from(entry.filename.clone());
-//         let parent = path.parent().unwrap_or(Path::new(""));
-//         let parent = parent.to_path_buf();
-//         if !dir_diff_map.contains_key(&parent) {
-//             dir_diff_map.insert(parent.clone(), vec![]);
-//         }
-//         dir_diff_map.get_mut(&parent).unwrap().push(entry);
-//     }
-
-//     let mut dir_tree: Vec<DirDiffChildrenSummary> = vec![];
-//     for (dir, entries) in dir_diff_map.iter() {
-//         let num_subdirs = entries.len();
-
-//         dir_tree.push(DirDiffChildrenSummary {
-//             name: dir.to_string_lossy().to_string(),
-//             num_subdirs: num_subdirs as u64,
-//             can_display: true,
-//             children: entries.clone(),
-//         })
-//     }
-
-//     log::debug!("Got {:#?} dir_tree", dir_tree);
-
-//     Ok(dir_tree)
-// }
 
 /// TODO this is insane. Need more efficient data structure or to use a database like duckdb.
 pub fn list_diff_entries(

--- a/src/lib/src/api/local/diff.rs
+++ b/src/lib/src/api/local/diff.rs
@@ -651,11 +651,6 @@ pub fn list_diff_entries_in_dir(
     })
 }
 
-// TODO: Right now, this grabs all dirs and their full DiffEntries when they have changes.
-// this assumes we need that info on the sidebar - if we don't, we can utilize a much more efficient
-// direct traversal of the merkle tree to only get changed dirs and the fact that they were added,
-// removed, or modified.
-
 pub fn list_changed_dirs(
     repo: &LocalRepository,
     base_commit: &Commit,
@@ -675,7 +670,6 @@ pub fn list_changed_dirs(
     let base_dir_hashes_db_path = ObjectDBReader::commit_dir_hash_db(&repo.path, &base_commit.id);
     let head_dir_hashes_db_path = ObjectDBReader::commit_dir_hash_db(&repo.path, &head_commit.id);
 
-    // open these two for read only
     let base_dir_hashes_db: DBWithThreadMode<MultiThreaded> = DBWithThreadMode::open_for_read_only(
         &db::opts::default(),
         dunce::simplified(&base_dir_hashes_db_path),

--- a/src/lib/src/constants.rs
+++ b/src/lib/src/constants.rs
@@ -158,3 +158,6 @@ pub const MIN_CLI_VERSION: &str = "0.10.0";
 
 /// Filepath used to track repo and server-level migration status
 pub const LAST_MIGRATION_FILE: &str = "last_migration.txt";
+
+/// Constraints for diff and compare size
+pub const MAX_DISPLAY_DIRS: usize = 10;

--- a/src/lib/src/core/index/commit_entry_reader.rs
+++ b/src/lib/src/core/index/commit_entry_reader.rs
@@ -96,6 +96,19 @@ impl CommitEntryReader {
         Ok(paths)
     }
 
+    pub fn list_dirs_set(&self) -> Result<HashSet<PathBuf>, OxenError> {
+        let root = PathBuf::from("");
+        let mut paths = path_db::list_paths(&self.dir_db, &root)?;
+        if !paths.contains(&root) {
+            paths.push(root);
+        }
+        let mut set = HashSet::new();
+        for path in paths {
+            set.insert(path);
+        }
+        Ok(set)
+    }
+
     /// Lists all the parents of directories that are in the commit dir db
     pub fn list_dir_parents(&self, path: impl AsRef<Path>) -> Result<Vec<PathBuf>, OxenError> {
         // A little hacky, we just filter by starts_with because we aren't representing the parents in the db

--- a/src/lib/src/model/diff/diff_entry_status.rs
+++ b/src/lib/src/model/diff/diff_entry_status.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum DiffEntryStatus {
     Added,
     Modified,

--- a/src/lib/src/model/diff/dir_tree_diff.rs
+++ b/src/lib/src/model/diff/dir_tree_diff.rs
@@ -1,0 +1,1 @@
+use super::dir_diff_summary::DirDiffSummary;

--- a/src/lib/src/view.rs
+++ b/src/lib/src/view.rs
@@ -5,6 +5,7 @@ pub mod branch;
 pub mod commit;
 pub mod compare;
 pub mod data_type_count;
+pub mod diff;
 pub mod entry;
 pub mod entry_metadata;
 pub mod file_metadata;

--- a/src/lib/src/view/diff.rs
+++ b/src/lib/src/view/diff.rs
@@ -7,20 +7,21 @@ use crate::model::diff::diff_entry_status::DiffEntryStatus;
 use super::StatusMessage;
 #[derive(Deserialize, Serialize, Debug)]
 pub struct DirTreeDiffResponse {
-    pub dirs: Vec<DirDiffChildrenSummary>,
+    pub dirs: Vec<DirDiffTreeSummary>,
     #[serde(flatten)]
     pub status: StatusMessage,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
-pub struct DirDiffChildrenSummary {
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct DirDiffTreeSummary {
     pub name: PathBuf,
+    pub status: DiffEntryStatus,
     pub num_subdirs: usize,
     pub can_display: bool,
     pub children: Vec<DirDiffStatus>,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct DirDiffStatus {
     pub name: PathBuf,
     pub status: DiffEntryStatus,

--- a/src/lib/src/view/diff.rs
+++ b/src/lib/src/view/diff.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 use crate::model::diff::diff_entry_status::DiffEntryStatus;
-use crate::model::DiffEntry;
 
 use super::StatusMessage;
 #[derive(Deserialize, Serialize, Debug)]

--- a/src/lib/src/view/diff.rs
+++ b/src/lib/src/view/diff.rs
@@ -1,0 +1,28 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::model::diff::diff_entry_status::DiffEntryStatus;
+use crate::model::DiffEntry;
+
+use super::StatusMessage;
+#[derive(Deserialize, Serialize, Debug)]
+pub struct DirTreeDiffResponse {
+    pub dirs: Vec<DirDiffChildrenSummary>,
+    #[serde(flatten)]
+    pub status: StatusMessage,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct DirDiffChildrenSummary {
+    pub name: PathBuf,
+    pub num_subdirs: usize,
+    pub can_display: bool,
+    pub children: Vec<DirDiffStatus>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct DirDiffStatus {
+    pub name: PathBuf,
+    pub status: DiffEntryStatus,
+}

--- a/src/server/src/controllers/compare.rs
+++ b/src/server/src/controllers/compare.rs
@@ -1,4 +1,5 @@
-use std::path::PathBuf;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 use crate::errors::OxenHttpError;
 
@@ -8,6 +9,7 @@ use liboxen::core::index::{CommitReader, Merger};
 use liboxen::error::OxenError;
 use liboxen::message::OxenMessage;
 use liboxen::model::compare::tabular_compare::{TabularCompareBody, TabularCompareTargetBody};
+use liboxen::model::diff::diff_entry_status::DiffEntryStatus;
 use liboxen::model::{Commit, DataFrameSize, LocalRepository, Schema};
 use liboxen::opts::df_opts::DFOptsView;
 use liboxen::opts::DFOpts;
@@ -15,7 +17,7 @@ use liboxen::view::compare::{
     CompareCommits, CompareCommitsResponse, CompareEntries, CompareEntryResponse, CompareResult,
     CompareTabularResponse,
 };
-use liboxen::view::diff::DirTreeDiffResponse;
+use liboxen::view::diff::{DirDiffStatus, DirDiffTreeSummary, DirTreeDiffResponse};
 use liboxen::view::json_data_frame_view::{DFResourceType, DerivedDFResource, JsonDataFrameSource};
 use liboxen::view::{
     CompareEntriesResponse, JsonDataFrame, JsonDataFrameView, JsonDataFrameViewResponse,
@@ -124,10 +126,7 @@ pub async fn entries(
     Ok(HttpResponse::Ok().json(view))
 }
 
-pub async fn dir_tree(
-    req: HttpRequest,
-    query: web::Query<PageNumQuery>,
-) -> actix_web::Result<HttpResponse, OxenHttpError> {
+pub async fn dir_tree(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let name = path_param(&req, "repo_name")?;
@@ -136,10 +135,6 @@ pub async fn dir_tree(
     // Get the repository or return error
     let repository = get_repo(&app_data.path, namespace, name)?;
 
-    // Page size and number
-    let page = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
-    let page_size = query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);
-
     // Parse the base and head from the base..head string
     let (base, head) = parse_base_head(&base_head)?;
     let (base_commit, head_commit) = resolve_base_head(&repository, &base, &head)?;
@@ -147,16 +142,9 @@ pub async fn dir_tree(
     let base_commit = base_commit.ok_or(OxenError::revision_not_found(base.into()))?;
     let head_commit = head_commit.ok_or(OxenError::revision_not_found(head.into()))?;
 
-    let page = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
-    let page_size = query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);
+    let dir_diffs = api::local::diff::list_changed_dirs(&repository, &base_commit, &head_commit)?;
 
-    let dir_diff_tree = api::local::diff::get_changed_dirs_tree(
-        &repository,
-        &base_commit,
-        &head_commit,
-        page,
-        page_size,
-    )?;
+    let dir_diff_tree = group_dir_diffs_by_dir(dir_diffs);
 
     let response = DirTreeDiffResponse {
         dirs: dir_diff_tree,
@@ -727,6 +715,60 @@ fn get_targets_from_req(targets: Vec<TabularCompareTargetBody>) -> Vec<String> {
         }
     }
     out_targets
+}
+
+fn group_dir_diffs_by_dir(dir_diffs: Vec<(PathBuf, DiffEntryStatus)>) -> Vec<DirDiffTreeSummary> {
+    // For attaching status to parent in response
+    let mut dir_status_map: HashMap<PathBuf, DiffEntryStatus> = HashMap::new();
+    for (dir, status) in dir_diffs.iter() {
+        dir_status_map.insert(dir.clone(), status.clone());
+    }
+    // Group by parent
+    let mut dir_parent_map: HashMap<PathBuf, Vec<DirDiffStatus>> = HashMap::new();
+    for (dir, status) in dir_diffs {
+        // Only root has no parent
+        if dir == Path::new("") {
+            continue;
+        }
+        let parent = dir.parent().unwrap_or(Path::new(""));
+        let parent = parent.to_path_buf();
+        if !dir_parent_map.contains_key(&parent) {
+            dir_parent_map.insert(parent.clone(), vec![]);
+        }
+        dir_parent_map
+            .get_mut(&parent)
+            .unwrap()
+            .push(DirDiffStatus {
+                name: dir.clone(),
+                status,
+            });
+    }
+
+    // If we're over the entity display limit (defaults to 10), only send back 10
+    let mut dir_tree: Vec<DirDiffTreeSummary> = vec![];
+    for (dir, entries) in dir_parent_map {
+        let num_subdirs = entries.len();
+        let can_display = num_subdirs > constants::MAX_DISPLAY_DIRS;
+        let status = dir_status_map
+            .get(&dir)
+            .unwrap_or(&DiffEntryStatus::Modified)
+            .clone();
+        let cropped_entries = if can_display {
+            entries[..constants::MAX_DISPLAY_DIRS].to_vec()
+        } else {
+            entries
+        };
+        let summary = DirDiffTreeSummary {
+            name: dir.clone(),
+            status,
+            num_subdirs,
+            can_display,
+            children: cropped_entries,
+        };
+        dir_tree.push(summary);
+    }
+
+    dir_tree
 }
 
 #[cfg(test)]

--- a/src/server/src/params.rs
+++ b/src/server/src/params.rs
@@ -126,7 +126,6 @@ pub fn resolve_branch(repo: &LocalRepository, name: &str) -> Result<Option<Branc
 }
 
 fn user_cli_is_out_of_date(user_agent: &str) -> bool {
-    log::debug!("Here's user agent {:?}", user_agent);
     // check if the user agent contains oxen
     if !user_agent.to_lowercase().contains("oxen") {
         // Not an oxen user agent

--- a/src/server/src/params.rs
+++ b/src/server/src/params.rs
@@ -126,6 +126,7 @@ pub fn resolve_branch(repo: &LocalRepository, name: &str) -> Result<Option<Branc
 }
 
 fn user_cli_is_out_of_date(user_agent: &str) -> bool {
+    log::debug!("Here's user agent {:?}", user_agent);
     // check if the user agent contains oxen
     if !user_agent.to_lowercase().contains("oxen") {
         // Not an oxen user agent

--- a/src/server/src/routes.rs
+++ b/src/server/src/routes.rs
@@ -151,6 +151,10 @@ pub fn config(cfg: &mut web::ServiceConfig) {
             web::get().to(controllers::compare::commits),
         )
         .route(
+            "/{namespace}/{repo_name}/compare/dir_tree/{base_head:.*}",
+            web::get().to(controllers::compare::dir_tree),
+        )
+        .route(
             "/{namespace}/{repo_name}/compare/entries/{base_head:.*}/dir/{dir:.*}",
             web::get().to(controllers::compare::dir_entries),
         )


### PR DESCRIPTION
Route: 

/api/repos/:namespace/:repo/compare/dir_tree/:basehead (hub or server)

Example: in postman at: OxenHub API > Diffs > Get Directory Diff Tree