### PR TITLE
Add the BASE and HEAD commit ids to the merge response

### DIFF
--- a/src/lib/src/view/merge.rs
+++ b/src/lib/src/view/merge.rs
@@ -23,3 +23,11 @@ pub struct MergeableResponse {
     #[serde(flatten)]
     pub mergeable: Mergeable,
 }
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct MergeSuccessResponse {
+    #[serde(flatten)]
+    pub status: StatusMessage,
+    pub head_commit: String,
+    pub base_commit: String,
+}


### PR DESCRIPTION
This adds the `head_commit` and `base_commit` IDs to the merge response.

It also returns an error if the merge can't happen ie. There was an error merging or the branches has merge conflicts.