### PR TITLE
URL decode resource paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3384,6 +3384,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-util",
+ "urlencoding",
  "uuid",
 ]
 

--- a/src/lib/src/api/local/resource.rs
+++ b/src/lib/src/api/local/resource.rs
@@ -11,7 +11,7 @@ pub fn parse_resource(
     repo: &LocalRepository,
     path: &Path,
 ) -> Result<Option<(String, String, PathBuf)>, OxenError> {
-    // Decode first 
+    // Decode first
     let decoded_path = PathBuf::from(urlencoding::decode(&path.to_string_lossy())?.to_string());
     let mut components = decoded_path.components().collect::<Vec<_>>();
     let commit_reader = CommitReader::new(repo)?;

--- a/src/lib/src/api/local/resource.rs
+++ b/src/lib/src/api/local/resource.rs
@@ -11,7 +11,9 @@ pub fn parse_resource(
     repo: &LocalRepository,
     path: &Path,
 ) -> Result<Option<(String, String, PathBuf)>, OxenError> {
-    let mut components = path.components().collect::<Vec<_>>();
+    // Decode first 
+    let decoded_path = PathBuf::from(urlencoding::decode(&path.to_string_lossy())?.to_string());
+    let mut components = decoded_path.components().collect::<Vec<_>>();
     let commit_reader = CommitReader::new(repo)?;
 
     // See if the first component is the commit id

--- a/src/lib/src/error.rs
+++ b/src/lib/src/error.rs
@@ -599,3 +599,9 @@ impl From<ParseIntError> for OxenError {
         OxenError::basic_str(error.to_string())
     }
 }
+
+impl From<std::string::FromUtf8Error> for OxenError {
+    fn from(error: std::string::FromUtf8Error) -> Self {
+        OxenError::basic_str(format!("UTF8 conversion error: {}", error))
+    }
+}

--- a/src/server/Cargo.toml
+++ b/src/server/Cargo.toml
@@ -38,6 +38,7 @@ tar = "0.4.38"
 time = { version = "0.3.20", features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7.8"
+urlencoding = "2.1.3"
 uuid = { version = "1.3.3", features = ["serde", "v4"] }
 
 

--- a/src/server/src/errors.rs
+++ b/src/server/src/errors.rs
@@ -56,6 +56,12 @@ impl From<serde_json::Error> for OxenHttpError {
     }
 }
 
+impl From<std::string::FromUtf8Error> for OxenHttpError {
+    fn from(error: std::string::FromUtf8Error) -> Self {
+        OxenHttpError::BadRequest(StringError::new(error.to_string()))
+    }
+}
+
 impl error::ResponseError for OxenHttpError {
     fn error_response(&self) -> HttpResponse {
         match self {

--- a/src/server/src/params.rs
+++ b/src/server/src/params.rs
@@ -12,6 +12,7 @@ use liboxen::util::oxen_version::OxenVersion;
 use crate::app_data::OxenAppData;
 use crate::errors::OxenHttpError;
 
+
 pub mod aggregate_query;
 pub use aggregate_query::AggregateQuery;
 
@@ -37,6 +38,7 @@ pub fn app_data(req: &HttpRequest) -> Result<&OxenAppData, OxenHttpError> {
         // Invalid user agent, so we can't check the version
         return get_app_data(req);
     };
+
 
     if user_cli_is_out_of_date(user_agent_str) {
         return Err(OxenHttpError::UpdateRequired(
@@ -75,7 +77,8 @@ pub fn parse_resource(
     repo: &LocalRepository,
 ) -> Result<ParsedResource, OxenHttpError> {
     let resource: PathBuf = PathBuf::from(req.match_info().query("resource"));
-    parse_resource_from_path(repo, &resource)?
+    let decoded_resource = PathBuf::from(urlencoding::decode(&resource.to_string_lossy())?.to_string());
+    parse_resource_from_path(repo, &decoded_resource)?
         .ok_or(OxenError::path_does_not_exist(resource).into())
 }
 

--- a/src/server/src/params.rs
+++ b/src/server/src/params.rs
@@ -12,7 +12,6 @@ use liboxen::util::oxen_version::OxenVersion;
 use crate::app_data::OxenAppData;
 use crate::errors::OxenHttpError;
 
-
 pub mod aggregate_query;
 pub use aggregate_query::AggregateQuery;
 
@@ -38,7 +37,6 @@ pub fn app_data(req: &HttpRequest) -> Result<&OxenAppData, OxenHttpError> {
         // Invalid user agent, so we can't check the version
         return get_app_data(req);
     };
-
 
     if user_cli_is_out_of_date(user_agent_str) {
         return Err(OxenHttpError::UpdateRequired(
@@ -77,7 +75,8 @@ pub fn parse_resource(
     repo: &LocalRepository,
 ) -> Result<ParsedResource, OxenHttpError> {
     let resource: PathBuf = PathBuf::from(req.match_info().query("resource"));
-    let decoded_resource = PathBuf::from(urlencoding::decode(&resource.to_string_lossy())?.to_string());
+    let decoded_resource =
+        PathBuf::from(urlencoding::decode(&resource.to_string_lossy())?.to_string());
     parse_resource_from_path(repo, &decoded_resource)?
         .ok_or(OxenError::path_does_not_exist(resource).into())
 }


### PR DESCRIPTION
This fixes the issues with non-alphanum characters in file names. Was originating from the `get_meta_entry` call looking up urlencoded file names.

Also solves the issue @Artforge was investigating with spaces in filenames
