### PR TITLE
check if df exists in the df_size cacher and skip if it does not

### DIFF
--- a/src/lib/src/core/cache/cachers/df_size.rs
+++ b/src/lib/src/core/cache/cachers/df_size.rs
@@ -43,7 +43,12 @@ pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError>
             df = df.vstack(&new_df)?;
             // log::debug!("df tail now is {:?}", df.tail(Some(1)));
         } else {
-            log::debug!("skipping entry {:?} at path {:?} exists? {}", entry, path, path.exists());
+            log::debug!(
+                "skipping entry {:?} at path {:?} exists? {}",
+                entry,
+                path,
+                path.exists()
+            );
         }
     }
 

--- a/src/lib/src/core/cache/cachers/df_size.rs
+++ b/src/lib/src/core/cache/cachers/df_size.rs
@@ -29,7 +29,8 @@ pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError>
     for entry in entries {
         let path = util::fs::version_path(repo, &entry);
 
-        if util::fs::is_tabular(&path) {
+        // The path may not exist if a file was not fully pushed
+        if path.exists() && util::fs::is_tabular(&path) {
             // log::debug!("getting size for entry {:?} at path {:?}", entry, path);
             let data_frame_size = tabular::get_size(&path)?;
             // log::debug!("resulting df size is {:?}", data_frame_size);
@@ -41,6 +42,8 @@ pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError>
 
             df = df.vstack(&new_df)?;
             // log::debug!("df tail now is {:?}", df.tail(Some(1)));
+        } else {
+            log::debug!("skipping entry {:?} at path {:?} exists? {}", entry, path, path.exists());
         }
     }
 


### PR DESCRIPTION
@benartuso some migrations were failing because a version file was not present. I am guessing these are pushes that failed. Skipping these files instead of erroring the migration, because they will just have to push again.