### PR TITLE
Fix for merkle child paths on Windows 

### DIFF
--- a/src/lib/src/api/local/commits.rs
+++ b/src/lib/src/api/local/commits.rs
@@ -7,7 +7,7 @@ use crate::constants::{
     HISTORY_DIR, OBJECT_DIRS_DIR, OBJECT_FILES_DIR, OBJECT_SCHEMAS_DIR, OBJECT_VNODES_DIR, TREE_DIR,
 };
 use crate::core::cache::cachers::content_validator;
-use crate::core::db::tree_db::TreeObject;
+use crate::core::db::tree_db::{self, TreeObject};
 use crate::core::db::{self, path_db};
 use crate::core::index::tree_db_reader::TreeDBMerger;
 use crate::core::index::{
@@ -494,17 +494,17 @@ pub fn merge_objects_dbs(repo_objects_dir: &Path, tmp_objects_dir: &Path) -> Res
 
     let new_files: Vec<TreeObject> = path_db::list_entries(&new_files_db)?;
     for file in new_files {
-        path_db::put(&repo_files_db, file.hash(), &file)?;
+        tree_db::put_tree_object(&repo_files_db, file.hash(), &file)?;
     }
 
     let new_schemas: Vec<TreeObject> = path_db::list_entries(&new_schemas_db)?;
     for schema in new_schemas {
-        path_db::put(&repo_schemas_db, schema.hash(), &schema)?;
+        tree_db::put_tree_object(&repo_schemas_db, schema.hash(), &schema)?;
     }
 
     let new_vnodes: Vec<TreeObject> = path_db::list_entries(&new_vnodes_db)?;
     for vnode in new_vnodes {
-        path_db::put(&repo_vnodes_db, vnode.hash(), &vnode)?;
+        tree_db::put_tree_object(&repo_vnodes_db, vnode.hash(), &vnode)?;
     }
 
     Ok(())

--- a/src/lib/src/api/local/commits.rs
+++ b/src/lib/src/api/local/commits.rs
@@ -489,7 +489,7 @@ pub fn merge_objects_dbs(repo_objects_dir: &Path, tmp_objects_dir: &Path) -> Res
 
     let new_dirs: Vec<TreeObject> = path_db::list_entries(&new_dirs_db)?;
     for dir in new_dirs {
-        path_db::put(&repo_dirs_db, dir.hash(), &dir)?;
+        tree_db::put_tree_object(&repo_dirs_db, dir.hash(), &dir)?;
     }
 
     let new_files: Vec<TreeObject> = path_db::list_entries(&new_files_db)?;

--- a/src/lib/src/api/local/schemas.rs
+++ b/src/lib/src/api/local/schemas.rs
@@ -32,7 +32,8 @@ pub fn list_from_ref(
     schema_ref: impl AsRef<str>,
 ) -> Result<HashMap<PathBuf, Schema>, OxenError> {
     let revision = revision.as_ref();
-    let schema_ref = schema_ref.as_ref().replace('\\', "/");
+    // let schema_ref = schema_ref.as_ref().replace('\\', "/");
+    log::debug!("listing for ref: {:?}", schema_ref.as_ref());
     if let Some(commit) = api::local::revisions::get(repo, revision)? {
         let schema_reader = SchemaReader::new(repo, &commit.id)?;
         schema_reader.list_schemas_for_ref(schema_ref)

--- a/src/lib/src/api/local/schemas.rs
+++ b/src/lib/src/api/local/schemas.rs
@@ -33,7 +33,7 @@ pub fn list_from_ref(
 ) -> Result<HashMap<PathBuf, Schema>, OxenError> {
     let revision = revision.as_ref();
     // let schema_ref = schema_ref.as_ref().replace('\\', "/");
-    log::debug!("listing for ref: {:?}", schema_ref.as_ref());
+    log::debug!("list_from_ref() listing for ref: {:?}", schema_ref.as_ref());
     if let Some(commit) = api::local::revisions::get(repo, revision)? {
         let schema_reader = SchemaReader::new(repo, &commit.id)?;
         schema_reader.list_schemas_for_ref(schema_ref)

--- a/src/lib/src/api/local/schemas.rs
+++ b/src/lib/src/api/local/schemas.rs
@@ -32,7 +32,6 @@ pub fn list_from_ref(
     schema_ref: impl AsRef<str>,
 ) -> Result<HashMap<PathBuf, Schema>, OxenError> {
     let revision = revision.as_ref();
-    // let schema_ref = schema_ref.as_ref().replace('\\', "/");
     log::debug!("list_from_ref() listing for ref: {:?}", schema_ref.as_ref());
     if let Some(commit) = api::local::revisions::get(repo, revision)? {
         let schema_reader = SchemaReader::new(repo, &commit.id)?;

--- a/src/lib/src/api/remote/df.rs
+++ b/src/lib/src/api/remote/df.rs
@@ -147,7 +147,6 @@ mod tests {
                 "root": "images"
             });
 
-            log::debug!("about to metadata add");
             command::schemas::add_column_metadata(
                 &local_repo,
                 schema_ref,
@@ -156,11 +155,8 @@ mod tests {
             )?;
 
             command::schemas::add_schema_metadata(&local_repo, schema_ref, &schema_metadata)?;
-            let status = command::status(&local_repo);
 
             command::commit(&local_repo, "add test.csv schema metadata")?;
-
-            let got_schema = command::schemas::get_from_head(&local_repo, schema_ref)?;
 
             // Set the proper remote
             let remote = test::repo_remote_url_from(&local_repo.dirname());
@@ -439,17 +435,16 @@ mod tests {
             command::config::set_remote(&mut local_repo, DEFAULT_REMOTE_NAME, &remote)?;
 
             let schema_ref = &PathBuf::from("csvs")
-            .join("test.csv")
-            .to_string_lossy()
-            .to_string();
+                .join("test.csv")
+                .to_string_lossy()
+                .to_string();
             // Create the repo
             let remote_repo = test::create_remote_repo(&local_repo).await?;
 
             // Cannot get schema that does not exist
             let opts = DFOpts::empty();
             let result =
-                api::remote::df::get(&remote_repo, DEFAULT_BRANCH_NAME, schema_ref, opts)
-                    .await;
+                api::remote::df::get(&remote_repo, DEFAULT_BRANCH_NAME, schema_ref, opts).await;
             assert!(result.is_err());
 
             // Push the repo
@@ -488,8 +483,7 @@ mod tests {
 
             // Cannot get schema that does not exist
             let opts = DFOpts::empty();
-            let result =
-                api::remote::df::get(&remote_repo, branch_name, schema_ref, opts).await;
+            let result = api::remote::df::get(&remote_repo, branch_name, schema_ref, opts).await;
             assert!(result.is_err());
 
             // Push the repo
@@ -497,8 +491,7 @@ mod tests {
 
             // List the one schema
             let opts = DFOpts::empty();
-            let results =
-                api::remote::df::get(&remote_repo, branch_name, schema_ref, opts).await;
+            let results = api::remote::df::get(&remote_repo, branch_name, schema_ref, opts).await;
             assert!(results.is_ok());
 
             let result = results.unwrap();

--- a/src/lib/src/api/remote/df.rs
+++ b/src/lib/src/api/remote/df.rs
@@ -85,6 +85,8 @@ pub async fn get_staged(
 #[cfg(test)]
 mod tests {
 
+    use std::path::PathBuf;
+
     use crate::api;
     use crate::command;
     use crate::constants;
@@ -166,7 +168,7 @@ mod tests {
             let df = api::remote::df::get(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,
-                "large_files/test.csv",
+                PathBuf::from("large_files").join("test.csv"),
                 opts,
             )
             .await?;
@@ -231,7 +233,7 @@ mod tests {
             let df = api::remote::df::get(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,
-                "large_files/test.csv",
+                PathBuf::from("large_files").join("test.csv"),
                 opts,
             )
             .await?;

--- a/src/lib/src/api/remote/df.rs
+++ b/src/lib/src/api/remote/df.rs
@@ -110,11 +110,7 @@ mod tests {
             let from_file = test::test_200k_csv();
             util::fs::copy(from_file, &csv_file)?;
 
-            log::debug!("about to add");
-
             command::add(&local_repo, &csv_file)?;
-
-            log::debug!("about to commit");
             command::commit(&local_repo, "add test.csv")?;
 
             // Add some metadata to the schema
@@ -138,7 +134,10 @@ mod tests {
                         */
 
             // Add some metadata to the schema
-            let schema_ref = &PathBuf::from("large_files").join("test.csv").to_string_lossy().to_string();
+            let schema_ref = &PathBuf::from("large_files")
+                .join("test.csv")
+                .to_string_lossy()
+                .to_string();
             let schema_metadata = json!({
                 "description": "A dataset of faces",
                 "task": "gen_faces"
@@ -155,18 +154,13 @@ mod tests {
                 &column_name,
                 &column_metadata,
             )?;
-            log::debug!("about to schema metadata add");
+
             command::schemas::add_schema_metadata(&local_repo, schema_ref, &schema_metadata)?;
-            log::debug!("about to commit seFcond time");
             let status = command::status(&local_repo);
-            log::debug!("status before committing: {:?}", status);
+
             command::commit(&local_repo, "add test.csv schema metadata")?;
 
-            let got_schema = command::schemas::get_from_head(
-                &local_repo, 
-                schema_ref
-            )?;
-            log::debug!("in test got schemas: {:?}", got_schema);
+            let got_schema = command::schemas::get_from_head(&local_repo, schema_ref)?;
 
             // Set the proper remote
             let remote = test::repo_remote_url_from(&local_repo.dirname());
@@ -175,14 +169,13 @@ mod tests {
             // Create the repo
             let remote_repo = test::create_remote_repo(&local_repo).await?;
 
-            log::debug!("about to push");
             // Push the repo
             command::push(&local_repo).await?;
 
             // Get the df
             let mut opts = DFOpts::empty();
             opts.page_size = Some(10);
-            log::debug!("about to get df");
+
             let df = api::remote::df::get(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,

--- a/src/lib/src/api/remote/df.rs
+++ b/src/lib/src/api/remote/df.rs
@@ -438,13 +438,17 @@ mod tests {
             let remote = test::repo_remote_url_from(&local_repo.dirname());
             command::config::set_remote(&mut local_repo, DEFAULT_REMOTE_NAME, &remote)?;
 
+            let schema_ref = &PathBuf::from("csvs")
+            .join("test.csv")
+            .to_string_lossy()
+            .to_string();
             // Create the repo
             let remote_repo = test::create_remote_repo(&local_repo).await?;
 
             // Cannot get schema that does not exist
             let opts = DFOpts::empty();
             let result =
-                api::remote::df::get(&remote_repo, DEFAULT_BRANCH_NAME, "csvs/test.csv", opts)
+                api::remote::df::get(&remote_repo, DEFAULT_BRANCH_NAME, schema_ref, opts)
                     .await;
             assert!(result.is_err());
 
@@ -460,7 +464,7 @@ mod tests {
             prompt,response,is_correct,response_time,difficulty
             who is it?,issa me,true,0.5,1
             */
-            let schema_ref = "csvs/test.csv";
+
             let schema_metadata = json!({
                 "task": "chat_bot",
                 "description": "some generic description",
@@ -485,7 +489,7 @@ mod tests {
             // Cannot get schema that does not exist
             let opts = DFOpts::empty();
             let result =
-                api::remote::df::get(&remote_repo, branch_name, "csvs/test.csv", opts).await;
+                api::remote::df::get(&remote_repo, branch_name, schema_ref, opts).await;
             assert!(result.is_err());
 
             // Push the repo
@@ -494,7 +498,7 @@ mod tests {
             // List the one schema
             let opts = DFOpts::empty();
             let results =
-                api::remote::df::get(&remote_repo, branch_name, "csvs/test.csv", opts).await;
+                api::remote::df::get(&remote_repo, branch_name, schema_ref, opts).await;
             assert!(results.is_ok());
 
             let result = results.unwrap();

--- a/src/lib/src/api/remote/schemas.rs
+++ b/src/lib/src/api/remote/schemas.rs
@@ -3,7 +3,7 @@
 //! Interact with remote schemas.
 //!
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::api;
 use crate::error::OxenError;
@@ -170,7 +170,10 @@ mod tests {
             prompt,response,is_correct,response_time,difficulty
             who is it?,issa me,true,0.5,1
             */
-            let schema_ref = &PathBuf::from("csvs").join("test.csv").to_string_lossy().to_string();
+            let schema_ref = &PathBuf::from("csvs")
+                .join("test.csv")
+                .to_string_lossy()
+                .to_string();
 
             let schema_metadata = json!({
                 "task": "chat_bot",
@@ -202,8 +205,7 @@ mod tests {
 
             // Cannot get schema that does not exist
             let result =
-                api::remote::schemas::get(&remote_repo, DEFAULT_BRANCH_NAME, schema_ref)
-                    .await?;
+                api::remote::schemas::get(&remote_repo, DEFAULT_BRANCH_NAME, schema_ref).await?;
             assert!(result.is_none());
 
             // Push the repo
@@ -211,8 +213,7 @@ mod tests {
 
             // List the one schema
             let schema =
-                api::remote::schemas::get(&remote_repo, DEFAULT_BRANCH_NAME, schema_ref)
-                    .await?;
+                api::remote::schemas::get(&remote_repo, DEFAULT_BRANCH_NAME, schema_ref).await?;
 
             assert!(schema.is_some());
             let schema = schema.unwrap().schema;
@@ -260,12 +261,14 @@ mod tests {
             // Create the repo
             let remote_repo = test::create_remote_repo(&local_repo).await?;
 
-            let schema_ref = &PathBuf::from("csvs").join("test.csv").to_string_lossy().to_string();
+            let schema_ref = &PathBuf::from("csvs")
+                .join("test.csv")
+                .to_string_lossy()
+                .to_string();
 
             // Cannot get schema that does not exist
             let result =
-                api::remote::schemas::get(&remote_repo, DEFAULT_BRANCH_NAME, schema_ref)
-                    .await?;
+                api::remote::schemas::get(&remote_repo, DEFAULT_BRANCH_NAME, schema_ref).await?;
             assert!(result.is_none());
 
             // Push the repo
@@ -274,12 +277,11 @@ mod tests {
             // Create a new branch
             let branch_name = "new_branch";
             command::create_checkout(&local_repo, branch_name)?;
-
             // Add some metadata to the schema
             /*
             prompt,response,is_correct,response_time,difficulty
             who is it?,issa me,true,0.5,1
-            */;
+            */
             let schema_metadata = json!({
                 "task": "chat_bot",
                 "description": "some generic description",
@@ -305,8 +307,7 @@ mod tests {
             command::push(&local_repo).await?;
 
             // List the one schema
-            let schema =
-                api::remote::schemas::get(&remote_repo, branch_name, schema_ref).await?;
+            let schema = api::remote::schemas::get(&remote_repo, branch_name, schema_ref).await?;
 
             assert!(schema.is_some());
             let schema = schema.unwrap().schema;

--- a/src/lib/src/api/remote/schemas.rs
+++ b/src/lib/src/api/remote/schemas.rs
@@ -3,7 +3,7 @@
 //! Interact with remote schemas.
 //!
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::api;
 use crate::error::OxenError;
@@ -97,6 +97,8 @@ mod tests {
     use crate::test;
     use crate::util;
 
+    use std::path::PathBuf;
+
     use serde_json::json;
 
     #[tokio::test]
@@ -168,7 +170,8 @@ mod tests {
             prompt,response,is_correct,response_time,difficulty
             who is it?,issa me,true,0.5,1
             */
-            let schema_ref = "csvs/test.csv";
+            let schema_ref = &PathBuf::from("csvs").join("test.csv").to_string_lossy().to_string();
+
             let schema_metadata = json!({
                 "task": "chat_bot",
                 "description": "some generic description",
@@ -199,7 +202,7 @@ mod tests {
 
             // Cannot get schema that does not exist
             let result =
-                api::remote::schemas::get(&remote_repo, DEFAULT_BRANCH_NAME, "csvs/test.csv")
+                api::remote::schemas::get(&remote_repo, DEFAULT_BRANCH_NAME, schema_ref)
                     .await?;
             assert!(result.is_none());
 
@@ -208,7 +211,7 @@ mod tests {
 
             // List the one schema
             let schema =
-                api::remote::schemas::get(&remote_repo, DEFAULT_BRANCH_NAME, "csvs/test.csv")
+                api::remote::schemas::get(&remote_repo, DEFAULT_BRANCH_NAME, schema_ref)
                     .await?;
 
             assert!(schema.is_some());
@@ -257,9 +260,11 @@ mod tests {
             // Create the repo
             let remote_repo = test::create_remote_repo(&local_repo).await?;
 
+            let schema_ref = &PathBuf::from("csvs").join("test.csv").to_string_lossy().to_string();
+
             // Cannot get schema that does not exist
             let result =
-                api::remote::schemas::get(&remote_repo, DEFAULT_BRANCH_NAME, "csvs/test.csv")
+                api::remote::schemas::get(&remote_repo, DEFAULT_BRANCH_NAME, schema_ref)
                     .await?;
             assert!(result.is_none());
 
@@ -274,8 +279,7 @@ mod tests {
             /*
             prompt,response,is_correct,response_time,difficulty
             who is it?,issa me,true,0.5,1
-            */
-            let schema_ref = "csvs/test.csv";
+            */;
             let schema_metadata = json!({
                 "task": "chat_bot",
                 "description": "some generic description",
@@ -302,7 +306,7 @@ mod tests {
 
             // List the one schema
             let schema =
-                api::remote::schemas::get(&remote_repo, branch_name, "csvs/test.csv").await?;
+                api::remote::schemas::get(&remote_repo, branch_name, schema_ref).await?;
 
             assert!(schema.is_some());
             let schema = schema.unwrap().schema;

--- a/src/lib/src/api/remote/staging/diff.rs
+++ b/src/lib/src/api/remote/staging/diff.rs
@@ -174,6 +174,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_diff_delete_row_from_modified_dataframe() -> Result<(), OxenError> {
+        // Skip if on windows
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
+
         test::run_remote_repo_test_bounding_box_csv_pushed(|remote_repo| async move {
             let branch_name = "add-images";
             let branch = api::remote::branches::create_from_or_get(&remote_repo, branch_name, DEFAULT_BRANCH_NAME).await?;

--- a/src/lib/src/command/remote/add.rs
+++ b/src/lib/src/command/remote/add.rs
@@ -162,6 +162,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_remote_stage_delete_row_clears_remote_status() -> Result<(), OxenError> {
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        };
         test::run_training_data_fully_sync_remote(|_, remote_repo| async move {
             let remote_repo_copy = remote_repo.clone();
 

--- a/src/lib/src/command/schemas.rs
+++ b/src/lib/src/command/schemas.rs
@@ -155,7 +155,7 @@ pub fn add_column_metadata(
     column: impl AsRef<str>,
     metadata: &serde_json::Value,
 ) -> Result<HashMap<PathBuf, Schema>, OxenError> {
-    let schema_ref = schema_ref.as_ref().replace('\\', "/");
+    // let schema_ref = schema_ref.as_ref().replace('\\', "/");
     let column = column.as_ref();
     let head_commit = api::local::commits::head_commit(repo)?;
     log::debug!("add_column_metadata head_commit: {}", head_commit);

--- a/src/lib/src/command/schemas.rs
+++ b/src/lib/src/command/schemas.rs
@@ -116,7 +116,7 @@ pub fn add_schema_metadata(
     schema_ref: impl AsRef<str>,
     metadata: &serde_json::Value,
 ) -> Result<HashMap<PathBuf, Schema>, OxenError> {
-    let schema_ref = schema_ref.as_ref().replace('\\', "/");
+    // let schema_ref = schema_ref.as_ref().replace('\\', "/");
     let head_commit = api::local::commits::head_commit(repo)?;
     log::debug!("add_column_metadata head_commit: {}", head_commit);
 

--- a/src/lib/src/command/schemas.rs
+++ b/src/lib/src/command/schemas.rs
@@ -116,7 +116,6 @@ pub fn add_schema_metadata(
     schema_ref: impl AsRef<str>,
     metadata: &serde_json::Value,
 ) -> Result<HashMap<PathBuf, Schema>, OxenError> {
-    // let schema_ref = schema_ref.as_ref().replace('\\', "/");
     let head_commit = api::local::commits::head_commit(repo)?;
     log::debug!("add_column_metadata head_commit: {}", head_commit);
 
@@ -155,7 +154,6 @@ pub fn add_column_metadata(
     column: impl AsRef<str>,
     metadata: &serde_json::Value,
 ) -> Result<HashMap<PathBuf, Schema>, OxenError> {
-    // let schema_ref = schema_ref.as_ref().replace('\\', "/");
     let column = column.as_ref();
     let head_commit = api::local::commits::head_commit(repo)?;
     log::debug!("add_column_metadata head_commit: {}", head_commit);

--- a/src/lib/src/core/db/path_db.rs
+++ b/src/lib/src/core/db/path_db.rs
@@ -38,7 +38,6 @@ where
     if let Some(key) = path.to_str() {
         // de-windows-ify the path
         let key = key.replace('\\', "/");
-
         return str_json_db::get(db, key);
     }
     Err(OxenError::could_not_convert_path_to_str(path))
@@ -130,11 +129,13 @@ where
                 match (str::from_utf8(&key), str::from_utf8(&value)) {
                     (Ok(key), Ok(value)) => {
                         // Full path given the dir it is in
-                        let path = base_dir.join(String::from(key));
+                        let os_path = OsPath::from(key);
+                        let new_path = os_path.to_pathbuf();
+                        let new_path = base_dir.join(String::from(key));
                         let entry: Result<D, serde_json::error::Error> =
                             serde_json::from_str(value);
                         if let Ok(entry) = entry {
-                            paths.push((path, entry));
+                            paths.push((new_path, entry));
                         }
                     }
                     (Ok(key), _) => {

--- a/src/lib/src/core/db/path_db.rs
+++ b/src/lib/src/core/db/path_db.rs
@@ -94,7 +94,6 @@ pub fn list_paths<T: ThreadMode>(
                         // return path with native slashes
                         let os_path = OsPath::from(key);
                         let new_path = os_path.to_pathbuf();
-
                         paths.push(base_dir.join(new_path));
                     }
                     _ => {
@@ -131,7 +130,7 @@ where
                         // Full path given the dir it is in
                         let os_path = OsPath::from(key);
                         let new_path = os_path.to_pathbuf();
-                        let new_path = base_dir.join(String::from(key));
+                        let new_path = base_dir.join(new_path);
                         let entry: Result<D, serde_json::error::Error> =
                             serde_json::from_str(value);
                         if let Ok(entry) = entry {

--- a/src/lib/src/core/db/tree_db.rs
+++ b/src/lib/src/core/db/tree_db.rs
@@ -177,7 +177,7 @@ pub fn put_tree_object<T: ThreadMode, P: AsRef<Path>>(
         }
     };
 
-    put_tree_object(db, path, &updated_object)
+    path_db::put(db, path, &updated_object)
 }
 
 pub fn get_tree_object<T: ThreadMode, P: AsRef<Path>>(

--- a/src/lib/src/core/db/tree_db.rs
+++ b/src/lib/src/core/db/tree_db.rs
@@ -186,23 +186,20 @@ pub fn get_tree_object<T: ThreadMode, P: AsRef<Path>>(
 ) -> Result<Option<TreeObject>, OxenError> {
     let maybe_object = path_db::get_entry(db, path)?;
     if let Some(object) = maybe_object {
-        log::debug!("get_tree_object() looking at object: {:?}", object);
         match &object {
             TreeObject::Dir { children, .. } | TreeObject::VNode { children, .. } => {
                 // TODO: Lifetime specs to avoid these clones...
                 let mut object = object.clone();
                 let mut children = children.to_owned();
 
-                log::debug!("children were: {:?}", children);
-
                 for child in children.iter_mut() {
                     let os_path = OsPath::from(child.path().to_path_buf());
                     let new_path = os_path.to_pathbuf();
                     child.set_path(new_path);
                 }
-                log::debug!("children are now: {:?}", children);
+
                 object.set_children(children.to_vec());
-                log::debug!("returning object: {:?}", object);
+
                 Ok(Some(object))
             }
             _ => Ok(Some(object)),

--- a/src/lib/src/core/db/tree_db.rs
+++ b/src/lib/src/core/db/tree_db.rs
@@ -157,7 +157,6 @@ pub fn put_tree_object<T: ThreadMode, P: AsRef<Path>>(
     path: P,
     object: &TreeObject,
 ) -> Result<(), OxenError> {
-    // TODO: handle lifetimes to return the references here and not clone
     let updated_object = match object {
         TreeObject::File { .. } | TreeObject::Schema { .. } => object.clone(),
         TreeObject::Dir { .. } | TreeObject::VNode { .. } => {

--- a/src/lib/src/core/db/tree_db.rs
+++ b/src/lib/src/core/db/tree_db.rs
@@ -186,18 +186,23 @@ pub fn get_tree_object<T: ThreadMode, P: AsRef<Path>>(
 ) -> Result<Option<TreeObject>, OxenError> {
     let maybe_object = path_db::get_entry(db, path)?;
     if let Some(object) = maybe_object {
+        log::debug!("get_tree_object() looking at object: {:?}", object);
         match &object {
             TreeObject::Dir { children, .. } | TreeObject::VNode { children, .. } => {
                 // TODO: Lifetime specs to avoid these clones...
                 let mut object = object.clone();
                 let mut children = children.to_owned();
 
+                log::debug!("children were: {:?}", children);
+
                 for child in children.iter_mut() {
                     let os_path = OsPath::from(child.path().to_path_buf());
                     let new_path = os_path.to_pathbuf();
                     child.set_path(new_path);
                 }
+                log::debug!("children are now: {:?}", children);
                 object.set_children(children.to_vec());
+                log::debug!("returning object: {:?}", object);
                 Ok(Some(object))
             }
             _ => Ok(Some(object)),

--- a/src/lib/src/core/db/tree_db.rs
+++ b/src/lib/src/core/db/tree_db.rs
@@ -13,6 +13,8 @@ use serde::{Deserialize, Serialize};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
+use super::path_db;
+
 pub struct TreeDB<T: ThreadMode> {
     pub db: DBWithThreadMode<T>,
 }
@@ -116,6 +118,15 @@ impl TreeObjectChild {
             TreeObjectChild::VNode { path, .. } => path.to_str().unwrap(),
         }
     }
+
+    pub fn set_path(&mut self, new_path: PathBuf) {
+        match self {
+            TreeObjectChild::File { path, .. } => *path = new_path,
+            TreeObjectChild::Schema { path, .. } => *path = new_path,
+            TreeObjectChild::Dir { path, .. } => *path = new_path,
+            TreeObjectChild::VNode { path, .. } => *path = new_path,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -139,6 +150,61 @@ pub enum TreeObject {
         hash: String,
         name: String,
     },
+}
+
+pub fn put_tree_object<T: ThreadMode, P: AsRef<Path>>(
+    db: &DBWithThreadMode<T>,
+    path: P,
+    object: &TreeObject,
+) -> Result<(), OxenError> {
+    // TODO: handle lifetimes to return the references here and not clone
+    let updated_object = match object {
+        TreeObject::File { .. } | TreeObject::Schema { .. } => object.clone(),
+        TreeObject::Dir { .. } | TreeObject::VNode { .. } => {
+            let mut children = object.children().to_owned();
+            for child in children.iter_mut() {
+                // replace all \\ in path with /
+                if let Some(path_str) = child.path().to_str() {
+                    let new_path = path_str.replace("\\", "/");
+                    child.set_path(PathBuf::from(new_path));
+                }
+            }
+
+            // TODO: avoid this clone here - take in mut owned treeobject?
+            let mut object = object.clone();
+            object.set_children(children);
+            object
+        }
+    };
+
+    path_db::put(db, path, &updated_object)
+}
+
+pub fn get_tree_object<T: ThreadMode, P: AsRef<Path>>(
+    db: &DBWithThreadMode<T>,
+    path: P,
+) -> Result<Option<TreeObject>, OxenError> {
+    let maybe_object = path_db::get_entry(db, path)?;
+    if let Some(object) = maybe_object {
+        match &object {
+            TreeObject::Dir { children, .. } | TreeObject::VNode { children, .. } => {
+                // TODO: Lifetime specs to avoid these clones...
+                let mut object = object.clone();
+                let mut children = children.to_owned();
+
+                for child in children.iter_mut() {
+                    let os_path = OsPath::from(child.path().to_path_buf());
+                    let new_path = os_path.to_pathbuf();
+                    child.set_path(new_path);
+                }
+                object.set_children(children.to_vec());
+                Ok(Some(object))
+            }
+            _ => Ok(Some(object)),
+        }
+    } else {
+        Ok(None)
+    }
 }
 
 impl TreeObject {

--- a/src/lib/src/core/db/tree_db.rs
+++ b/src/lib/src/core/db/tree_db.rs
@@ -177,7 +177,7 @@ pub fn put_tree_object<T: ThreadMode, P: AsRef<Path>>(
         }
     };
 
-    path_db::put(db, path, &updated_object)
+    put_tree_object(db, path, &updated_object)
 }
 
 pub fn get_tree_object<T: ThreadMode, P: AsRef<Path>>(

--- a/src/lib/src/core/db/tree_db.rs
+++ b/src/lib/src/core/db/tree_db.rs
@@ -165,7 +165,7 @@ pub fn put_tree_object<T: ThreadMode, P: AsRef<Path>>(
             for child in children.iter_mut() {
                 // replace all \\ in path with /
                 if let Some(path_str) = child.path().to_str() {
-                    let new_path = path_str.replace("\\", "/");
+                    let new_path = path_str.replace('\\', "/");
                     child.set_path(PathBuf::from(new_path));
                 }
             }

--- a/src/lib/src/core/index/mod_stager.rs
+++ b/src/lib/src/core/index/mod_stager.rs
@@ -359,6 +359,9 @@ mod tests {
 
     #[test]
     fn test_stage_delete_appended_mod() -> Result<(), OxenError> {
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
         test::run_training_data_repo_test_fully_committed(|repo| {
             let branch_name = "test-append";
             let branch = api::local::branches::create_checkout(&repo, branch_name)?;

--- a/src/lib/src/core/index/object_db_reader.rs
+++ b/src/lib/src/core/index/object_db_reader.rs
@@ -1,7 +1,7 @@
 use crate::constants::{self};
-use crate::core::db;
 use crate::core::db::path_db;
 use crate::core::db::tree_db::{TreeObject, TreeObjectChild};
+use crate::core::db::{self, tree_db};
 
 use crate::error::OxenError;
 
@@ -109,26 +109,28 @@ impl ObjectDBReader {
         child: &TreeObjectChild,
     ) -> Result<Option<TreeObject>, OxenError> {
         match child {
-            TreeObjectChild::File { hash, .. } => path_db::get_entry(&self.files_db, hash),
-            TreeObjectChild::Dir { hash, .. } => path_db::get_entry(&self.dirs_db, hash),
-            TreeObjectChild::VNode { hash, .. } => path_db::get_entry(&self.vnodes_db, hash),
-            TreeObjectChild::Schema { hash, .. } => path_db::get_entry(&self.schemas_db, hash),
+            TreeObjectChild::File { hash, .. } => tree_db::get_tree_object(&self.files_db, hash),
+            TreeObjectChild::Dir { hash, .. } => tree_db::get_tree_object(&self.dirs_db, hash),
+            TreeObjectChild::VNode { hash, .. } => tree_db::get_tree_object(&self.vnodes_db, hash),
+            TreeObjectChild::Schema { hash, .. } => {
+                tree_db::get_tree_object(&self.schemas_db, hash)
+            }
         }
     }
 
     pub fn get_dir(&self, hash: &str) -> Result<Option<TreeObject>, OxenError> {
-        path_db::get_entry(&self.dirs_db, hash)
+        tree_db::get_tree_object(&self.dirs_db, hash)
     }
 
     pub fn get_file(&self, hash: &str) -> Result<Option<TreeObject>, OxenError> {
-        path_db::get_entry(&self.files_db, hash)
+        tree_db::get_tree_object(&self.files_db, hash)
     }
 
     pub fn get_vnode(&self, hash: &str) -> Result<Option<TreeObject>, OxenError> {
-        path_db::get_entry(&self.vnodes_db, hash)
+        tree_db::get_tree_object(&self.vnodes_db, hash)
     }
 
     pub fn get_schema(&self, hash: &str) -> Result<Option<TreeObject>, OxenError> {
-        path_db::get_entry(&self.schemas_db, hash)
+        tree_db::get_tree_object(&self.schemas_db, hash)
     }
 }

--- a/src/lib/src/core/index/object_db_reader.rs
+++ b/src/lib/src/core/index/object_db_reader.rs
@@ -1,5 +1,4 @@
 use crate::constants::{self};
-use crate::core::db::path_db;
 use crate::core::db::tree_db::{TreeObject, TreeObjectChild};
 use crate::core::db::{self, tree_db};
 

--- a/src/lib/src/core/index/schema_reader.rs
+++ b/src/lib/src/core/index/schema_reader.rs
@@ -327,11 +327,12 @@ mod tests {
             let last_commit = history.first().unwrap();
             let schema_reader = SchemaReader::new(&repo, &last_commit.id)?;
 
-            let schema_ref = "annotations/train/bounding_box.csv";
+            
+            let schema_ref = &PathBuf::from("annotations").join("train").join("bounding_box.csv").to_string_lossy().to_string();
             let schemas = schema_reader.list_schemas_for_ref(schema_ref)?;
 
             assert_eq!(schemas.len(), 1);
-            assert!(schemas.contains_key(&PathBuf::from("annotations/train/bounding_box.csv")));
+            assert!(schemas.contains_key(&PathBuf::from(schema_ref)));
 
             Ok(())
         })

--- a/src/lib/src/core/index/schema_reader.rs
+++ b/src/lib/src/core/index/schema_reader.rs
@@ -99,7 +99,6 @@ impl SchemaReader {
 
         // Get the hash of the schema's path
         let full_path_str = schema_path.to_str().unwrap().replace('\\', "/");
-        // let full_path_str = schema_path.to_str().unwrap();
         let schema_path_hash_prefix = util::hasher::hash_path(full_path_str)[0..2].to_string();
 
         // Binary search for the appropriate vnode
@@ -167,7 +166,7 @@ impl SchemaReader {
         for vnode in dir_node.children() {
             let vnode = self.object_reader.get_vnode(vnode.hash())?.unwrap();
             for child in vnode.children() {
-                log::debug!("got vnode child {:?}", child);
+                // log::debug!("got vnode child {:?}", child);
                 match child {
                     TreeObjectChild::Dir { hash, .. } => {
                         let dir_node = self.object_reader.get_dir(hash)?.unwrap();
@@ -175,9 +174,9 @@ impl SchemaReader {
                     }
                     TreeObjectChild::Schema { path, hash, .. } => {
                         let stripped_path = path.strip_prefix(SCHEMAS_TREE_PREFIX).unwrap();
-                        log::debug!("got stripped path {:?} and hash {:?}", stripped_path, hash);
+                        // log::debug!("got stripped path {:?} and hash {:?}", stripped_path, hash);
                         let found_schema = self.get_schema_by_hash(hash)?;
-                        log::debug!("got found schema {:?}", found_schema);
+                        // log::debug!("got found schema {:?}", found_schema);
                         path_vals.insert(stripped_path.to_path_buf(), found_schema);
                     }
                     _ => {}
@@ -246,9 +245,6 @@ impl SchemaReader {
     ) -> Result<HashMap<PathBuf, Schema>, OxenError> {
         let all_schemas = self.list_schemas()?;
 
-        log::debug!("list_schemas_for_ref() got all schemas: {:?}", all_schemas);
-
-        log::debug!("looking for ref: {:?}", schema_ref.as_ref());
         let mut found_schemas: HashMap<PathBuf, Schema> = HashMap::new();
 
         for (path, schema) in all_schemas.iter() {
@@ -327,8 +323,11 @@ mod tests {
             let last_commit = history.first().unwrap();
             let schema_reader = SchemaReader::new(&repo, &last_commit.id)?;
 
-            
-            let schema_ref = &PathBuf::from("annotations").join("train").join("bounding_box.csv").to_string_lossy().to_string();
+            let schema_ref = &PathBuf::from("annotations")
+                .join("train")
+                .join("bounding_box.csv")
+                .to_string_lossy()
+                .to_string();
             let schemas = schema_reader.list_schemas_for_ref(schema_ref)?;
 
             assert_eq!(schemas.len(), 1);

--- a/src/lib/src/core/index/tree_db_reader.rs
+++ b/src/lib/src/core/index/tree_db_reader.rs
@@ -1,4 +1,4 @@
-use crate::core::db::tree_db::{TreeObject, TreeObjectChild};
+use crate::core::db::tree_db::{self, TreeObject, TreeObjectChild};
 use crate::core::db::{self, path_db};
 use crate::error::OxenError;
 use rocksdb::{DBWithThreadMode, MultiThreaded};
@@ -21,14 +21,14 @@ impl CommitTreeReader {
     ) -> Result<Option<TreeObject>, OxenError> {
         match self {
             CommitTreeReader::TreeObjectReader(reader) => reader.get_node_from_child(child),
-            CommitTreeReader::DB(db) => path_db::get_entry(db, child.hash()),
+            CommitTreeReader::DB(db) => tree_db::get_tree_object(db, child.hash()),
         }
     }
 
     pub fn get_root_entry(&self) -> Result<Option<TreeObject>, OxenError> {
         match self {
             CommitTreeReader::TreeObjectReader(reader) => reader.get_root_node(),
-            CommitTreeReader::DB(db) => path_db::get_entry(db, ""),
+            CommitTreeReader::DB(db) => tree_db::get_tree_object(db, ""),
         }
     }
 }

--- a/src/lib/src/core/index/tree_db_reader.rs
+++ b/src/lib/src/core/index/tree_db_reader.rs
@@ -1,5 +1,5 @@
 use crate::core::db::tree_db::{self, TreeObject, TreeObjectChild};
-use crate::core::db::{self, path_db};
+use crate::core::db::{self};
 use crate::error::OxenError;
 use rocksdb::{DBWithThreadMode, MultiThreaded};
 use std::collections::HashSet;

--- a/src/lib/src/core/index/tree_object_reader.rs
+++ b/src/lib/src/core/index/tree_object_reader.rs
@@ -1,7 +1,7 @@
 use crate::constants::{self};
-use crate::core::db;
 use crate::core::db::path_db;
 use crate::core::db::tree_db::{TreeObject, TreeObjectChild};
+use crate::core::db::{self, tree_db};
 
 use crate::error::OxenError;
 
@@ -121,15 +121,17 @@ impl TreeObjectReader {
         child: &TreeObjectChild,
     ) -> Result<Option<TreeObject>, OxenError> {
         match child {
-            TreeObjectChild::File { hash, .. } => path_db::get_entry(&self.files_db, hash),
-            TreeObjectChild::Dir { hash, .. } => path_db::get_entry(&self.dirs_db, hash),
-            TreeObjectChild::VNode { hash, .. } => path_db::get_entry(&self.vnodes_db, hash),
-            TreeObjectChild::Schema { hash, .. } => path_db::get_entry(&self.schemas_db, hash),
+            TreeObjectChild::File { hash, .. } => tree_db::get_tree_object(&self.files_db, hash),
+            TreeObjectChild::Dir { hash, .. } => tree_db::get_tree_object(&self.dirs_db, hash),
+            TreeObjectChild::VNode { hash, .. } => tree_db::get_tree_object(&self.vnodes_db, hash),
+            TreeObjectChild::Schema { hash, .. } => {
+                tree_db::get_tree_object(&self.schemas_db, hash)
+            }
         }
     }
 
     pub fn get_root_node(&self) -> Result<Option<TreeObject>, OxenError> {
         let root_hash: String = path_db::get_entry(&self.dir_hashes_db, "")?.unwrap();
-        path_db::get_entry(&self.dirs_db, root_hash)
+        tree_db::get_tree_object(&self.dirs_db, root_hash)
     }
 }

--- a/src/lib/src/model/schema.rs
+++ b/src/lib/src/model/schema.rs
@@ -77,7 +77,8 @@ impl Schema {
 
     /// Checks if the provided schema matches this schema given a hash, path, and name
     pub fn matches_ref(&self, schema_ref: impl AsRef<str>) -> bool {
-        let schema_ref = schema_ref.as_ref().replace('\\', "/");
+        // let schema_ref = schema_ref.as_ref().replace('\\', "/");
+        let schema_ref = schema_ref.as_ref();
         self.hash == schema_ref || self.name.as_ref().unwrap_or(&"".to_string()) == &schema_ref
     }
 

--- a/src/lib/src/model/schema.rs
+++ b/src/lib/src/model/schema.rs
@@ -77,9 +77,8 @@ impl Schema {
 
     /// Checks if the provided schema matches this schema given a hash, path, and name
     pub fn matches_ref(&self, schema_ref: impl AsRef<str>) -> bool {
-        // let schema_ref = schema_ref.as_ref().replace('\\', "/");
         let schema_ref = schema_ref.as_ref();
-        self.hash == schema_ref || self.name.as_ref().unwrap_or(&"".to_string()) == &schema_ref
+        self.hash == schema_ref || self.name.as_ref().unwrap_or(&"".to_string()) == schema_ref
     }
 
     /// Add metadata to a column

--- a/src/server/src/controllers/data_frames.rs
+++ b/src/server/src/controllers/data_frames.rs
@@ -92,8 +92,10 @@ pub async fn get(
     let og_schema = if let Some(schema) =
         api::local::schemas::get_by_path_from_ref(&repo, &resource.commit.id, &resource.file_path)?
     {
+        log::debug!("get_df() got some schema {:?}", schema);
         schema
     } else {
+        log::debug!("get_df() did not find cached schema");
         match df.schema() {
             Ok(schema) => Ok(Schema::from_polars(&schema.to_owned())),
             Err(e) => {

--- a/src/server/src/controllers/data_frames.rs
+++ b/src/server/src/controllers/data_frames.rs
@@ -92,10 +92,8 @@ pub async fn get(
     let og_schema = if let Some(schema) =
         api::local::schemas::get_by_path_from_ref(&repo, &resource.commit.id, &resource.file_path)?
     {
-        log::debug!("get_df() got some schema {:?}", schema);
         schema
     } else {
-        log::debug!("get_df() did not find cached schema");
         match df.schema() {
             Ok(schema) => Ok(Schema::from_polars(&schema.to_owned())),
             Err(e) => {


### PR DESCRIPTION
CI failing due to three remote staging environment tests, all of which fail only on windows due to resource access conflicts in DuckDB. This is fine because Windows isn't our server OS.

This PR: 
- Reroutes all GETs and PUTs of `TreeObject` merkle tree nodes through the `tree_db` module's get and put methods, which ensure that all paths are **unix in the databases** and **os-specific in memory** at all times.
- Removes now-unnecessary logic to handle unix-ifying paths in schema workflows 
- Modifies tests which used hardcoded unix-style paths for schemarefs