### PR TITLE
Fix dir sizes bug

### DIFF
--- a/src/lib/src/api/local/entries.rs
+++ b/src/lib/src/api/local/entries.rs
@@ -80,11 +80,6 @@ pub fn meta_entry_from_dir(
     let latest_commit_path =
         core::cache::cachers::repo_size::dir_latest_commit_path(repo, commit, path);
 
-    log::debug!(
-        "latest_commit_path is at {:?}",
-        latest_commit_path.display()
-    );
-
     let latest_commit = match util::fs::read_from_path(latest_commit_path) {
         Ok(id) => commit_reader.get_commit_by_id(id)?,
         Err(_) => {
@@ -93,17 +88,12 @@ pub fn meta_entry_from_dir(
     };
 
     let total_size_path = core::cache::cachers::repo_size::dir_size_path(repo, commit, path);
-    log::debug!("total_size_path is at {:?}", total_size_path.display());
     let total_size = match util::fs::read_from_path(total_size_path) {
-        Ok(total_size_str) => {
-            log::debug!("cache hit for dir size at path");
-            total_size_str
-                .parse::<u64>()
-                .map_err(|_| OxenError::basic_str("Could not get cached total size of dir"))?
-        }
+        Ok(total_size_str) => total_size_str
+            .parse::<u64>()
+            .map_err(|_| OxenError::basic_str("Could not get cached total size of dir"))?,
         Err(_) => {
             // cache failed, go compute it
-            log::debug!("cache miss for dir size");
             compute_dir_size(repo, object_reader.clone(), commit, path)?
         }
     };
@@ -377,7 +367,6 @@ pub fn list_directory(
     }
 
     let metadata = get_dir_entry_metadata(repo, commit, directory)?;
-    log::debug!("dir metadata is {:?}", metadata);
     let dir = meta_entry_from_dir(
         repo,
         object_reader,
@@ -386,7 +375,6 @@ pub fn list_directory(
         &commit_reader,
         revision,
     )?;
-    log::debug!("dir is {:?}", dir);
 
     Ok((
         PaginatedDirEntries {

--- a/src/lib/src/api/local/entries.rs
+++ b/src/lib/src/api/local/entries.rs
@@ -80,6 +80,11 @@ pub fn meta_entry_from_dir(
     let latest_commit_path =
         core::cache::cachers::repo_size::dir_latest_commit_path(repo, commit, path);
 
+    log::debug!(
+        "latest_commit_path is at {:?}",
+        latest_commit_path.display()
+    );
+
     let latest_commit = match util::fs::read_from_path(latest_commit_path) {
         Ok(id) => commit_reader.get_commit_by_id(id)?,
         Err(_) => {
@@ -88,12 +93,17 @@ pub fn meta_entry_from_dir(
     };
 
     let total_size_path = core::cache::cachers::repo_size::dir_size_path(repo, commit, path);
+    log::debug!("total_size_path is at {:?}", total_size_path.display());
     let total_size = match util::fs::read_from_path(total_size_path) {
-        Ok(total_size_str) => total_size_str
-            .parse::<u64>()
-            .map_err(|_| OxenError::basic_str("Could not get cached total size of dir"))?,
+        Ok(total_size_str) => {
+            log::debug!("cache hit for dir size at path");
+            total_size_str
+                .parse::<u64>()
+                .map_err(|_| OxenError::basic_str("Could not get cached total size of dir"))?
+        }
         Err(_) => {
             // cache failed, go compute it
+            log::debug!("cache miss for dir size");
             compute_dir_size(repo, object_reader.clone(), commit, path)?
         }
     };
@@ -367,6 +377,7 @@ pub fn list_directory(
     }
 
     let metadata = get_dir_entry_metadata(repo, commit, directory)?;
+    log::debug!("dir metadata is {:?}", metadata);
     let dir = meta_entry_from_dir(
         repo,
         object_reader,
@@ -375,6 +386,7 @@ pub fn list_directory(
         &commit_reader,
         revision,
     )?;
+    log::debug!("dir is {:?}", dir);
 
     Ok((
         PaginatedDirEntries {

--- a/src/lib/src/core/cache/cachers/repo_size.rs
+++ b/src/lib/src/core/cache/cachers/repo_size.rs
@@ -62,7 +62,7 @@ pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError>
     let object_reader = ObjectDBReader::new(repo)?;
 
     for dir in dirs {
-        log::debug!("REPO_SIZE PROCESSING DIR {dir:?}");
+        // log::debug!("REPO_SIZE PROCESSING DIR {dir:?}");
 
         // Start with the size of all the entries in this dir
         let entries = {
@@ -124,7 +124,6 @@ pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError>
         // Recursively compute the size of the directory children
         let children = reader.list_dir_children(&dir)?;
 
-        log::debug!("got dir children {:#?} for dir {:?}", children, dir);
         for child in children {
             // log::debug!("REPO_SIZE PROCESSING CHILD {child:?}");
 
@@ -142,8 +141,6 @@ pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError>
             }
 
             let size = api::local::entries::compute_entries_size(&entries)?;
-
-            log::debug!("Size of child {:?} is {} for dir {:?}", child, size, dir);
 
             total_size += size;
 

--- a/src/lib/src/core/cache/cachers/repo_size.rs
+++ b/src/lib/src/core/cache/cachers/repo_size.rs
@@ -62,7 +62,7 @@ pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError>
     let object_reader = ObjectDBReader::new(repo)?;
 
     for dir in dirs {
-        // log::debug!("REPO_SIZE PROCESSING DIR {dir:?}");
+        log::debug!("REPO_SIZE PROCESSING DIR {dir:?}");
 
         // Start with the size of all the entries in this dir
         let entries = {
@@ -123,6 +123,8 @@ pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError>
 
         // Recursively compute the size of the directory children
         let children = reader.list_dir_children(&dir)?;
+
+        log::debug!("got dir children {:#?} for dir {:?}", children, dir);
         for child in children {
             // log::debug!("REPO_SIZE PROCESSING CHILD {child:?}");
 
@@ -140,6 +142,8 @@ pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError>
             }
 
             let size = api::local::entries::compute_entries_size(&entries)?;
+
+            log::debug!("Size of child {:?} is {} for dir {:?}", child, size, dir);
 
             total_size += size;
 

--- a/src/lib/src/core/index/commit_entry_reader.rs
+++ b/src/lib/src/core/index/commit_entry_reader.rs
@@ -115,7 +115,10 @@ impl CommitEntryReader {
         let path = path.as_ref();
         let parents = path_db::list_paths(&self.dir_db, Path::new(""))?
             .into_iter()
-            .filter(|dir| path == Path::new("") || (dir.starts_with(path) && dir != path))
+            .filter(|dir| {
+                (path == Path::new("") && dir != Path::new(""))
+                    || (dir.starts_with(path) && dir != path)
+            })
             .collect();
         Ok(parents)
     }


### PR DESCRIPTION
`CommitEntryReader::list_dir_children` was errantly listing root as a child of root - so any top-level files were getting double-counted, leading to the 1.0-2.0x inflation of repo size on this screen 

![Screenshot 2024-02-29 at 9 50 53 AM](https://github.com/Oxen-AI/Oxen/assets/49073323/d1fb93fe-0391-4d23-a539-aee9b1de9af0)
