### PR TITLE
Migration: add directory counts to cache

### DIFF
--- a/src/cli/src/cmd_setup.rs
+++ b/src/cli/src/cmd_setup.rs
@@ -1,7 +1,9 @@
+use std::ops::Add;
+
 use clap::{arg, Arg, Command};
 use liboxen::command::migrate::{
-    CacheDataFrameSizeMigration, CreateMerkleTreesMigration, Migrate, PropagateSchemasMigration,
-    UpdateVersionFilesMigration,
+    AddDirectoriesToCacheMigration, CacheDataFrameSizeMigration, CreateMerkleTreesMigration,
+    Migrate, PropagateSchemasMigration, UpdateVersionFilesMigration,
 };
 use liboxen::constants::{DEFAULT_BRANCH_NAME, DEFAULT_REMOTE_NAME};
 
@@ -939,6 +941,24 @@ pub fn migrate() -> Command {
                             .action(clap::ArgAction::SetTrue),
                     ),
                 )
+                .subcommand(
+                    Command::new(AddDirectoriesToCacheMigration.name())
+                    .about("SERVER ONLY: Re-caches past commits to include directories in the cache")
+                    .arg(
+                        Arg::new("PATH")
+                            .help("Directory in which to apply the migration")
+                            .required(true),
+                    )
+                    .arg(
+                        Arg::new("all")
+                            .long("all")
+                            .short('a')
+                            .help(
+                                "Run the migration for all oxen repositories in this directory",
+                            )
+                            .action(clap::ArgAction::SetTrue),
+                    ),
+                )
         )
         .subcommand(
             Command::new("down")
@@ -1001,6 +1021,24 @@ pub fn migrate() -> Command {
                 .subcommand(
                     Command::new(CreateMerkleTreesMigration.name())
                     .about("Reformats the underlying data model into merkle trees for storage and lookup efficiency")
+                    .arg(
+                        Arg::new("PATH")
+                            .help("Directory in which to apply the migration")
+                            .required(true),
+                    )
+                    .arg(
+                        Arg::new("all")
+                            .long("all")
+                            .short('a')
+                            .help(
+                                "Run the migration for all oxen repositories in this directory",
+                            )
+                            .action(clap::ArgAction::SetTrue),
+                    ),
+                )
+                .subcommand(
+                    Command::new(AddDirectoriesToCacheMigration.name())
+                    .about("SERVER ONLY: Re-caches past commits to include directories in the cache")
                     .arg(
                         Arg::new("PATH")
                             .help("Directory in which to apply the migration")

--- a/src/cli/src/cmd_setup.rs
+++ b/src/cli/src/cmd_setup.rs
@@ -1,5 +1,3 @@
-use std::ops::Add;
-
 use clap::{arg, Arg, Command};
 use liboxen::command::migrate::{
     AddDirectoriesToCacheMigration, CacheDataFrameSizeMigration, CreateMerkleTreesMigration,

--- a/src/cli/src/dispatch.rs
+++ b/src/cli/src/dispatch.rs
@@ -1,6 +1,7 @@
 use colored::ColoredString;
 use liboxen::api;
 use liboxen::command;
+use liboxen::command::migrate::AddDirectoriesToCacheMigration;
 use liboxen::command::migrate::CreateMerkleTreesMigration;
 use liboxen::command::migrate::Migrate;
 use liboxen::command::migrate::UpdateVersionFilesMigration;

--- a/src/cli/src/dispatch.rs
+++ b/src/cli/src/dispatch.rs
@@ -1,7 +1,6 @@
 use colored::ColoredString;
 use liboxen::api;
 use liboxen::command;
-use liboxen::command::migrate::AddDirectoriesToCacheMigration;
 use liboxen::command::migrate::CreateMerkleTreesMigration;
 use liboxen::command::migrate::Migrate;
 use liboxen::command::migrate::UpdateVersionFilesMigration;

--- a/src/cli/src/parse_and_run.rs
+++ b/src/cli/src/parse_and_run.rs
@@ -8,8 +8,8 @@ use crate::cmd_setup::{ADD, COMMIT, DF, DIFF, DOWNLOAD, LOG, LS, METADATA, RESTO
 use crate::dispatch;
 use clap::ArgMatches;
 use liboxen::command::migrate::{
-    CacheDataFrameSizeMigration, CreateMerkleTreesMigration, Migrate, PropagateSchemasMigration,
-    UpdateVersionFilesMigration,
+    AddDirectoriesToCacheMigration, CacheDataFrameSizeMigration, CreateMerkleTreesMigration,
+    Migrate, PropagateSchemasMigration, UpdateVersionFilesMigration,
 };
 use liboxen::constants::{DEFAULT_BRANCH_NAME, DEFAULT_HOST, DEFAULT_REMOTE_NAME};
 use liboxen::error::OxenError;
@@ -1107,6 +1107,13 @@ pub async fn migrate(sub_matches: &ArgMatches) {
                     } else if migration == CreateMerkleTreesMigration.name() {
                         if let Err(err) =
                             run_migration(&CreateMerkleTreesMigration, direction, sub_matches)
+                        {
+                            eprintln!("Error running migration: {}", err);
+                            std::process::exit(1);
+                        }
+                    } else if migration == AddDirectoriesToCacheMigration.name() {
+                        if let Err(err) =
+                            run_migration(&AddDirectoriesToCacheMigration, direction, sub_matches)
                         {
                             eprintln!("Error running migration: {}", err);
                             std::process::exit(1);

--- a/src/lib/src/api/remote/metadata.rs
+++ b/src/lib/src/api/remote/metadata.rs
@@ -143,14 +143,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_remote_metadata_table_list_dir() -> Result<(), OxenError> {
-        test::run_training_data_fully_sync_remote(|local_repo, remote_repo| async move {
+        test::run_training_data_fully_sync_remote(|_local_repo, remote_repo| async move {
             let branch = DEFAULT_BRANCH_NAME;
             let directory = Path::new("train");
 
             let meta: JsonDataFrameViewResponse =
                 api::remote::metadata::list_dir(&remote_repo, branch, directory).await?;
 
-            let df = meta.data_frame.view.to_df();
+            let _df = meta.data_frame.view.to_df();
 
             assert_eq!(meta.data_frame.source.size.width, 11);
             assert_eq!(meta.data_frame.source.size.height, 5);

--- a/src/lib/src/api/remote/metadata.rs
+++ b/src/lib/src/api/remote/metadata.rs
@@ -167,10 +167,6 @@ mod tests {
             let directory = Path::new("");
 
             let head = api::local::commits::head_commit(&local_repo)?;
-            let commit_entry_reader = CommitEntryReader::new(&local_repo, &head)?;
-            let all_dirs = commit_entry_reader.list_dirs()?;
-
-            log::debug!("all_dirs: {:#?}", all_dirs);
 
             let meta: JsonDataFrameViewResponse =
                 api::remote::metadata::agg_dir(&remote_repo, branch, directory, "data_type")

--- a/src/lib/src/api/remote/metadata.rs
+++ b/src/lib/src/api/remote/metadata.rs
@@ -166,8 +166,6 @@ mod tests {
             let branch = DEFAULT_BRANCH_NAME;
             let directory = Path::new("");
 
-            let head = api::local::commits::head_commit(&local_repo)?;
-
             let meta: JsonDataFrameViewResponse =
                 api::remote::metadata::agg_dir(&remote_repo, branch, directory, "data_type")
                     .await?;

--- a/src/lib/src/command/migrate.rs
+++ b/src/lib/src/command/migrate.rs
@@ -14,6 +14,9 @@ pub use update_version_files::UpdateVersionFilesMigration;
 pub mod cache_dataframe_size;
 pub use cache_dataframe_size::CacheDataFrameSizeMigration;
 
+pub mod add_directories_to_cache;
+pub use add_directories_to_cache::AddDirectoriesToCacheMigration;
+
 pub trait Migrate {
     fn up(&self, path: &Path, all: bool) -> Result<(), OxenError>;
     fn down(&self, path: &Path, all: bool) -> Result<(), OxenError>;

--- a/src/lib/src/command/migrate/add_directories_to_cache.rs
+++ b/src/lib/src/command/migrate/add_directories_to_cache.rs
@@ -1,0 +1,125 @@
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use jwalk::WalkDir;
+
+use crate::constants;
+use crate::constants::{HASH_FILE, VERSIONS_DIR, VERSION_FILE_NAME};
+
+use crate::core::cache;
+use crate::core::index::{CommitEntryReader, CommitReader};
+use crate::error::OxenError;
+use crate::model::LocalRepository;
+use crate::util::fs::version_dir_from_hash;
+use crate::util::progress_bar::{oxen_progress_bar, ProgressBarType};
+use crate::{api, util};
+
+use super::Migrate;
+
+pub struct AddDirectoriesToCacheMigration;
+impl AddDirectoriesToCacheMigration {}
+
+impl Migrate for AddDirectoriesToCacheMigration {
+    fn name(&self) -> &'static str {
+        "add_directories_to_cache"
+    }
+    fn up(&self, path: &Path, all: bool) -> Result<(), OxenError> {
+        if all {
+            add_directories_to_cache_for_all_repos_up(path)?;
+        } else {
+            let repo = LocalRepository::new(path)?;
+            add_directories_to_cache_up(&repo)?;
+        }
+        Ok(())
+    }
+
+    fn down(&self, path: &Path, all: bool) -> Result<(), OxenError> {
+        if all {
+            add_directories_to_cache_for_all_repos_down(path)?;
+        } else {
+            println!("Running down migration");
+            let repo = LocalRepository::new(path)?;
+            add_directories_to_cache_down(&repo)?;
+        }
+        Ok(())
+    }
+
+    fn is_needed(&self, repo: &LocalRepository) -> Result<bool, OxenError> {
+        // Server migration only, no client-side migration needed
+        Ok(false)
+    }
+}
+
+pub fn add_directories_to_cache_up(repo: &LocalRepository) -> Result<(), OxenError> {
+    let reader = CommitReader::new(repo)?;
+
+    let mut all_commits = reader.list_all()?;
+
+    for commit in all_commits {
+        cache::cachers::repo_size::compute(repo, &commit)?;
+    }
+
+    Ok(())
+}
+
+pub fn add_directories_to_cache_down(repo: &LocalRepository) -> Result<(), OxenError> {
+    println!("Nothing to do here.");
+    Ok(())
+}
+
+pub fn add_directories_to_cache_for_all_repos_down(path: &Path) -> Result<(), OxenError> {
+    let namespaces = api::local::repositories::list_namespaces(path)?;
+    let bar = oxen_progress_bar(namespaces.len() as u64, ProgressBarType::Counter);
+    println!("🐂 Migrating {} namespaces", namespaces.len());
+    for namespace in namespaces {
+        let namespace_path = path.join(namespace);
+        let repos = api::local::repositories::list_repos_in_namespace(&namespace_path);
+        for repo in repos {
+            match add_directories_to_cache_down(&repo) {
+                Ok(_) => {}
+                Err(err) => {
+                    log::error!(
+                        "Could not down-migrate version files for repo {:?}\nErr: {}",
+                        repo.path,
+                        err
+                    )
+                }
+            }
+        }
+        bar.inc(1);
+    }
+
+    Ok(())
+}
+
+pub fn add_directories_to_cache_for_all_repos_up(path: &Path) -> Result<(), OxenError> {
+    println!("🐂 Collecting namespaces to migrate...");
+    let namespaces = api::local::repositories::list_namespaces(path)?;
+    let bar = oxen_progress_bar(namespaces.len() as u64, ProgressBarType::Counter);
+    println!("🐂 Migrating {} namespaces", namespaces.len());
+    for namespace in namespaces {
+        let namespace_path = path.join(namespace);
+        // Show the canonical namespace path
+        log::debug!(
+            "This is the namespace path we're walking: {:?}",
+            namespace_path.canonicalize()?
+        );
+        let repos = api::local::repositories::list_repos_in_namespace(&namespace_path);
+        for repo in repos {
+            match add_directories_to_cache_up(&repo) {
+                Ok(_) => {}
+                Err(err) => {
+                    log::error!(
+                        "Could not migrate version files for repo {:?}\nErr: {}",
+                        repo.path.canonicalize(),
+                        err
+                    )
+                }
+            }
+        }
+        bar.inc(1);
+    }
+
+    Ok(())
+}

--- a/src/lib/src/command/migrate/add_directories_to_cache.rs
+++ b/src/lib/src/command/migrate/add_directories_to_cache.rs
@@ -44,6 +44,10 @@ impl Migrate for AddDirectoriesToCacheMigration {
 }
 
 pub fn add_directories_to_cache_up(repo: &LocalRepository) -> Result<(), OxenError> {
+    // Lock repo, releases when goes out of scope at the end of this
+    let mut lock_file = api::local::repositories::get_lock_file(repo)?;
+    let _mutex = api::local::repositories::get_exclusive_lock(&mut lock_file)?;
+
     let reader = CommitReader::new(repo)?;
 
     let all_commits = reader.list_all()?;
@@ -72,7 +76,7 @@ pub fn add_directories_to_cache_for_all_repos_down(path: &Path) -> Result<(), Ox
                 Ok(_) => {}
                 Err(err) => {
                     log::error!(
-                        "Could not down-migrate version files for repo {:?}\nErr: {}",
+                        "Could not down-migrate cache files for repo {:?}\nErr: {}",
                         repo.path,
                         err
                     )
@@ -105,7 +109,7 @@ pub fn add_directories_to_cache_for_all_repos_up(path: &Path) -> Result<(), Oxen
                 Ok(_) => {}
                 Err(err) => {
                     log::error!(
-                        "Could not migrate version files for repo {:?}\nErr: {}",
+                        "Could not migrate directory cache for repo {:?}\nErr: {}",
                         repo.path.canonicalize(),
                         err
                     )

--- a/src/lib/src/command/migrate/add_directories_to_cache.rs
+++ b/src/lib/src/command/migrate/add_directories_to_cache.rs
@@ -50,7 +50,9 @@ pub fn add_directories_to_cache_up(repo: &LocalRepository) -> Result<(), OxenErr
 
     let reader = CommitReader::new(repo)?;
 
-    let all_commits = reader.list_all()?;
+    let mut all_commits = reader.list_all()?;
+
+    all_commits.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
 
     for commit in all_commits {
         cache::cachers::content_stats::compute(repo, &commit)?;
@@ -64,28 +66,8 @@ pub fn add_directories_to_cache_down(_repo: &LocalRepository) -> Result<(), Oxen
     Ok(())
 }
 
-pub fn add_directories_to_cache_for_all_repos_down(path: &Path) -> Result<(), OxenError> {
-    let namespaces = api::local::repositories::list_namespaces(path)?;
-    let bar = oxen_progress_bar(namespaces.len() as u64, ProgressBarType::Counter);
-    println!("🐂 Migrating {} namespaces", namespaces.len());
-    for namespace in namespaces {
-        let namespace_path = path.join(namespace);
-        let repos = api::local::repositories::list_repos_in_namespace(&namespace_path);
-        for repo in repos {
-            match add_directories_to_cache_down(&repo) {
-                Ok(_) => {}
-                Err(err) => {
-                    log::error!(
-                        "Could not down-migrate cache files for repo {:?}\nErr: {}",
-                        repo.path,
-                        err
-                    )
-                }
-            }
-        }
-        bar.inc(1);
-    }
-
+pub fn add_directories_to_cache_for_all_repos_down(_path: &Path) -> Result<(), OxenError> {
+    println!("Nothing to do here.");
     Ok(())
 }
 

--- a/src/lib/src/core/cache/cachers/content_stats.rs
+++ b/src/lib/src/core/cache/cachers/content_stats.rs
@@ -36,6 +36,25 @@ pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError>
     // that we can serve up.
     let reader = CommitEntryReader::new(repo, commit)?;
     let dirs = reader.list_dirs()?;
+
+    // // Get a count of all descendent dirs of each dir
+    // let mut tree = HashMap::new();
+    // for dir in dirs {
+    //     let components: Vec<&str> = dir.split('/').collect();
+    //     let mut current_path = String::new();
+    //     for (i, component) in components.iter().enumerate() {
+    //         if i > 0 {
+    //             current_path.push('/');
+    //         }
+    //         current_path.push_str(component);
+    //         if i < components.len() - 1 {
+    //             tree.entry(current_path.clone())
+    //                 .or_insert_with(Vec::new)
+    //                 .push(format!("{}/{}", current_path, components[i + 1]));
+    //         }
+    //     }
+    // }
+
     log::debug!("Computing size of {} dirs", dirs.len());
     let columns = ["data_type", "mime_type"];
     for dir in dirs {
@@ -46,8 +65,6 @@ pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError>
             if let Some(parent) = path.parent() {
                 std::fs::create_dir_all(parent)?;
             }
-            log::debug!("Writing cached df {} to {}", column, path.display());
-            // log::debug!("df {}", df);
             tabular::write_df(&mut df, &path)?;
         }
     }

--- a/src/lib/src/core/index/commit_metadata_db.rs
+++ b/src/lib/src/core/index/commit_metadata_db.rs
@@ -295,10 +295,6 @@ mod tests {
 
             let directory = PathBuf::from("");
 
-            let commit_entry_reader = CommitEntryReader::new(&repo, &commit)?;
-            let dirs = commit_entry_reader.list_dirs()?;
-            log::debug!("all_dirs: {:?}", dirs);
-
             let df = commit_metadata_db::aggregate_col(&repo, &commit, directory, "data_type")?;
 
             let df_str = format!("{:?}", df);

--- a/src/lib/src/core/index/commit_metadata_db.rs
+++ b/src/lib/src/core/index/commit_metadata_db.rs
@@ -70,7 +70,7 @@ pub fn index_commit(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenE
 
     let metas = meta_entries
         .into_iter()
-        .chain(meta_dirs.into_iter())
+        .chain(meta_dirs)
         .collect::<Vec<_>>();
 
     bar.finish();
@@ -261,7 +261,7 @@ pub fn full_size(
 mod tests {
     use std::path::PathBuf;
 
-    use crate::core::index::{commit_metadata_db, CommitEntryReader};
+    use crate::core::index::commit_metadata_db;
     use crate::error::OxenError;
     use crate::test;
     use crate::{api, command, util};

--- a/src/lib/src/core/index/commit_metadata_db.rs
+++ b/src/lib/src/core/index/commit_metadata_db.rs
@@ -40,6 +40,7 @@ pub fn index_commit(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenE
 
     let entry_reader = CommitEntryReader::new(repo, commit)?;
     let entries = entry_reader.list_entries()?;
+    let dirs = entry_reader.list_dirs()?;
 
     let commit_reader = CommitReader::new(repo)?;
     let num_entries = entries.len();
@@ -48,13 +49,28 @@ pub fn index_commit(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenE
     log::debug!("compute metadata for {num_entries} entries in commit: {commit:?}");
 
     // Compute the metadata in parallel
-    let metas = entries
+    let meta_entries = entries
         .par_iter()
         .map(|entry| {
             // Takes some time to compute from_entry
             bar.inc(1);
             DirMetadataItem::from_entry(repo, entry, &commit_reader)
         })
+        .collect::<Vec<_>>();
+
+    // Gather dirs, except root to avoid double counting
+    let meta_dirs = dirs
+        .par_iter()
+        .filter(|dir| *dir != &PathBuf::from(""))
+        .map(|dir| {
+            // Takes some time to compute from_dir
+            DirMetadataItem::from_dir(repo, dir, commit, &commit_reader)
+        })
+        .collect::<Vec<_>>();
+
+    let metas = meta_entries
+        .into_iter()
+        .chain(meta_dirs.into_iter())
         .collect::<Vec<_>>();
 
     bar.finish();
@@ -245,7 +261,7 @@ pub fn full_size(
 mod tests {
     use std::path::PathBuf;
 
-    use crate::core::index::commit_metadata_db;
+    use crate::core::index::{commit_metadata_db, CommitEntryReader};
     use crate::error::OxenError;
     use crate::test;
     use crate::{api, command, util};
@@ -279,19 +295,26 @@ mod tests {
 
             let directory = PathBuf::from("");
 
+            let commit_entry_reader = CommitEntryReader::new(&repo, &commit)?;
+            let dirs = commit_entry_reader.list_dirs()?;
+            log::debug!("all_dirs: {:?}", dirs);
+
             let df = commit_metadata_db::aggregate_col(&repo, &commit, directory, "data_type")?;
 
             let df_str = format!("{:?}", df);
 
+            log::debug!("df: {:#?}", df);
+
             // Add assert here
             assert_eq!(
                 df_str,
-                r"shape: (3, 2)
+                r"shape: (4, 2)
 ┌───────────┬───────┐
 │ data_type ┆ count │
 │ ---       ┆ ---   │
 │ str       ┆ i64   │
 ╞═══════════╪═══════╡
+│ directory ┆ 9     │
 │ image     ┆ 7     │
 │ tabular   ┆ 7     │
 │ text      ┆ 4     │
@@ -326,15 +349,18 @@ mod tests {
             let df_str = format!("{:?}", df);
             println!("df:\n{:?}", df_str);
 
+            log::debug!("df: {:#?}", df);
+
             // Add assert here
             assert_eq!(
                 df_str,
-                r"shape: (1, 2)
+                r"shape: (2, 2)
 ┌───────────┬───────┐
 │ data_type ┆ count │
 │ ---       ┆ ---   │
 │ str       ┆ i64   │
 ╞═══════════╪═══════╡
+│ directory ┆ 1     │
 │ text      ┆ 10    │
 └───────────┴───────┘"
             );

--- a/src/lib/src/core/index/commit_metadata_db.rs
+++ b/src/lib/src/core/index/commit_metadata_db.rs
@@ -64,7 +64,7 @@ pub fn index_commit(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenE
         .filter(|dir| *dir != &PathBuf::from(""))
         .map(|dir| {
             // Takes some time to compute from_dir
-            DirMetadataItem::from_dir(repo, dir, commit, &commit_reader)
+            DirMetadataItem::from_dir(dir, commit)
         })
         .collect::<Vec<_>>();
 

--- a/src/lib/src/model/metadata/dir_metadata_item.rs
+++ b/src/lib/src/model/metadata/dir_metadata_item.rs
@@ -42,12 +42,7 @@ impl DirMetadataItem {
         Schema::new("metadata", fields)
     }
 
-    pub fn from_dir(
-        repo: &LocalRepository,
-        dir: &Path,
-        commit: &Commit,
-        commit_reader: &CommitReader,
-    ) -> Self {
+    pub fn from_dir(dir: &Path, commit: &Commit) -> Self {
         let path = dir.to_string_lossy();
         let mime_type = "directory".to_string();
         let data_type = "directory".to_string();

--- a/src/lib/src/model/metadata/dir_metadata_item.rs
+++ b/src/lib/src/model/metadata/dir_metadata_item.rs
@@ -2,9 +2,9 @@ use crate::api;
 use crate::core::index::CommitReader;
 use crate::model::metadata::to_duckdb_sql::ToDuckDBSql;
 use crate::model::schema::{DataType, Field};
-use crate::model::CommitEntry;
 use crate::model::LocalRepository;
 use crate::model::Schema;
+use crate::model::{Commit, CommitEntry};
 use crate::util;
 
 use duckdb::types::ToSql;
@@ -21,6 +21,7 @@ pub struct DirMetadataItem {
     data_type: String,
     mime_type: String,
     extension: String,
+    is_dir: bool,
 }
 
 impl DirMetadataItem {
@@ -36,8 +37,44 @@ impl DirMetadataItem {
             Field::new("data_type", DataType::String.to_string().as_str()),
             Field::new("mime_type", DataType::String.to_string().as_str()),
             Field::new("extension", DataType::String.to_string().as_str()),
+            Field::new("is_dir", DataType::Boolean.to_string().as_str()),
         ];
         Schema::new("metadata", fields)
+    }
+
+    pub fn from_dir(
+        repo: &LocalRepository,
+        dir: &Path,
+        commit: &Commit,
+        commit_reader: &CommitReader,
+    ) -> Self {
+        let path = dir.to_string_lossy();
+        let mime_type = "directory".to_string();
+        let data_type = "directory".to_string();
+        let size = 0;
+        let directory = dir.parent().unwrap_or(Path::new("")).to_string_lossy();
+        log::debug!("trying to get filename for {:?}", dir);
+        let filename = dir.file_name().unwrap().to_str().unwrap();
+        log::debug!("got filename {:?}", filename);
+        let extension = "".to_string();
+        let timestamp = commit
+            .timestamp
+            .format(&time::format_description::well_known::Rfc3339)
+            .unwrap();
+
+        DirMetadataItem {
+            hash: "".to_string(),
+            directory: directory.to_string(),
+            filename: filename.to_string(),
+            path: path.to_string(),
+            num_bytes: size,
+            commit_id: commit.id.clone(),
+            timestamp,
+            data_type,
+            mime_type,
+            extension,
+            is_dir: true,
+        }
     }
 
     pub fn from_entry(
@@ -78,6 +115,7 @@ impl DirMetadataItem {
             data_type,
             mime_type,
             extension,
+            is_dir: false,
         }
     }
 }
@@ -95,6 +133,7 @@ impl ToDuckDBSql for DirMetadataItem {
             &self.data_type,
             &self.mime_type,
             &self.extension,
+            &self.is_dir,
         ]
     }
 }


### PR DESCRIPTION
This PR adapts the content stats cacher to include directories for later aggregation and inclusion in metadata dfs. 

The migration will take a long time to run. More on this: 
1. Repos will be fully viewable while the migrations are running
2. Any new commits to repos will fail to properly cache while the migrations are running due to the schema change in the metadata db. If we drop the `is_dir` column, we can likely avoid this @gschoeni 
3. After the migrations successfully run, the repos will error out (for now) until a change is made in the UI code for rendering the dir badges to either include or ignore "directory" data type, see image below 

<img width="926" alt="Screenshot 2024-03-05 at 11 19 56 AM" src="https://github.com/Oxen-AI/Oxen/assets/49073323/2c247ec7-fb43-43d7-aefd-31171d262526">
