### PR TITLE
Repo counts fix part 2 (remote staging)

### DIFF
--- a/src/lib/src/api/remote/staging/commit.rs
+++ b/src/lib/src/api/remote/staging/commit.rs
@@ -35,6 +35,7 @@ pub async fn commit(
                 is_head: false
             };
             api::remote::commits::post_push_complete(remote_repo, &branch, &commit.id).await?;
+            api::remote::repositories::post_push(remote_repo, &branch, &commit.id).await?;
             Ok(commit)
         },
         Err(err) => Err(OxenError::basic_str(format!(


### PR DESCRIPTION
Previously, we were just calling `post push complete` - which verifies commits on the server - and not `post-push`, which triggers the post-push hub actions, so the cache for remote commits wasn't getting updated. Added!