### PR TITLE
Handle compound column types in diffs

### DIFF
--- a/src/lib/src/api/local/diff/join_diff.rs
+++ b/src/lib/src/api/local/diff/join_diff.rs
@@ -86,8 +86,7 @@ pub fn diff(
 
     let modifications = calculate_compare_mods(&joined_df)?;
 
-    // Sort by any keys whose datatypes are primtivie
-
+    // Sort by all keys with primitive dtypes
     let joined_df = sort_df_on_keys(joined_df, keys.clone())?;
 
     let result_fields =

--- a/src/lib/src/api/local/diff/join_diff.rs
+++ b/src/lib/src/api/local/diff/join_diff.rs
@@ -86,8 +86,19 @@ pub fn diff(
 
     let modifications = calculate_compare_mods(&joined_df)?;
 
-    let descending = keys.iter().map(|_| false).collect::<Vec<bool>>();
-    let joined_df = joined_df.sort(&keys, descending, false)?;
+    // Sort by any keys whose datatypes are primtivie
+
+    let mut sort_cols = vec![];
+    for key in keys.iter() {
+        if let Ok(col) = joined_df.column(key) {
+            if col.dtype().is_primitive() {
+                sort_cols.push(key);
+            }
+        }
+    }
+    let descending = sort_cols.iter().map(|_| false).collect::<Vec<bool>>();
+
+    let joined_df = joined_df.sort(&sort_cols, descending, false)?;
 
     let result_fields =
         prepare_response_fields(&schema_diff, keys.clone(), targets.clone(), display);

--- a/src/lib/src/core/df/tabular.rs
+++ b/src/lib/src/core/df/tabular.rs
@@ -705,7 +705,7 @@ pub fn any_val_to_bytes(value: &AnyValue) -> Vec<u8> {
         //     }
         // },
         AnyValue::Datetime(val, TimeUnit::Milliseconds, _) => val.to_le_bytes().to_vec(),
-        _ => Vec::<u8>::new(),
+        _ => value.to_string().as_bytes().to_vec(),
     }
 }
 


### PR DESCRIPTION
Two fixes here - tried to smoke out any others but seems to be working for now: 

1. Only sort on primitive-typed key columns - polars doesn't support sorting on compounds

2. Hash compound data type columns by converting them to_string => bytes so that we can show row diffs on array et. al cols

