### PR TITLE
Fix out of memory error for big tabular diffs + add `self` node for dir diff summaries

### DIFF
--- a/src/lib/src/api/local/diff.rs
+++ b/src/lib/src/api/local/diff.rs
@@ -654,16 +654,32 @@ pub fn list_diff_entries_in_dir(
         &mut dir_entries,
     )?;
 
+    log::debug!("here are our dir diff entries: {:?}", dir_entries);
+
     dir_entries.sort_by(|a, b| a.filename.cmp(&b.filename));
 
     let mut added_commit_entries: Vec<DiffCommitEntry> = vec![];
+    log::debug!("about to collect added entries");
     collect_added_entries(&base_entries, &head_entries, &mut added_commit_entries)?;
+    log::debug!(
+        "collected added entries and they are {:?}",
+        added_commit_entries
+    );
 
     let mut removed_commit_entries: Vec<DiffCommitEntry> = vec![];
     collect_removed_entries(&base_entries, &head_entries, &mut removed_commit_entries)?;
+    log::debug!(
+        "collected removed entries and they are {:?}",
+        removed_commit_entries
+    );
 
     let mut modified_commit_entries: Vec<DiffCommitEntry> = vec![];
     collect_modified_entries(&base_entries, &head_entries, &mut modified_commit_entries)?;
+
+    log::debug!(
+        "collected modified entries and they are {:?}",
+        modified_commit_entries
+    );
 
     let counts = AddRemoveModifyCounts {
         added: added_commit_entries.len(),
@@ -685,6 +701,7 @@ pub fn list_diff_entries_in_dir(
     let diff_entries: Vec<DiffEntry> = files
         .into_iter()
         .map(|entry| {
+            log::debug!("calling from_commit_entry for entry: {:?}", entry);
             DiffEntry::from_commit_entry(
                 repo,
                 entry.base_entry,

--- a/src/lib/src/api/local/diff.rs
+++ b/src/lib/src/api/local/diff.rs
@@ -595,7 +595,7 @@ pub fn diff_entries(
         status,
         should_do_full_diff,
         Some(df_opts),
-    );
+    )?;
 
     Ok(entry)
 }
@@ -696,7 +696,7 @@ pub fn list_diff_entries_in_dir(
                 None,
             )
         })
-        .collect();
+        .collect::<Result<Vec<DiffEntry>, OxenError>>()?;
 
     let (dirs, _) =
         util::paginate::paginate_dirs_assuming_files(&dir_entries, combined.len(), page, page_size);
@@ -979,7 +979,7 @@ pub fn list_diff_entries(
                 None,
             )
         })
-        .collect();
+        .collect::<Result<Vec<DiffEntry>, OxenError>>()?;
 
     let (dirs, _) =
         util::paginate::paginate_dirs_assuming_files(&dir_entries, combined.len(), page, page_size);

--- a/src/lib/src/api/local/entries.rs
+++ b/src/lib/src/api/local/entries.rs
@@ -422,7 +422,7 @@ pub fn get_dir_entry_metadata(
             .into_no_null_iter()
             .collect();
 
-        let mut data_types: Vec<DataTypeCount> = dt_series
+        let data_types: Vec<DataTypeCount> = dt_series
             .iter()
             .zip(count_series.iter())
             .map(|(&data_type, &count)| DataTypeCount {

--- a/src/lib/src/api/local/entries.rs
+++ b/src/lib/src/api/local/entries.rs
@@ -405,8 +405,8 @@ pub fn get_dir_entry_metadata(
         "list_directory reading data types from {}",
         data_types_path.display()
     );
+
     if let Ok(data_type_df) = core::df::tabular::read_df(&data_types_path, DFOpts::empty()) {
-        log::debug!("got this data_type_df {:?}", data_type_df);
         let dt_series: Vec<&str> = data_type_df
             .column("data_type")
             .unwrap()
@@ -422,7 +422,7 @@ pub fn get_dir_entry_metadata(
             .into_no_null_iter()
             .collect();
 
-        let data_types: Vec<DataTypeCount> = dt_series
+        let mut data_types: Vec<DataTypeCount> = dt_series
             .iter()
             .zip(count_series.iter())
             .map(|(&data_type, &count)| DataTypeCount {

--- a/src/lib/src/api/local/entries.rs
+++ b/src/lib/src/api/local/entries.rs
@@ -406,6 +406,7 @@ pub fn get_dir_entry_metadata(
         data_types_path.display()
     );
     if let Ok(data_type_df) = core::df::tabular::read_df(&data_types_path, DFOpts::empty()) {
+        log::debug!("got this data_type_df {:?}", data_type_df);
         let dt_series: Vec<&str> = data_type_df
             .column("data_type")
             .unwrap()

--- a/src/lib/src/api/local/metadata.rs
+++ b/src/lib/src/api/local/metadata.rs
@@ -71,23 +71,16 @@ pub fn from_commit_entry(
     entry: &CommitEntry,
     commit: &Commit,
 ) -> Result<MetadataEntry, OxenError> {
-    log::debug!("in from_commit_entry");
     let path = util::fs::version_path(repo, entry);
     let base_name = entry
         .path
         .file_name()
         .ok_or(OxenError::file_has_no_name(&path))?;
-    log::debug!("getting file size");
     let size = get_file_size(&path)?;
-    log::debug!("getting mime type");
     let mime_type = util::fs::file_mime_type(&path);
-    log::debug!("getting data type");
     let data_type = util::fs::datatype_from_mimetype(&path, mime_type.as_str());
-    log::debug!("getting data extension");
     let extension = util::fs::file_extension(&path);
-    log::debug!("getting metadata");
     let metadata = get_file_metadata(&path, &data_type)?;
-    log::debug!("got metadata");
 
     Ok(MetadataEntry {
         filename: base_name.to_string_lossy().to_string(),

--- a/src/lib/src/api/local/metadata.rs
+++ b/src/lib/src/api/local/metadata.rs
@@ -71,16 +71,23 @@ pub fn from_commit_entry(
     entry: &CommitEntry,
     commit: &Commit,
 ) -> Result<MetadataEntry, OxenError> {
+    log::debug!("in from_commit_entry");
     let path = util::fs::version_path(repo, entry);
     let base_name = entry
         .path
         .file_name()
         .ok_or(OxenError::file_has_no_name(&path))?;
+    log::debug!("getting file size");
     let size = get_file_size(&path)?;
+    log::debug!("getting mime type");
     let mime_type = util::fs::file_mime_type(&path);
+    log::debug!("getting data type");
     let data_type = util::fs::datatype_from_mimetype(&path, mime_type.as_str());
+    log::debug!("getting data extension");
     let extension = util::fs::file_extension(&path);
+    log::debug!("getting metadata");
     let metadata = get_file_metadata(&path, &data_type)?;
+    log::debug!("got metadata");
 
     Ok(MetadataEntry {
         filename: base_name.to_string_lossy().to_string(),

--- a/src/lib/src/api/local/metadata/tabular.rs
+++ b/src/lib/src/api/local/metadata/tabular.rs
@@ -11,9 +11,10 @@ use std::path::Path;
 /// Detects the tabular metadata for the given file.
 pub fn get_metadata(path: impl AsRef<Path>) -> Result<MetadataTabular, OxenError> {
     let path = path.as_ref();
-    let opts = DFOpts::empty();
-    let df = tabular::read_df(path, opts)?;
-    Ok(MetadataTabular::new(df.width(), df.height()))
+    log::debug!("getting df size for {:?}", path);
+    let size = tabular::get_size(path)?;
+    log::debug!("got df size {:?}", size);
+    Ok(MetadataTabular::new(size.width, size.height))
 }
 
 #[cfg(test)]

--- a/src/lib/src/api/local/metadata/tabular.rs
+++ b/src/lib/src/api/local/metadata/tabular.rs
@@ -4,7 +4,6 @@
 use crate::core::df::tabular;
 use crate::error::OxenError;
 use crate::model::metadata::MetadataTabular;
-use crate::opts::DFOpts;
 
 use std::path::Path;
 

--- a/src/lib/src/api/local/metadata/tabular.rs
+++ b/src/lib/src/api/local/metadata/tabular.rs
@@ -11,9 +11,7 @@ use std::path::Path;
 /// Detects the tabular metadata for the given file.
 pub fn get_metadata(path: impl AsRef<Path>) -> Result<MetadataTabular, OxenError> {
     let path = path.as_ref();
-    log::debug!("getting df size for {:?}", path);
     let size = tabular::get_size(path)?;
-    log::debug!("got df size {:?}", size);
     Ok(MetadataTabular::new(size.width, size.height))
 }
 

--- a/src/lib/src/model/diff/diff_entry.rs
+++ b/src/lib/src/model/diff/diff_entry.rs
@@ -369,8 +369,6 @@ impl DiffEntry {
             }
         }
 
-        let data_type_counts = find_data_type_differences(Some(base_dir), Some(head_dir));
-
         Ok(Some(GenericDiffSummary::DirDiffSummary(DirDiffSummary {
             dir: DirDiffSummaryImpl {
                 file_counts: AddRemoveModifyCounts {
@@ -378,7 +376,6 @@ impl DiffEntry {
                     removed: num_removed,
                     modified: num_modified,
                 },
-                data_type_counts: Some(data_type_counts),
             },
         })))
     }
@@ -412,8 +409,6 @@ impl DiffEntry {
             num_removed += count;
         }
 
-        let data_type_counts = find_data_type_differences(Some(base_dir), None);
-
         Ok(Some(GenericDiffSummary::DirDiffSummary(DirDiffSummary {
             dir: DirDiffSummaryImpl {
                 file_counts: AddRemoveModifyCounts {
@@ -421,7 +416,6 @@ impl DiffEntry {
                     removed: num_removed,
                     modified: 0,
                 },
-                data_type_counts: Some(data_type_counts), // TODO: add data type counts diff
             },
         })))
     }
@@ -455,8 +449,6 @@ impl DiffEntry {
             num_added += count;
         }
 
-        let data_type_counts = find_data_type_differences(None, Some(head_dir));
-
         Ok(Some(GenericDiffSummary::DirDiffSummary(DirDiffSummary {
             dir: DirDiffSummaryImpl {
                 file_counts: AddRemoveModifyCounts {
@@ -464,7 +456,6 @@ impl DiffEntry {
                     removed: 0,
                     modified: 0,
                 },
-                data_type_counts: Some(data_type_counts), // TODO: add data type counts diff
             },
         })))
     }

--- a/src/lib/src/model/diff/diff_entry.rs
+++ b/src/lib/src/model/diff/diff_entry.rs
@@ -134,25 +134,15 @@ impl DiffEntry {
             )
         };
 
-        log::debug!("trying to infer datatype");
         let data_type = util::fs::file_data_type(&version_path);
-        log::debug!("got data type {:?}", data_type);
 
         let base_resource = DiffEntry::resource_from_entry(base_entry.clone());
         let head_resource = DiffEntry::resource_from_entry(head_entry.clone());
 
-        log::debug!(
-            "got resource versions {:?} and {:?}",
-            base_resource,
-            head_resource
-        );
-
         let mut base_meta_entry =
             MetadataEntry::from_commit_entry(repo, base_entry.clone(), base_commit);
-        log::debug!("got base entry {:?}", base_meta_entry);
         let mut head_meta_entry =
             MetadataEntry::from_commit_entry(repo, head_entry.clone(), head_commit);
-        log::debug!("got head entry {:?}", head_meta_entry);
 
         if base_entry.is_some() {
             base_meta_entry.as_mut().unwrap().resource = base_resource.clone();
@@ -172,8 +162,6 @@ impl DiffEntry {
         //     pagination.is_some()
         // );
 
-        log::debug!("df_opts: {:?}", df_opts);
-        log::debug!("should_do_full_diff {}", should_do_full_diff);
         if let Some(df_opts) = df_opts {
             if data_type == EntryDataType::Tabular && should_do_full_diff {
                 let diff =
@@ -293,12 +281,6 @@ impl DiffEntry {
         let base_commit_id = &base_dir.latest_commit.as_ref().unwrap().id;
         let head_commit_id = &head_dir.latest_commit.as_ref().unwrap().id;
 
-        log::debug!(
-            "in all files we have base_dir: {:?} and head_dir {:?}",
-            base_dir,
-            head_dir
-        );
-
         // base and head path will be the same so just choose base
         let path = PathBuf::from(&base_dir.resource.clone().unwrap().path);
 
@@ -380,17 +362,12 @@ impl DiffEntry {
     ) -> Result<Option<GenericDiffSummary>, OxenError> {
         let commit_id = &base_dir.latest_commit.as_ref().unwrap().id;
         let path = PathBuf::from(&base_dir.resource.clone().unwrap().path);
-        log::debug!("r_compute_removed_files base_dir: {:?}", path);
-
-        log::debug!("in removed files we have base_dir: {:?}", base_dir);
 
         // Count all removals in the directory and its children
         let commit_entry_reader =
             CommitEntryReader::new_from_commit_id(repo, commit_id, object_reader.clone())?;
         let mut dirs = commit_entry_reader.list_dir_children(&path)?;
         dirs.push(path);
-
-        log::debug!("r_compute_removed_files got dirs: {:?}", dirs.len());
 
         let mut num_removed = 0;
         for dir in dirs {
@@ -421,8 +398,6 @@ impl DiffEntry {
         let commit_id = &head_dir.latest_commit.as_ref().unwrap().id;
         let path = PathBuf::from(&head_dir.resource.clone().unwrap().path);
         log::debug!("r_compute_added_files base_dir: {:?}", path);
-
-        log::debug!("in added files we have head_dir {:?}", head_dir);
 
         // Count all removals in the directory and its children
         let commit_entry_reader =
@@ -460,7 +435,6 @@ impl DiffEntry {
         head_entry: &Option<CommitEntry>,
     ) -> Result<Option<GenericDiffSummary>, OxenError> {
         // TODO match on type, and create the appropriate summary
-        log::debug!("getting diff summary from file");
         match data_type {
             EntryDataType::Tabular => Ok(Some(GenericDiffSummary::TabularDiffWrapper(
                 TabularDiffWrapper::from_commit_entries(repo, base_entry, head_entry)?,

--- a/src/lib/src/model/diff/dir_diff_summary.rs
+++ b/src/lib/src/model/diff/dir_diff_summary.rs
@@ -16,7 +16,6 @@ pub struct DirDiffSummary {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct DirDiffSummaryImpl {
     pub file_counts: AddRemoveModifyCounts,
-    pub data_type_counts: Option<AddRemoveDataTypeCounts>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/src/lib/src/model/diff/dir_diff_summary.rs
+++ b/src/lib/src/model/diff/dir_diff_summary.rs
@@ -1,6 +1,11 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
-use crate::model::diff::AddRemoveModifyCounts;
+use crate::{
+    model::{diff::AddRemoveModifyCounts, EntryDataType},
+    view::DataTypeCount,
+};
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct DirDiffSummary {
@@ -11,4 +16,11 @@ pub struct DirDiffSummary {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct DirDiffSummaryImpl {
     pub file_counts: AddRemoveModifyCounts,
+    pub data_type_counts: Option<AddRemoveDataTypeCounts>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct AddRemoveDataTypeCounts {
+    pub added: Vec<DataTypeCount>,
+    pub removed: Vec<DataTypeCount>,
 }

--- a/src/lib/src/model/diff/dir_diff_summary.rs
+++ b/src/lib/src/model/diff/dir_diff_summary.rs
@@ -1,11 +1,6 @@
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    model::{diff::AddRemoveModifyCounts, EntryDataType},
-    view::DataTypeCount,
-};
+use crate::{model::diff::AddRemoveModifyCounts, view::DataTypeCount};
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct DirDiffSummary {

--- a/src/lib/src/model/diff/tabular_diff_summary.rs
+++ b/src/lib/src/model/diff/tabular_diff_summary.rs
@@ -1,7 +1,6 @@
 use polars::prelude::DataFrame;
 use serde::{Deserialize, Serialize};
 
-use crate::api;
 use crate::core::df::tabular;
 use crate::model::{CommitEntry, DataFrameSize, LocalRepository};
 use crate::opts::DFOpts;
@@ -77,7 +76,7 @@ impl TabularDiffWrapper {
                     0
                 };
 
-                return TabularDiffWrapper {
+                TabularDiffWrapper {
                     tabular: TabularDiffSummaryImpl {
                         num_added_rows,
                         num_added_cols,
@@ -85,13 +84,13 @@ impl TabularDiffWrapper {
                         num_removed_cols,
                         schema_has_changed,
                     },
-                };
+                }
             }
             (Some(base_entry), None) => {
                 let base_version_file = util::fs::version_path(repo, base_entry);
                 let base_size = tabular::get_size(base_version_file).unwrap();
 
-                return TabularDiffWrapper {
+                TabularDiffWrapper {
                     tabular: TabularDiffSummaryImpl {
                         num_added_rows: 0,
                         num_added_cols: 0,
@@ -99,14 +98,14 @@ impl TabularDiffWrapper {
                         num_removed_cols: base_size.width,
                         schema_has_changed: false,
                     },
-                };
+                }
             }
 
             (None, Some(head_entry)) => {
                 let head_version_file = util::fs::version_path(repo, head_entry);
                 let head_size = tabular::get_size(head_version_file).unwrap();
 
-                return TabularDiffWrapper {
+                TabularDiffWrapper {
                     tabular: TabularDiffSummaryImpl {
                         num_added_rows: head_size.height,
                         num_added_cols: head_size.width,
@@ -114,20 +113,18 @@ impl TabularDiffWrapper {
                         num_removed_cols: 0,
                         schema_has_changed: false,
                     },
-                };
+                }
             }
 
-            (None, None) => {
-                return TabularDiffWrapper {
-                    tabular: TabularDiffSummaryImpl {
-                        num_added_rows: 0,
-                        num_added_cols: 0,
-                        num_removed_rows: 0,
-                        num_removed_cols: 0,
-                        schema_has_changed: false,
-                    },
-                };
-            }
+            (None, None) => TabularDiffWrapper {
+                tabular: TabularDiffSummaryImpl {
+                    num_added_rows: 0,
+                    num_added_cols: 0,
+                    num_removed_rows: 0,
+                    num_removed_cols: 0,
+                    schema_has_changed: false,
+                },
+            },
         }
     }
 

--- a/src/lib/src/model/diff/tabular_diff_summary.rs
+++ b/src/lib/src/model/diff/tabular_diff_summary.rs
@@ -117,7 +117,20 @@ impl TabularDiffWrapper {
             }
             (Some(base_entry), None) => {
                 let base_version_file = util::fs::version_path(repo, base_entry);
-                let base_size = tabular::get_size(base_version_file).unwrap();
+                let base_commit =
+                    CommitReader::new(repo)?.get_commit_by_id(&base_entry.commit_id)?;
+
+                let base_commit = if let Some(commit) = base_commit {
+                    commit
+                } else {
+                    return Err(OxenError::resource_not_found(base_entry.commit_id.clone()));
+                };
+
+                let base_size = cachers::df_size::get_cache_for_version(
+                    repo,
+                    &base_commit,
+                    &base_version_file,
+                )?;
 
                 Ok(TabularDiffWrapper {
                     tabular: TabularDiffSummaryImpl {
@@ -132,7 +145,21 @@ impl TabularDiffWrapper {
 
             (None, Some(head_entry)) => {
                 let head_version_file = util::fs::version_path(repo, head_entry);
-                let head_size = tabular::get_size(head_version_file).unwrap();
+
+                let head_commit =
+                    CommitReader::new(repo)?.get_commit_by_id(&head_entry.commit_id)?;
+
+                let head_commit = if let Some(commit) = head_commit {
+                    commit
+                } else {
+                    return Err(OxenError::resource_not_found(head_entry.commit_id.clone()));
+                };
+
+                let head_size = cachers::df_size::get_cache_for_version(
+                    repo,
+                    &head_commit,
+                    &head_version_file,
+                )?;
 
                 Ok(TabularDiffWrapper {
                     tabular: TabularDiffSummaryImpl {

--- a/src/lib/src/view/compare.rs
+++ b/src/lib/src/view/compare.rs
@@ -35,6 +35,8 @@ pub struct CompareEntries {
     pub head_commit: Commit,
     pub counts: AddRemoveModifyCounts,
     pub entries: Vec<DiffEntry>,
+    #[serde(rename = "self")]
+    pub self_diff: Option<DiffEntry>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
- Changes df size read from loading full df in memory to reading from cache on DiffEntry construction 
- Refactors DiffEntry constructors to use result to avoid panicking during the above ^ 

- gets the diff summary for the parent directory and (optionally) adds it to the view on the get dir diff call to `/api/repos/:namespace/:repo_name/compare/entries/:basehead/dir/:path