### PR TITLE
Query SQL with duckdb instead of polars.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,6 @@ dependencies = [
  "rand",
  "rayon",
  "redis",
- "regex",
  "reqwest",
  "rocksdb",
  "sanitize-filename",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,7 @@ dependencies = [
  "rand",
  "rayon",
  "redis",
+ "regex",
  "reqwest",
  "rocksdb",
  "sanitize-filename",
@@ -4444,9 +4445,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ r2d2 = "0.8.10"
 rand = "0.8.5"
 rayon = "1.7.0"
 redis = { version = "0.25.3", features = ["r2d2"] }
+regex = "1.10.4"
 reqwest = { version = "0.12.3", features = [
     "multipart",
     "json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,6 @@ r2d2 = "0.8.10"
 rand = "0.8.5"
 rayon = "1.7.0"
 redis = { version = "0.25.3", features = ["r2d2"] }
-regex = "1.10.4"
 reqwest = { version = "0.12.3", features = [
     "multipart",
     "json",

--- a/src/lib/src/api/remote/df.rs
+++ b/src/lib/src/api/remote/df.rs
@@ -85,6 +85,8 @@ pub async fn get_staged(
 #[cfg(test)]
 mod tests {
 
+    use std::path::PathBuf;
+
     use crate::api;
     use crate::command;
     use crate::constants;
@@ -384,7 +386,7 @@ mod tests {
             let df = api::remote::df::get(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,
-                "large_files/test.csv",
+                PathBuf::from("large_files").join("test.csv"),
                 opts,
             )
             .await?;

--- a/src/lib/src/api/remote/df.rs
+++ b/src/lib/src/api/remote/df.rs
@@ -4,7 +4,7 @@ use crate::api;
 use crate::error::OxenError;
 use crate::model::RemoteRepository;
 use crate::opts::DFOpts;
-use crate::view::JsonDataFrameViewResponse;
+use crate::view::{JsonDataFrameViewResponse, StatusMessage};
 
 use super::client;
 
@@ -79,6 +79,35 @@ pub async fn get_staged(
             let err = format!("Request failed: {url}\nErr {err:?}");
             Err(OxenError::basic_str(err))
         }
+    }
+}
+
+pub async fn index_df(
+    remote_repo: &RemoteRepository,
+    commit_or_branch: &str,
+    path: impl AsRef<Path>,
+) -> Result<StatusMessage, OxenError> {
+    let path_str = path.as_ref().to_str().unwrap();
+    let uri = format!("/data_frame/index/{commit_or_branch}/{path_str}");
+    let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
+
+    let client = client::new_for_url(&url)?;
+
+    if let Ok(res) = client.post(&url).send().await {
+        let body = client::parse_json_body(&url, res).await?;
+        let response: Result<StatusMessage, serde_json::Error> = serde_json::from_str(&body);
+
+        match response {
+            Ok(val) => {
+                log::debug!("got StatusMessage: {:?}", val);
+                Ok(val)
+            }
+            Err(err) => Err(OxenError::basic_str(format!(
+                "error parsing response from {url}\n\nErr {err:?} \n\n{body}"
+            ))),
+        }
+    } else {
+        Err(OxenError::basic_str(format!("Request failed: {url}")))
     }
 }
 
@@ -384,6 +413,10 @@ mod tests {
 
             // Push the repo
             command::push(&local_repo).await?;
+
+            // Index the df on the remote repo
+            api::remote::df::index_df(&remote_repo, DEFAULT_BRANCH_NAME, "large_files/test.csv")
+                .await?;
 
             // Get the df
             let mut opts = DFOpts::empty();

--- a/src/lib/src/api/remote/df.rs
+++ b/src/lib/src/api/remote/df.rs
@@ -393,6 +393,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_paginate_df_after_sql() -> Result<(), OxenError> {
+        if std::env::consts::OS == "windows" {
+            return Ok(());
+        }
+
         test::run_empty_local_repo_test_async(|mut local_repo| async move {
             let repo_dir = &local_repo.path;
             let large_dir = repo_dir.join("large_files");

--- a/src/lib/src/constants.rs
+++ b/src/lib/src/constants.rs
@@ -61,6 +61,8 @@ pub const STAGED_DIR: &str = "staged";
 pub const TABLE_NAME: &str = "STAGED_DATA";
 /// Oxen's internal id column in duckdb remote staging tables
 pub const OXEN_ID_COL: &str = "_oxen_id";
+/// Name of the folder of the cache dir in which dfs are indexed as duckdbs
+pub const DUCKDB_CACHE_DIR: &str = "duckdb";
 /// prefix for the sync status dirs to tell if commits are synced locally
 pub const SYNC_STATUS_DIR: &str = "sync_status";
 /// Flag for if the repository was cloned in a shallow fashion

--- a/src/lib/src/constants.rs
+++ b/src/lib/src/constants.rs
@@ -58,7 +58,7 @@ pub const STATS_DIR: &str = "stats";
 /// prefix for the staged dirs
 pub const STAGED_DIR: &str = "staged";
 /// Name of the table in the duckdb db used for remote staging
-pub const TABLE_NAME: &str = "STAGED_DATA";
+pub const TABLE_NAME: &str = "df";
 /// Oxen's internal id column in duckdb remote staging tables
 pub const OXEN_ID_COL: &str = "_oxen_id";
 /// Name of the folder of the cache dir in which dfs are indexed as duckdbs

--- a/src/lib/src/constants.rs
+++ b/src/lib/src/constants.rs
@@ -63,6 +63,8 @@ pub const TABLE_NAME: &str = "STAGED_DATA";
 pub const OXEN_ID_COL: &str = "_oxen_id";
 /// Name of the folder of the cache dir in which dfs are indexed as duckdbs
 pub const DUCKDB_CACHE_DIR: &str = "duckdb";
+/// Default name for duckdb table used for indexing dataframes
+pub const DUCKDB_DF_TABLE_NAME: &str = "df";
 /// prefix for the sync status dirs to tell if commits are synced locally
 pub const SYNC_STATUS_DIR: &str = "sync_status";
 /// Flag for if the repository was cloned in a shallow fashion

--- a/src/lib/src/constants.rs
+++ b/src/lib/src/constants.rs
@@ -65,6 +65,8 @@ pub const OXEN_ID_COL: &str = "_oxen_id";
 pub const DUCKDB_CACHE_DIR: &str = "duckdb";
 /// Default name for duckdb table used for indexing dataframes
 pub const DUCKDB_DF_TABLE_NAME: &str = "df";
+/// Max number of rows to query from a dataframe
+pub const MAX_QUERYABLE_ROWS: usize = 1_000_000;
 /// prefix for the sync status dirs to tell if commits are synced locally
 pub const SYNC_STATUS_DIR: &str = "sync_status";
 /// Flag for if the repository was cloned in a shallow fashion

--- a/src/lib/src/core/db/df_db.rs
+++ b/src/lib/src/core/db/df_db.rs
@@ -1,7 +1,7 @@
 //! Abstraction over DuckDB database to write and read dataframes from disk.
 //!
 
-use crate::constants::{DEFAULT_PAGE_SIZE, OXEN_ID_COL};
+use crate::constants::{DEFAULT_PAGE_SIZE, DUCKDB_DF_TABLE_NAME, OXEN_ID_COL};
 use crate::core::db::df_db;
 use crate::core::df::tabular;
 use crate::error::OxenError;
@@ -337,35 +337,35 @@ pub fn insert_polars_df(
 }
 
 pub fn index_file(path: &Path, conn: &duckdb::Connection) -> Result<(), OxenError> {
-    let table_name = "df";
+    log::debug!("df_db() index file {:?}", path);
     let extension: &str = &util::fs::extension_from_path(path);
     let path_str = path.to_string_lossy().to_string();
     match extension {
         "csv" => {
             let query = format!(
                 "CREATE TABLE {} AS SELECT * FROM read_csv('{}')",
-                table_name, path_str
+                DUCKDB_DF_TABLE_NAME, path_str
             );
             conn.execute(&query, [])?;
         }
         "tsv" => {
             let query = format!(
                 "CREATE TABLE {} AS SELECT * FROM read_tsv('{}')",
-                table_name, path_str
+                DUCKDB_DF_TABLE_NAME, path_str
             );
             conn.execute(&query, [])?;
         }
         "parquet" => {
             let query = format!(
                 "CREATE TABLE {} AS SELECT * FROM read_parquet('{}')",
-                table_name, path_str
+                DUCKDB_DF_TABLE_NAME, path_str
             );
             conn.execute(&query, [])?;
         }
         "jsonl" | "json" | "ndjson" => {
             let query = format!(
                 "CREATE TABLE {} AS SELECT * FROM read_json('{}')",
-                table_name, path_str
+                DUCKDB_DF_TABLE_NAME, path_str
             );
             conn.execute(&query, [])?;
         }

--- a/src/lib/src/core/db/df_db.rs
+++ b/src/lib/src/core/db/df_db.rs
@@ -186,8 +186,13 @@ pub fn count_where(
 /// Select fields from a table.
 pub fn select(conn: &duckdb::Connection, stmt: &sql::Select) -> Result<DataFrame, OxenError> {
     let sql = stmt.as_string();
-    log::debug!("select sql: {}", sql);
-    let mut stmt = conn.prepare(&sql)?;
+    let df = select_raw(conn, &sql)?;
+    Ok(df)
+}
+
+pub fn select_raw(conn: &duckdb::Connection, stmt: &str) -> Result<DataFrame, OxenError> {
+    log::debug!("select sql: {}", stmt);
+    let mut stmt = conn.prepare(&stmt)?;
 
     // let pl: Vec<DataFrame> = stmt.query_polars([])?.collect();
     // let df = accumulate_dataframes_vertical_unchecked(pl);

--- a/src/lib/src/core/db/df_db.rs
+++ b/src/lib/src/core/db/df_db.rs
@@ -192,7 +192,7 @@ pub fn select(conn: &duckdb::Connection, stmt: &sql::Select) -> Result<DataFrame
 
 pub fn select_raw(conn: &duckdb::Connection, stmt: &str) -> Result<DataFrame, OxenError> {
     log::debug!("select sql: {}", stmt);
-    let mut stmt = conn.prepare(&stmt)?;
+    let mut stmt = conn.prepare(stmt)?;
 
     // let pl: Vec<DataFrame> = stmt.query_polars([])?.collect();
     // let df = accumulate_dataframes_vertical_unchecked(pl);

--- a/src/lib/src/core/db/df_db.rs
+++ b/src/lib/src/core/db/df_db.rs
@@ -350,7 +350,7 @@ pub fn index_file(path: &Path, conn: &duckdb::Connection) -> Result<(), OxenErro
         }
         "tsv" => {
             let query = format!(
-                "CREATE TABLE {} AS SELECT * FROM read_tsv('{}')",
+                "CREATE TABLE {} AS SELECT * FROM read_csv('{}')",
                 DUCKDB_DF_TABLE_NAME, path_str
             );
             conn.execute(&query, [])?;
@@ -390,7 +390,7 @@ pub fn index_file_with_id(path: &Path, conn: &duckdb::Connection) -> Result<(), 
             conn.execute(&query, [])?;
         }
         "tsv" => {
-            let query = format!("CREATE TABLE {} AS SELECT *, CAST(uuid() AS VARCHAR) AS {} FROM read_tsv('{}', AUTO_DETECT=TRUE, header=True);", DUCKDB_DF_TABLE_NAME, OXEN_ID_COL, path.to_string_lossy());
+            let query = format!("CREATE TABLE {} AS SELECT *, CAST(uuid() AS VARCHAR) AS {} FROM read_csv('{}', AUTO_DETECT=TRUE, header=True);", DUCKDB_DF_TABLE_NAME, OXEN_ID_COL, path.to_string_lossy());
             conn.execute(&query, [])?;
         }
         "parquet" => {
@@ -429,7 +429,7 @@ pub fn from_clause_from_disk_path(path: &Path) -> Result<String, OxenError> {
         }
         "tsv" => {
             let str_path = path.to_string_lossy().to_string();
-            Ok(format!("read_tsv('{}')", str_path))
+            Ok(format!("read_csv('{}')", str_path))
         }
         "parquet" => {
             let str_path = path.to_string_lossy().to_string();

--- a/src/lib/src/core/db/df_db.rs
+++ b/src/lib/src/core/db/df_db.rs
@@ -331,6 +331,48 @@ pub fn insert_polars_df(
     Ok(result_df)
 }
 
+pub fn index_file(path: &Path, conn: &duckdb::Connection) -> Result<(), OxenError> {
+    let table_name = "df";
+    let extension: &str = &util::fs::extension_from_path(path);
+    let path_str = path.to_string_lossy().to_string();
+    match extension {
+        "csv" => {
+            let query = format!(
+                "CREATE TABLE {} AS SELECT * FROM read_csv('{}')",
+                table_name, path_str
+            );
+            conn.execute(&query, [])?;
+        }
+        "tsv" => {
+            let query = format!(
+                "CREATE TABLE {} AS SELECT * FROM read_tsv('{}')",
+                table_name, path_str
+            );
+            conn.execute(&query, [])?;
+        }
+        "parquet" => {
+            let query = format!(
+                "CREATE TABLE {} AS SELECT * FROM read_parquet('{}')",
+                table_name, path_str
+            );
+            conn.execute(&query, [])?;
+        }
+        "jsonl" | "json" | "ndjson" => {
+            let query = format!(
+                "CREATE TABLE {} AS SELECT * FROM read_json('{}')",
+                table_name, path_str
+            );
+            conn.execute(&query, [])?;
+        }
+        _ => {
+            return Err(OxenError::basic_str(
+                "Invalid file type: expected .csv, .tsv, .parquet, .jsonl, .json, .ndjson",
+            ))
+        }
+    }
+    Ok(())
+}
+
 pub fn from_clause_from_disk_path(path: &Path) -> Result<String, OxenError> {
     let extension: &str = &util::fs::extension_from_path(path);
     match extension {

--- a/src/lib/src/core/df.rs
+++ b/src/lib/src/core/df.rs
@@ -4,4 +4,5 @@
 pub mod agg;
 pub mod filter;
 pub mod pretty_print;
+pub mod sql;
 pub mod tabular;

--- a/src/lib/src/core/df/sql.rs
+++ b/src/lib/src/core/df/sql.rs
@@ -116,6 +116,13 @@ pub fn index_df(
     Ok(())
 }
 
+pub fn df_is_indexed(repo: &LocalRepository, entry: &CommitEntry) -> Result<bool, OxenError> {
+    let duckdb_path = db_cache_path(repo, entry);
+    let conn = df_db::get_connection(duckdb_path)?;
+    let is_indexed = df_db::table_exists(&conn, DUCKDB_DF_TABLE_NAME)?;
+    Ok(is_indexed)
+}
+
 async fn get_sql(schema: &Schema, q: &str, host: String) -> Result<String, OxenError> {
     let polars_schema = schema.to_polars();
     let schema_str = tabular::polars_schema_to_flat_str(&polars_schema);

--- a/src/lib/src/core/df/sql.rs
+++ b/src/lib/src/core/df/sql.rs
@@ -109,7 +109,7 @@ pub fn index_df(
 
     let version_path = util::fs::version_path(repo, entry);
 
-    df_db::index_file(&version_path, conn)?;
+    df_db::index_file_with_id(&version_path, conn)?;
 
     log::debug!("file successfully indexed");
 

--- a/src/lib/src/core/df/sql.rs
+++ b/src/lib/src/core/df/sql.rs
@@ -1,16 +1,13 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-use futures::executor::LocalPool;
-use polars::{frame::DataFrame, lazy::frame::LazyFrame};
-use sql_query_builder::Select;
+use polars::frame::DataFrame;
 
 use crate::{
     api,
     constants::{CACHE_DIR, DUCKDB_CACHE_DIR, DUCKDB_DF_TABLE_NAME},
     core::db::df_db,
     error::OxenError,
-    model::{schema::DataType, CommitEntry, LocalRepository, Schema},
-    opts::PaginateOpts,
+    model::{CommitEntry, LocalRepository, Schema},
     util,
 };
 
@@ -21,13 +18,12 @@ use super::tabular;
 pub fn db_cache_path(repo: &LocalRepository, entry: &CommitEntry) -> PathBuf {
     let hash_prefix = &entry.hash[0..2];
     let hash_suffix = &entry.hash[2..];
-    let path = repo
-        .path
+
+    repo.path
         .join(CACHE_DIR)
         .join(DUCKDB_CACHE_DIR)
         .join(hash_prefix)
-        .join(hash_suffix);
-    path
+        .join(hash_suffix)
 }
 
 pub fn get_conn(
@@ -35,7 +31,7 @@ pub fn get_conn(
     entry: &CommitEntry,
 ) -> Result<duckdb::Connection, OxenError> {
     let duckdb_path = db_cache_path(repo, entry);
-    let conn = df_db::get_connection(&duckdb_path)?;
+    let conn = df_db::get_connection(duckdb_path)?;
     Ok(conn)
 }
 
@@ -47,31 +43,12 @@ pub fn query_df(
     repo: &LocalRepository,
     entry: &CommitEntry,
     sql: String,
-    page_opts: &PaginateOpts,
     conn: &mut duckdb::Connection,
 ) -> Result<DataFrame, OxenError> {
     let duckdb_path = db_cache_path(repo, entry);
     index_df(repo, entry, conn)?;
 
-    // let limit_suffix = if page_opts.page_size > 0 {
-    //     format!(" LIMIT {}", page_opts.page_size)
-    // } else {
-    //     "".to_string()
-    // };
-
-    // let offset_suffix = if page_opts.page_num > 0 {
-    //     format!(" OFFSET {}", page_opts.page_size * (page_opts.page_num - 1))
-    // } else {
-    //     "".to_string()
-    // };
-
-    // // Strip a semicolon off the end of sql if it exists, then add limit suffix and offset suffix
-    // let mut sql = sql.strip_suffix(";").unwrap_or(&sql).to_string();
-    // sql.push_str(&limit_suffix);
-    // sql.push_str(&offset_suffix);
-    // sql.push_str(";");
-
-    let conn = df_db::get_connection(&duckdb_path)?;
+    let conn = df_db::get_connection(duckdb_path)?;
     log::debug!("connection created");
 
     let df = df_db::select_raw(&conn, &sql)?;
@@ -84,13 +61,12 @@ pub fn text2sql_df(
     entry: &CommitEntry,
     schema: &Schema,
     nlp: String,
-    page_opts: &PaginateOpts,
     conn: &mut duckdb::Connection,
     host: String,
 ) -> Result<DataFrame, OxenError> {
     let sql = futures::executor::block_on(get_sql(schema, &nlp, host))?;
     println!("\n{}\n", sql);
-    query_df(repo, entry, sql, page_opts, conn)
+    query_df(repo, entry, sql, conn)
 }
 
 pub fn clear_all_cached_dfs(repo: &LocalRepository) -> Result<(), OxenError> {
@@ -128,12 +104,12 @@ pub fn index_df(
     }
 
     if !parent.exists() {
-        util::fs::create_dir_all(&parent)?;
+        util::fs::create_dir_all(parent)?;
     }
 
-    let version_path = util::fs::version_path(&repo, &entry);
+    let version_path = util::fs::version_path(repo, entry);
 
-    df_db::index_file(&version_path, &conn)?;
+    df_db::index_file(&version_path, conn)?;
 
     log::debug!("file successfully indexed");
 

--- a/src/lib/src/core/df/sql.rs
+++ b/src/lib/src/core/df/sql.rs
@@ -1,0 +1,59 @@
+use std::path::{Path, PathBuf};
+
+use polars::frame::DataFrame;
+use sql_query_builder::Select;
+
+use crate::{
+    constants::{CACHE_DIR, DUCKDB_CACHE_DIR},
+    core::db::df_db,
+    error::OxenError,
+    model::{CommitEntry, LocalRepository}, util,
+};
+
+/// Module for handling the indexing of versioned dfs into duckdbs for SQL querying
+
+pub fn db_cache_path(repo: LocalRepository, entry: CommitEntry) -> PathBuf {
+    let hash_prefix = &entry.hash[0..2];
+    let hash_suffix = &entry.hash[2..];
+    let path = repo
+        .path
+        .join(CACHE_DIR)
+        .join(DUCKDB_CACHE_DIR)
+        .join(hash_prefix)
+        .join(hash_suffix);
+    path
+}
+
+pub fn index_df(repo: LocalRepository, entry: CommitEntry) -> Result<(), OxenError> {
+    let duckdb_path = db_cache_path(repo, entry);
+
+    if duckdb_path.exists() {
+        return Ok(());
+    }
+
+    let parent = duckdb_path.parent().unwrap_or(&PathBuf::from(""));
+
+    if !parent.exists() {
+        util::fs::create_dir_all(&parent)?;
+    }
+
+    let conn = df_db::get_connection(&duckdb_path)?;
+    
+    let version_path = util::fs::version_path(&repo, &entry);
+
+    index_file()
+
+    Ok(df)
+}
+
+pub fn query_df(file_path: impl AsRef<Path>, sql: String) -> Result<DataFrame, OxenError> {
+    let duckdb_path = file_path.as_ref().parent().unwrap().join("duckdb");
+    let conn = df_db::get_connection(&duckdb_path)?;
+    log::debug!("connection created");
+    let from_clause = df_db::from_clause_from_disk_path(&file_path.as_ref())?;
+
+    let select_all = Select::new().select("*").from(&from_clause);
+    log::debug!("About to run select statement {}", select_all);
+    let df = df_db::select(&conn, &select_all)?;
+    Ok(df)
+}

--- a/src/lib/src/core/df/tabular.rs
+++ b/src/lib/src/core/df/tabular.rs
@@ -1,7 +1,6 @@
 use duckdb::ToSql;
 use polars::prelude::*;
 use polars_sql::SQLContext;
-use regex::Regex;
 use sql_query_builder::Select;
 use std::fs::File;
 
@@ -919,18 +918,6 @@ pub fn scan_df(
         },
         None => Err(OxenError::basic_str(err)),
     }
-}
-
-pub fn query_df(file_path: impl AsRef<Path>, sql: String) -> Result<DataFrame, OxenError> {
-    let duckdb_path = file_path.as_ref().parent().unwrap().join("duckdb");
-    let conn = df_db::get_connection(&duckdb_path)?;
-    log::debug!("connection created");
-    let from_clause = df_db::from_clause_from_disk_path(&file_path.as_ref())?;
-
-    let select_all = Select::new().select("*").from(&from_clause);
-    log::debug!("About to run select statement {}", select_all);
-    let df = df_db::select(&conn, &select_all)?;
-    Ok(df)
 }
 
 pub fn get_size(path: impl AsRef<Path>) -> Result<DataFrameSize, OxenError> {

--- a/src/lib/src/core/df/tabular.rs
+++ b/src/lib/src/core/df/tabular.rs
@@ -10,7 +10,7 @@ use crate::core::df::pretty_print;
 use crate::error::OxenError;
 use crate::model::schema::DataType;
 use crate::model::{CommitEntry, ContentType, DataFrameSize, LocalRepository};
-use crate::opts::{CountLinesOpts, DFOpts};
+use crate::opts::{CountLinesOpts, DFOpts, PaginateOpts};
 use crate::util::{fs, hasher};
 use crate::{api, constants};
 
@@ -658,6 +658,18 @@ fn tail(df: LazyFrame, height: usize, opts: &DFOpts) -> LazyFrame {
 pub fn slice_df(df: DataFrame, start: usize, end: usize) -> Result<DataFrame, OxenError> {
     let mut opts = DFOpts::empty();
     opts.slice = Some(format!("{}..{}", start, end));
+    let df = df.lazy();
+    let df = slice(df, &opts);
+    Ok(df.collect().expect(COLLECT_ERROR))
+}
+
+pub fn paginate_df(df: DataFrame, page_opts: &PaginateOpts) -> Result<DataFrame, OxenError> {
+    let mut opts = DFOpts::empty();
+    opts.slice = Some(format!(
+        "{}..{}",
+        page_opts.page_size * (page_opts.page_num - 1),
+        page_opts.page_size * page_opts.page_num
+    ));
     let df = df.lazy();
     let df = slice(df, &opts);
     Ok(df.collect().expect(COLLECT_ERROR))

--- a/src/lib/src/core/df/tabular.rs
+++ b/src/lib/src/core/df/tabular.rs
@@ -1,18 +1,15 @@
 use duckdb::ToSql;
 use polars::prelude::*;
-use polars_sql::SQLContext;
-use sql_query_builder::Select;
 use std::fs::File;
 
-use crate::core::db::df_db;
+use crate::constants;
 use crate::core::df::filter::DFLogicalOp;
 use crate::core::df::pretty_print;
 use crate::error::OxenError;
 use crate::model::schema::DataType;
-use crate::model::{CommitEntry, ContentType, DataFrameSize, LocalRepository};
+use crate::model::{ContentType, DataFrameSize};
 use crate::opts::{CountLinesOpts, DFOpts, PaginateOpts};
 use crate::util::{fs, hasher};
-use crate::{api, constants};
 
 use colored::Colorize;
 use comfy_table::Table;

--- a/src/lib/src/core/df/tabular.rs
+++ b/src/lib/src/core/df/tabular.rs
@@ -470,35 +470,8 @@ pub fn transform_lazy(
         df = add_col_lazy(df, &col_vals.name, &col_vals.value, &col_vals.dtype)?;
     }
 
-    // if let Some(query) = &opts.text2sql {
-    //     df = run_text2sql(df, query, opts.get_host())?;
-    // }
-
     // For aggregations, sort by first column, because it is non-deterministic
     let mut should_sort_by_first_column = false;
-    // if let Some(query) = &opts.sql {
-    //     df = run_sql(df, query)?;
-
-    //     if let Some(sql) = &opts.sql {
-    //         if sql.to_lowercase().contains("group by")
-    //             || sql.to_lowercase().contains("count(")
-    //             || sql.to_lowercase().contains("sum(")
-    //             || sql.to_lowercase().contains("avg(")
-    //             || sql.to_lowercase().contains("min(")
-    //             || sql.to_lowercase().contains("max(")
-    //             || sql.to_lowercase().contains("stddev(")
-    //             || sql.to_lowercase().contains("variance(")
-    //             || sql.to_lowercase().contains("group_concat(")
-    //             || sql.to_lowercase().contains("select distinct")
-    //         {
-    //             should_sort_by_first_column = true;
-    //         }
-
-    //         if sql.to_lowercase().contains("order by") {
-    //             should_sort_by_first_column = false;
-    //         }
-    //     }
-    // }
 
     match opts.get_filter() {
         Ok(filter) => {
@@ -607,32 +580,6 @@ pub fn transform_slice_lazy(
         Err(err) => Err(OxenError::basic_str(format!("DataFrame Error: {}", err))),
     }
 }
-
-// fn run_sql(df: LazyFrame, q: &str) -> Result<DataFrame, OxenError> {}
-
-// async fn get_sql(df: LazyFrame, q: &str, host: String) -> Result<String, OxenError> {
-//     let schema_str = schema_to_flat_str(&df.schema().unwrap());
-
-//     api::remote::text2sql::convert(q, &schema_str, Some(host.to_string())).await
-// }
-
-// pub fn run_text2sql(df: LazyFrame, q: &str, host: String) -> Result<LazyFrame, OxenError> {
-//     let sql = futures::executor::block_on(get_sql(df.clone(), q, host))?;
-//     println!("\n{}\n", sql);
-//     run_sql(df, &sql)
-// }
-
-// pub fn run_text2sql(
-//     repo: &LocalRepository,
-//     entry: &CommitEntry,
-//     df: DataFrame,
-//     q: &str,
-//     host: String,
-// ) -> Result<LazyFrame, OxenError> {
-//     let sql = futures::executor::block_on(get_sql(df, q, host))?;
-//     println!("\n{}\n", sql);
-//     run_sql(df, &sql)
-// }
 
 fn head(df: LazyFrame, opts: &DFOpts) -> LazyFrame {
     if let Some(head) = opts.head {

--- a/src/lib/src/core/index/remote_df_stager.rs
+++ b/src/lib/src/core/index/remote_df_stager.rs
@@ -257,10 +257,10 @@ fn copy_duckdb_if_already_indexed(
     opts: &DFOpts,
     new_db_path: &Path,
 ) -> Result<Option<DataFrame>, OxenError> {
-    let maybe_existing_db_path = sql::db_cache_path(repo, &entry);
+    let maybe_existing_db_path = sql::db_cache_path(repo, entry);
     let conn = df_db::get_connection(&maybe_existing_db_path)?;
     if df_db::table_exists(&conn, TABLE_NAME)? {
-        std::fs::copy(&maybe_existing_db_path, &new_db_path)?;
+        std::fs::copy(&maybe_existing_db_path, new_db_path)?;
         let select = Select::new().select("*").from(TABLE_NAME);
         let preview = df_db::select_with_opts(&conn, &select, opts)?;
         return Ok(Some(preview));

--- a/src/lib/src/core/index/remote_df_stager.rs
+++ b/src/lib/src/core/index/remote_df_stager.rs
@@ -5,7 +5,7 @@ use sql_query_builder::Select;
 
 use crate::constants::{OXEN_ID_COL, TABLE_NAME};
 use crate::core::db::df_db;
-use crate::core::df::tabular;
+use crate::core::df::{sql, tabular};
 use crate::core::index::{mod_stager, remote_dir_stager};
 
 use crate::model::{Branch, CommitEntry, LocalRepository};
@@ -17,19 +17,17 @@ use super::{CommitEntryReader, CommitReader};
 
 pub fn index_dataset(
     repo: &LocalRepository,
-    // branch_repo: &LocalRepository,
     branch: &Branch,
     path: &Path,
     identifier: &str,
     opts: &DFOpts,
 ) -> Result<DataFrame, OxenError> {
-    // TODONOW: this should return a RemoteDataset struct
-
     if !util::fs::is_tabular(path) {
         return Err(OxenError::basic_str(
             "File format not supported, must be tabular.must be tabular.",
         ));
     }
+
     // need to init or get the remote staging env - for if this was called from API? todo
     let _branch_repo = remote_dir_stager::init_or_get(repo, branch, identifier)?;
 
@@ -58,6 +56,12 @@ pub fn index_dataset(
         std::fs::create_dir_all(db_path.parent().expect("Failed to get parent directory"))?;
     }
 
+    let maybe_preview = copy_duckdb_if_already_indexed(repo, &entry, opts, &db_path)?;
+
+    if let Some(preview) = maybe_preview {
+        return Ok(preview);
+    }
+
     let conn = df_db::get_connection(db_path)?;
 
     if df_db::table_exists(&conn, TABLE_NAME)? {
@@ -67,36 +71,14 @@ pub fn index_dataset(
 
     log::debug!("index_dataset() got version path: {:?}", version_path);
 
-    // TODO: We will eventually want to parse the actual type, not just the extension.
-    // For now, just treat the extension as law
-    match entry.path.extension() {
-        Some(ext) => match ext.to_str() {
-            Some("csv") => index_csv(&version_path, &conn)?,
-            Some("tsv") => index_tsv(&version_path, &conn)?,
-            Some("json") | Some("jsonl") | Some("ndjson") => index_json(&version_path, &conn)?,
-            Some("parquet") => index_parquet(&version_path, &conn)?,
-            _ => {
-                return Err(OxenError::basic_str(
-                    "File format not supported, must be tabular.",
-                ))
-            }
-        },
-        None => {
-            return Err(OxenError::basic_str(
-                "File format not supported, must be tabular.",
-            ))
-        }
-    }
+    df_db::index_file_with_id(&version_path, &conn)?;
 
     let commit_path = mod_stager::mods_commit_ref_path(repo, branch, identifier, &entry.path);
     std::fs::write(commit_path, branch.commit_id.as_str())?;
 
-    // Print whole table after index for debugging
-
-    let select_all = Select::new().select("*").from(TABLE_NAME);
-    let inserted_data = df_db::select_with_opts(&conn, &select_all, opts)?;
-
-    Ok(inserted_data)
+    let select = Select::new().select("*").from(TABLE_NAME);
+    let preview = df_db::select_with_opts(&conn, &select, opts)?;
+    Ok(preview)
 }
 
 pub fn unindex_df(
@@ -269,70 +251,21 @@ pub fn count(
     Ok(count)
 }
 
-fn index_csv(path: &Path, conn: &Connection) -> Result<(), OxenError> {
-    let query = format!("CREATE TABLE {} AS SELECT *, CAST(uuid() AS VARCHAR) AS {} FROM read_csv('{}', AUTO_DETECT=TRUE, header=True);", TABLE_NAME, OXEN_ID_COL, path.to_string_lossy());
-    conn.execute(&query, [])?;
-
-    let add_default_query = format!(
-        "ALTER TABLE {} ALTER COLUMN {} SET DEFAULT CAST(uuid() AS VARCHAR);",
-        TABLE_NAME, OXEN_ID_COL
-    );
-    conn.execute(&add_default_query, [])?;
-
-    // let select_all = Select::new().select("*").from(TABLE_NAME);
-    // let all_data = df_db::select(conn, &select_all)?;
-    // log::debug!("All data in table {}: {:?}", TABLE_NAME, all_data);
-
-    Ok(())
-}
-
-fn index_tsv(path: &Path, conn: &Connection) -> Result<(), OxenError> {
-    let query = format!("CREATE TABLE {} AS SELECT *, CAST(uuid() AS VARCHAR) AS {} FROM read_csv('{}', AUTO_DETECT=TRUE, header=True);", TABLE_NAME, OXEN_ID_COL, path.to_string_lossy());
-    conn.execute(&query, [])?;
-
-    let add_default_query = format!(
-        "ALTER TABLE {} ALTER COLUMN {} SET DEFAULT CAST(uuid() AS VARCHAR);",
-        TABLE_NAME, OXEN_ID_COL
-    );
-    conn.execute(&add_default_query, [])?;
-
-    Ok(())
-}
-
-fn index_json(path: &Path, conn: &Connection) -> Result<(), OxenError> {
-    let query = format!(
-        "CREATE TABLE {} AS SELECT *, CAST(uuid() AS VARCHAR) AS {} FROM '{}';",
-        TABLE_NAME,
-        OXEN_ID_COL,
-        path.to_string_lossy()
-    );
-    conn.execute(&query, [])?;
-
-    let add_default_query = format!(
-        "ALTER TABLE {} ALTER COLUMN {} SET DEFAULT CAST(uuid() AS VARCHAR);",
-        TABLE_NAME, OXEN_ID_COL
-    );
-    conn.execute(&add_default_query, [])?;
-
-    Ok(())
-}
-
-fn index_parquet(path: &Path, conn: &Connection) -> Result<(), OxenError> {
-    let query = format!(
-        "CREATE TABLE {} AS SELECT *, CAST(uuid() AS VARCHAR) AS {} FROM '{}';",
-        TABLE_NAME,
-        OXEN_ID_COL,
-        path.to_string_lossy()
-    );
-    conn.execute(&query, [])?;
-
-    let add_default_query = format!(
-        "ALTER TABLE {} ALTER COLUMN {} SET DEFAULT CAST(uuid() AS VARCHAR);",
-        TABLE_NAME, OXEN_ID_COL
-    );
-    conn.execute(&add_default_query, [])?;
-
-    Ok(())
+fn copy_duckdb_if_already_indexed(
+    repo: &LocalRepository,
+    entry: &CommitEntry,
+    opts: &DFOpts,
+    new_db_path: &Path,
+) -> Result<Option<DataFrame>, OxenError> {
+    let maybe_existing_db_path = sql::db_cache_path(repo, &entry);
+    let conn = df_db::get_connection(&maybe_existing_db_path)?;
+    if df_db::table_exists(&conn, TABLE_NAME)? {
+        std::fs::copy(&maybe_existing_db_path, &new_db_path)?;
+        let select = Select::new().select("*").from(TABLE_NAME);
+        let preview = df_db::select_with_opts(&conn, &select, opts)?;
+        return Ok(Some(preview));
+    }
+    Ok(None)
 }
 
 fn export_rest(path: &Path, conn: &Connection) -> Result<(), OxenError> {
@@ -391,6 +324,7 @@ fn export_tsv(path: &Path, conn: &Connection) -> Result<(), OxenError> {
 
 fn export_parquet(path: &Path, conn: &Connection) -> Result<(), OxenError> {
     log::debug!("export_parquet()");
+
     let query = format!(
         "COPY (SELECT * EXCLUDE {} FROM '{}') to '{}' (FORMAT PARQUET);",
         OXEN_ID_COL,
@@ -398,5 +332,6 @@ fn export_parquet(path: &Path, conn: &Connection) -> Result<(), OxenError> {
         path.to_string_lossy()
     );
     conn.execute(&query, [])?;
+
     Ok(())
 }

--- a/src/lib/src/view/json_data_frame_view.rs
+++ b/src/lib/src/view/json_data_frame_view.rs
@@ -143,7 +143,7 @@ impl JsonDataFrameView {
         opts: &DFOpts,
     ) -> JsonDataFrameView {
         let full_width = df.width();
-        let full_height = og_height;
+        let view_height = df.height();
 
         let opts_view = DFOptsView::from_df_opts(opts);
         let mut sliced_df = tabular::transform(df, opts.clone()).unwrap();
@@ -158,15 +158,15 @@ impl JsonDataFrameView {
         JsonDataFrameView {
             schema: slice_schema,
             size: DataFrameSize {
-                height: full_height,
+                height: view_height,
                 width: full_width,
             },
             data: JsonDataFrameView::json_from_df(&mut sliced_df),
             pagination: Pagination {
                 page_number: opts.page.unwrap_or(constants::DEFAULT_PAGE_NUM),
                 page_size: opts.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE),
-                total_pages: (full_height as f64 / og_height as f64).ceil() as usize,
-                total_entries: full_height,
+                total_pages: (og_height as f64 / view_height as f64).ceil() as usize,
+                total_entries: og_height,
             },
             opts: opts_view,
         }

--- a/src/server/src/controllers/data_frames.rs
+++ b/src/server/src/controllers/data_frames.rs
@@ -114,7 +114,7 @@ pub async fn get(
         let mut conn = sql::get_conn(&repo, &entry)?;
         sql::index_df(&repo, &entry, &mut conn)?;
         let db_schema = df_db::get_schema(&conn, DUCKDB_DF_TABLE_NAME)?;
-        let df = sql::query_df(&repo, &entry, sql, &page_opts, &mut conn)?;
+        let df = sql::query_df(&repo, &entry, sql, &mut conn)?;
 
         log::debug!("sql got this df: {:?}", df);
         let json_df = format_sql_df_response(
@@ -135,12 +135,11 @@ pub async fn get(
         sql::index_df(&repo, &entry, &mut conn)?;
         let db_schema = df_db::get_schema(&conn, DUCKDB_DF_TABLE_NAME)?;
 
-        let mut df = sql::text2sql_df(
+        let df = sql::text2sql_df(
             &repo,
             &entry,
             &db_schema,
             text2sql,
-            &page_opts,
             &mut conn,
             opts.get_host(),
         )?;
@@ -270,7 +269,7 @@ fn format_sql_df_response(
     let response = JsonDataFrameViewResponse {
         status: StatusMessage::resource_found(),
         data_frame: JsonDataFrameViews {
-            source: JsonDataFrameSource::from_df_size(&data_frame_size, &og_schema),
+            source: JsonDataFrameSource::from_df_size(data_frame_size, og_schema),
             view,
         },
         commit: Some(resource.commit.clone()),

--- a/src/server/src/controllers/data_frames.rs
+++ b/src/server/src/controllers/data_frames.rs
@@ -86,6 +86,11 @@ pub async fn get(
         opts.slice = Some(format!("{}..{}", start, end));
     }
 
+    if let Some(sql) = opts.sql.clone() {
+        let df = tabular::query_df(&version_path, sql)?;
+        log::debug!("got this df: {:?}", df);
+    }
+
     let df = tabular::scan_df(&version_path, &opts, data_frame_size.height)?;
 
     // Try to get the schema from disk

--- a/src/server/src/errors.rs
+++ b/src/server/src/errors.rs
@@ -107,7 +107,7 @@ impl error::ResponseError for OxenHttpError {
                         )
                     },
                     "status": STATUS_ERROR,
-                    "status_message": MSG_UPDATE_REQUIRED,
+                    "status_message": MSG_BAD_REQUEST,
                 });
                 HttpResponse::BadRequest().json(error_json)
             }

--- a/src/server/src/params.rs
+++ b/src/server/src/params.rs
@@ -133,6 +133,11 @@ pub fn resolve_branch(repo: &LocalRepository, name: &str) -> Result<Option<Branc
 }
 
 fn user_cli_is_out_of_date(user_agent: &str) -> bool {
+    // Bypass for postman requests - TODO, make this more robust or only in dev
+    if user_agent.contains("Postman") {
+        return false;
+    }
+
     // check if the user agent contains oxen
     if !user_agent.to_lowercase().contains("oxen") {
         // Not an oxen user agent

--- a/src/server/src/routes.rs
+++ b/src/server/src/routes.rs
@@ -298,6 +298,10 @@ pub fn config(cfg: &mut web::ServiceConfig) {
         )
         // ----- DataFrame ----- //
         .route(
+            "/{namespace}/{repo_name}/data_frame/index/{resource:.*}",
+            web::post().to(controllers::data_frames::index),
+        )
+        .route(
             "/{namespace}/{repo_name}/data_frame/{resource:.*}",
             web::get().to(controllers::data_frames::get),
         )


### PR DESCRIPTION
Note: a dataframe must be first indexed for querying before it can be queried through either sql or NLP. **This will break the current query frontend if merged without frontend changes to accommodate this.**

This route is documented in Postman: OxenServer API > data_frame. 

Queries and indexes are blocked on dataframes > 1M rows for now, this is configurable. 

Note: this needs more tests, which I will write in a follow-up after unblocking Adam on the dataframe editing work. Has been tested manually though

Additionally...I added specific error messages and error types for "this df is not indexed" and "this df is too big" and they're getting swallowed by the hub and just returned as 400 bad request. Think we could really benefit from a mini-sprint on error propagation between our 3 projects - can possibly revisit this after df editing work as well 

