### PR TITLE
fix error handling for incompatible schemas and return more verbose errors for python

### DIFF
--- a/src/lib/src/api/local/diff.rs
+++ b/src/lib/src/api/local/diff.rs
@@ -104,17 +104,17 @@ fn validate_required_fields(
 ) -> Result<(), OxenError> {
     // Keys must be in both dfs
     if !schema_1.has_field_names(&keys) {
-        return Err(OxenError::incompatible_schemas(&keys, schema_1));
+        return Err(OxenError::incompatible_schemas(schema_1.clone()));
     };
 
     if !schema_2.has_field_names(&keys) {
-        return Err(OxenError::incompatible_schemas(&keys, schema_2));
+        return Err(OxenError::incompatible_schemas(schema_2));
     };
 
     // Targets must be in either df
     for target in targets {
         if !schema_1.has_field_name(&target) && !schema_2.has_field_name(&target) {
-            return Err(OxenError::incompatible_schemas(&[target], schema_1));
+            return Err(OxenError::incompatible_schemas(schema_1));
         }
     }
 

--- a/src/lib/src/api/remote/client.rs
+++ b/src/lib/src/api/remote/client.rs
@@ -179,10 +179,7 @@ fn parse_status_and_message(
                 }
             }
 
-            Err(OxenError::basic_str(format!(
-                "Err: {}",
-                response.error_or_msg()
-            )))
+            Err(OxenError::basic_str(response.full_err_msg()))
         }
         status => Err(OxenError::basic_str(format!("Unknown status [{status}]"))),
     }

--- a/src/lib/src/api/remote/df.rs
+++ b/src/lib/src/api/remote/df.rs
@@ -62,7 +62,6 @@ pub async fn get_staged(
     match client.get(&url).send().await {
         Ok(res) => {
             let body = client::parse_json_body(&url, res).await?;
-            log::debug!("got body: {}", body);
             let response: Result<JsonDataFrameViewResponse, serde_json::Error> =
                 serde_json::from_str(&body);
             match response {

--- a/src/lib/src/core/db/staged_df_db.rs
+++ b/src/lib/src/core/db/staged_df_db.rs
@@ -22,13 +22,7 @@ pub fn append_row(conn: &duckdb::Connection, df: &DataFrame) -> Result<DataFrame
     let df_schema = df.schema();
 
     if !table_schema.has_field_names(&df_schema.get_names()) {
-        return Err(OxenError::incompatible_schemas(
-            &df_schema
-                .iter_fields()
-                .map(|f| f.name.to_string())
-                .collect::<Vec<String>>(),
-            table_schema,
-        ));
+        return Err(OxenError::incompatible_schemas(table_schema.clone()));
     }
 
     let added_column = Series::new(
@@ -80,13 +74,7 @@ pub fn modify_row(
     let df_schema = df.schema();
 
     if !table_schema.has_field_names(&df_schema.get_names()) {
-        return Err(OxenError::incompatible_schemas(
-            &df_schema
-                .iter_fields()
-                .map(|f| f.name.to_string())
-                .collect::<Vec<String>>(),
-            table_schema,
-        ));
+        return Err(OxenError::incompatible_schemas(table_schema));
     }
 
     // get existing hash and status from db

--- a/src/lib/src/error.rs
+++ b/src/lib/src/error.rs
@@ -20,6 +20,7 @@ pub mod string_error;
 
 pub use crate::error::path_buf_error::PathBufError;
 pub use crate::error::string_error::StringError;
+
 use polars::prelude::PolarsError;
 
 pub const NO_REPO_FOUND: &str = "No oxen repository exists, looking for directory: .oxen";
@@ -70,11 +71,8 @@ pub enum OxenError {
 
     // Schema
     InvalidSchema(Box<Schema>),
-    IncompatibleSchemas(StringError),
+    IncompatibleSchemas(Box<Schema>),
     InvalidFileType(StringError),
-
-    // Generic
-    ParsingError(Box<StringError>),
 
     // Metadata
     ImageMetadataParseError(StringError),
@@ -447,12 +445,8 @@ impl OxenError {
         OxenError::InvalidFileType(StringError::from(err))
     }
 
-    pub fn incompatible_schemas(cols: &[String], schema: Schema) -> OxenError {
-        let err = format!(
-            "\nERROR: Incompatible schemas. \n\nCols: {:?}\n\nare not compatible with schema: {:?}",
-            cols, schema
-        );
-        OxenError::IncompatibleSchemas(StringError::from(err))
+    pub fn incompatible_schemas(schema: Schema) -> OxenError {
+        OxenError::IncompatibleSchemas(Box::new(schema))
     }
 
     pub fn parse_error(value: impl AsRef<str>) -> OxenError {

--- a/src/lib/src/view/oxen_response.rs
+++ b/src/lib/src/view/oxen_response.rs
@@ -13,12 +13,20 @@ pub struct ErrorResponse {
     title: String,
     #[serde(rename = "type")]
     error_type: String,
+    detail: Option<String>,
 }
 
 impl OxenResponse {
     pub fn desc_or_msg(&self) -> String {
         match self.status_description.to_owned() {
             Some(desc) => desc,
+            None => self.status_message.to_owned(),
+        }
+    }
+
+    pub fn full_err_msg(&self) -> String {
+        match self.error.to_owned() {
+            Some(err) => format!("{}\n{}", err.title, err.detail.unwrap_or("".to_string())),
             None => self.status_message.to_owned(),
         }
     }

--- a/src/server/src/controllers/data_frames.rs
+++ b/src/server/src/controllers/data_frames.rs
@@ -82,7 +82,7 @@ pub async fn get(
         }
 
         if !sql::df_is_indexed(&repo, &entry)? {
-            return Err(OxenHttpError::DatasetNotIndexed);
+            return Err(OxenHttpError::DatasetNotIndexed(resource.file_path.into()));
         }
     }
 


### PR DESCRIPTION
We now return our standard error format for invalid schemas on add_row

{
  "error": {
    "detail": "Schema does not match. Valid Fields [prompt: str, response: str, source: str]",
    "title": "Incompatible Schemas",
    "type": "schema_error"
  },
  "status": "error",
  "status_message": "bad_request"
}