### PR TITLE
Fix bug and improve perf for diff summary calculation

### DIFF
--- a/src/lib/src/api/local/diff.rs
+++ b/src/lib/src/api/local/diff.rs
@@ -950,7 +950,6 @@ pub fn list_diff_entries(
         head_commit.id,
         head_commit.message
     );
-    // let head_entries = read_entries_from_commit(repo, head_commit)?;
     let object_reader = ObjectDBReader::new(repo)?;
 
     let base_reader =
@@ -973,11 +972,8 @@ pub fn list_diff_entries(
 
     log::debug!("Got {} base entries", base_entries.len());
 
-    // let head_dirs = read_dirs_from_commit(repo, head_commit)?;
-
     log::debug!("Got {} head_dirs", head_dirs.len());
 
-    // let base_dirs = read_dirs_from_commit(repo, base_commit)?;
     log::debug!("Got {} base_dirs", base_dirs.len());
 
     let mut dir_entries: Vec<DiffEntry> = vec![];
@@ -1274,26 +1270,6 @@ pub fn get_add_remove_modify_counts(entries: &[DiffEntry]) -> AddRemoveModifyCou
         modified,
     }
 }
-
-// fn read_dirs_from_commit(
-//     repo: &LocalRepository,
-//     commit: &Commit,
-// ) -> Result<HashSet<PathBuf>, OxenError> {
-//     let reader = CommitEntryReader::new(repo, commit)?;
-//     let entries = reader.list_dirs()?;
-//     Ok(HashSet::from_iter(
-//         entries.into_iter().filter(|p| p != Path::new("")),
-//     ))
-// }
-
-// fn read_entries_from_commit(
-//     repo: &LocalRepository,
-//     commit: &Commit,
-// ) -> Result<HashSet<CommitEntry>, OxenError> {
-//     let reader = CommitEntryReader::new(repo, commit)?;
-//     let entries = reader.list_entries_set()?;
-//     Ok(entries)
-// }
 
 #[cfg(test)]
 mod tests {

--- a/src/lib/src/core/index/commit_entry_reader.rs
+++ b/src/lib/src/core/index/commit_entry_reader.rs
@@ -268,7 +268,7 @@ impl CommitEntryReader {
     pub fn list_directory_set(&self, dir: &Path) -> Result<HashSet<CommitEntry>, OxenError> {
         log::debug!("CommitEntryReader::list_directory_set() dir: {:?}", dir);
         let entries = self.list_directory(dir)?;
-        let entries_set: HashSet<CommitEntry> = HashSet::from_iter(entries.into_iter());
+        let entries_set: HashSet<CommitEntry> = HashSet::from_iter(entries);
         Ok(entries_set)
     }
 

--- a/src/lib/src/model/diff/diff_entry.rs
+++ b/src/lib/src/model/diff/diff_entry.rs
@@ -86,7 +86,13 @@ impl DiffEntry {
             (base_dir.unwrap(), base_entry.to_owned().unwrap())
         };
 
-        let diff_summary = DiffEntry::diff_summary_from_dir(repo, &base_entry, &head_entry)?;
+        let diff_summary = DiffEntry::diff_summary_from_dir(
+            repo,
+            &base_entry,
+            &head_entry,
+            &base_commit,
+            &head_commit,
+        )?;
         let head_resource = DiffEntry::resource_from_dir(head_dir, head_commit);
         let base_resource = DiffEntry::resource_from_dir(base_dir, base_commit);
 
@@ -110,6 +116,58 @@ impl DiffEntry {
             base_entry,
             diff_summary,
             diff: None, // TODO: Come back to what we want a full directory diff to look like
+        })
+    }
+
+    // If the summary for a dir diff is already calculated (such as when wanting a self diff for a directory)
+    // this prevents re-traversing through the directory structure.
+    pub fn from_dir_with_summary(
+        repo: &LocalRepository,
+        base_dir: Option<&PathBuf>,
+        base_commit: &Commit,
+        head_dir: Option<&PathBuf>,
+        head_commit: &Commit,
+        summary: GenericDiffSummary,
+        status: DiffEntryStatus,
+    ) -> Result<DiffEntry, OxenError> {
+        let mut base_entry = DiffEntry::metadata_from_dir(repo, base_dir, base_commit);
+        let mut head_entry = DiffEntry::metadata_from_dir(repo, head_dir, head_commit);
+
+        log::debug!("from_dir base_entry: {:?}", base_entry);
+        log::debug!("from_dir head_entry: {:?}", head_entry);
+
+        log::debug!("from_dir base_dir: {:?}", base_dir);
+        log::debug!("from_dir head_dir: {:?}", head_dir);
+        // Need to check whether we have the head or base entry to check data about the file
+        let (current_dir, current_entry) = if let Some(dir) = head_dir {
+            (dir, head_entry.to_owned().unwrap())
+        } else {
+            (base_dir.unwrap(), base_entry.to_owned().unwrap())
+        };
+
+        let head_resource = DiffEntry::resource_from_dir(head_dir, head_commit);
+        let base_resource = DiffEntry::resource_from_dir(base_dir, base_commit);
+
+        if base_entry.is_some() {
+            base_entry.as_mut().unwrap().resource = base_resource.clone();
+        }
+
+        if head_entry.is_some() {
+            head_entry.as_mut().unwrap().resource = head_resource.clone();
+        }
+
+        Ok(DiffEntry {
+            status: status.to_string(),
+            data_type: EntryDataType::Dir,
+            filename: current_dir.as_os_str().to_str().unwrap().to_string(),
+            is_dir: true,
+            size: current_entry.size,
+            head_resource,
+            base_resource,
+            head_entry,
+            base_entry,
+            diff_summary: Some(summary),
+            diff: None,
         })
     }
 
@@ -237,6 +295,8 @@ impl DiffEntry {
         repo: &LocalRepository,
         base_dir: &Option<MetadataEntry>,
         head_dir: &Option<MetadataEntry>,
+        base_commit: &Commit,
+        head_commit: &Commit,
     ) -> Result<Option<GenericDiffSummary>, OxenError> {
         log::debug!("diff_summary_from_dir base_dir: {:?}", base_dir);
         log::debug!("diff_summary_from_dir head_dir: {:?}", head_dir);
@@ -270,21 +330,24 @@ impl DiffEntry {
         let base_dir = base_dir.as_ref().unwrap();
         let head_dir = head_dir.as_ref().unwrap();
 
-        DiffEntry::r_compute_diff_all_files(repo, base_dir, head_dir)
+        DiffEntry::r_compute_diff_all_files(repo, base_dir, head_dir, base_commit, head_commit)
     }
 
     fn r_compute_diff_all_files(
         repo: &LocalRepository,
         base_dir: &MetadataEntry,
         head_dir: &MetadataEntry,
+        base_commit: &Commit,
+        head_commit: &Commit,
     ) -> Result<Option<GenericDiffSummary>, OxenError> {
-        let base_commit_id = &base_dir.latest_commit.as_ref().unwrap().id;
-        let head_commit_id = &head_dir.latest_commit.as_ref().unwrap().id;
+        let base_commit_id = &base_commit.id;
+        let head_commit_id = &head_commit.id;
 
         // base and head path will be the same so just choose base
         let path = PathBuf::from(&base_dir.resource.clone().unwrap().path);
 
         let mut num_removed = 0;
+
         let mut num_added = 0;
         let mut num_modified = 0;
 
@@ -304,6 +367,17 @@ impl DiffEntry {
         // Uniq them
         let dirs: HashSet<PathBuf> = HashSet::from_iter(dirs);
 
+        log::debug!(
+            "got base commit id {:?} for base_dir {:?}",
+            base_commit_id,
+            base_dir
+        );
+        log::debug!(
+            "got head commit id {:?} for head_dir {:?}",
+            head_commit_id,
+            head_dir
+        );
+
         for dir in dirs {
             let base_dir_reader =
                 CommitDirEntryReader::new(repo, base_commit_id, &dir, object_reader.clone())?;
@@ -313,6 +387,9 @@ impl DiffEntry {
             // List the entries in hash sets
             let head_entries = head_dir_reader.list_entries_set()?;
             let base_entries = base_dir_reader.list_entries_set()?;
+
+            log::debug!("got head entries {:#?} for dir {:?}", head_entries, dir);
+            log::debug!("got base entries {:#?} for dir {:?}", base_entries, dir);
             log::debug!(
                 "diff_summary_from_dir head_entries: {:?}",
                 head_entries.len()
@@ -326,20 +403,28 @@ impl DiffEntry {
             let added_entries = head_entries
                 .difference(&base_entries)
                 .collect::<HashSet<_>>();
+
+            log::debug!("got added entries {:?}", added_entries.len());
             num_added += added_entries.len();
 
             // Find the removed entries
             let removed_entries = base_entries
                 .difference(&head_entries)
                 .collect::<HashSet<_>>();
+            log::debug!("got removed entries {:?}", removed_entries.len());
             num_removed += removed_entries.len();
 
             // Find the modified entries
             for base_entry in base_entries {
+                log::debug!("got base mod entry {:?}", base_entry);
                 if let Some(head_entry) = head_entries.get(&base_entry) {
+                    log::debug!("got head mod entry {:?}", head_entry);
                     if head_entry.hash != base_entry.hash {
+                        log::debug!("FOUND MOD ENTRY FOR {:?}", base_entry.path);
                         num_modified += 1;
                     }
+                } else {
+                    log::debug!("could not get head for base entry {:?}", base_entry);
                 }
             }
         }

--- a/src/lib/src/model/diff/dir_diff_summary.rs
+++ b/src/lib/src/model/diff/dir_diff_summary.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{model::diff::AddRemoveModifyCounts, view::DataTypeCount};
+use crate::model::diff::AddRemoveModifyCounts;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct DirDiffSummary {
@@ -11,10 +11,4 @@ pub struct DirDiffSummary {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct DirDiffSummaryImpl {
     pub file_counts: AddRemoveModifyCounts,
-}
-
-#[derive(Deserialize, Serialize, Debug, Clone)]
-pub struct AddRemoveDataTypeCounts {
-    pub added: Vec<DataTypeCount>,
-    pub removed: Vec<DataTypeCount>,
 }


### PR DESCRIPTION
1. The logic for calculating changed files was using the latest commit for a dir to get `base_commit` and `head_commit`. This was excluding some diff entries and is a bit unstable right now (we have another bug with latest commit across branches) - so I changed it to just use the provided `base_commit` and `head_commit` from the parent scope. I don't see any issues w/ this tweak 

2. Getting the `self` rollup node for dir diff view previously had to call the recursive count-all-the-added-modified-removed-entries call twice, this dedupes that 

3. `list_diff_entries` and `list_diff_entries_in_dir` consolidated to one fn that takes a dir param 

