### PR TITLE
Hotfix for df size issue

### DIFF
--- a/src/lib/src/core/cache/cachers/df_size.rs
+++ b/src/lib/src/core/cache/cachers/df_size.rs
@@ -30,9 +30,9 @@ pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError>
         let path = util::fs::version_path(repo, &entry);
 
         if util::fs::is_tabular(&path) {
-            log::debug!("getting size for entry {:?} at path {:?}", entry, path);
+            // log::debug!("getting size for entry {:?} at path {:?}", entry, path);
             let data_frame_size = tabular::get_size(&path)?;
-            log::debug!("resulting df size is {:?}", data_frame_size);
+            // log::debug!("resulting df size is {:?}", data_frame_size);
 
             let new_df = df!(
                 COL_PATH => [path.to_str()],
@@ -40,7 +40,7 @@ pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError>
                 COL_HEIGHT => [data_frame_size.height.to_string()])?;
 
             df = df.vstack(&new_df)?;
-            log::debug!("df tail now is {:?}", df.tail(Some(1)));
+            // log::debug!("df tail now is {:?}", df.tail(Some(1)));
         }
     }
 
@@ -52,7 +52,6 @@ pub fn get_cache_for_version(
     commit: &Commit,
     version_path: &PathBuf,
 ) -> Result<DataFrameSize, OxenError> {
-    log::debug!("getting cache for version at path {:?}", version_path);
     match get_from_cache(repo, commit, version_path) {
         Ok(result) => match result {
             Some(size) => Ok(size),
@@ -88,8 +87,6 @@ fn get_from_cache(
             ])
             .filter(col(COL_PATH).eq(lit(version_path.to_string_lossy().to_string())))
             .collect()?;
-
-        log::debug!("and got the df");
 
         let column_width = df_for_path.column(COL_WIDTH)?.u64()?;
 

--- a/src/lib/src/core/df/tabular.rs
+++ b/src/lib/src/core/df/tabular.rs
@@ -162,7 +162,7 @@ pub fn scan_df_parquet(
     );
     Ok(LazyFrame::scan_parquet(&path, args).unwrap_or_else(|_| {
         panic!(
-            "WHOA UNWRAPPING PARQUET {}: {:?}",
+            "Panic scanning parquet file {}: {:?}",
             READ_ERROR,
             path.as_ref()
         )

--- a/src/lib/src/core/df/tabular.rs
+++ b/src/lib/src/core/df/tabular.rs
@@ -160,8 +160,13 @@ pub fn scan_df_parquet(
         path.as_ref(),
         args.n_rows
     );
-    Ok(LazyFrame::scan_parquet(&path, args)
-        .unwrap_or_else(|_| panic!("{}: {:?}", READ_ERROR, path.as_ref())))
+    Ok(LazyFrame::scan_parquet(&path, args).unwrap_or_else(|_| {
+        panic!(
+            "WHOA UNWRAPPING PARQUET {}: {:?}",
+            READ_ERROR,
+            path.as_ref()
+        )
+    }))
 }
 
 fn read_df_arrow(path: impl AsRef<Path>) -> Result<DataFrame, OxenError> {

--- a/src/server/src/controllers/data_frames.rs
+++ b/src/server/src/controllers/data_frames.rs
@@ -49,6 +49,7 @@ pub async fn get(
     // Get the cached size of the data frame
     let data_frame_size =
         cachers::df_size::get_cache_for_version(&repo, &resource.commit, &version_path)?;
+
     log::debug!(
         "controllers::data_frames got data frame size {:?}",
         data_frame_size
@@ -86,11 +87,7 @@ pub async fn get(
         opts.slice = Some(format!("{}..{}", start, end));
     }
 
-    log::debug!("about to scan the df at path {:?}", version_path);
-
     let df = tabular::scan_df(&version_path, &opts, data_frame_size.height)?;
-
-    log::debug!("got the df");
 
     // Try to get the schema from disk
     let og_schema = if let Some(schema) =

--- a/src/server/src/controllers/data_frames.rs
+++ b/src/server/src/controllers/data_frames.rs
@@ -86,7 +86,11 @@ pub async fn get(
         opts.slice = Some(format!("{}..{}", start, end));
     }
 
+    log::debug!("about to scan the df at path {:?}", version_path);
+
     let df = tabular::scan_df(&version_path, &opts, data_frame_size.height)?;
+
+    log::debug!("got the df");
 
     // Try to get the schema from disk
     let og_schema = if let Some(schema) =


### PR DESCRIPTION
Temporary, will investigate further next week. This triggers a cache miss rather than a panic if the polars ops on the dataframe return nothing

Things I've seen so far @gschoeni 
1. The df cache does still seem to write. I haven't yet verified the paths yet 
2. Clearing out .oxen dir and pushing from new has the same issue, so it's definitely a recurring problem and not just a corrupt repo
3. I do think it's kinda weird that we store the df sizes for a commit under the version paths rather than the entry path 🤔 