### PR TITLE
Refactor/log cmd

### DIFF
--- a/src/cli/src/cmd.rs
+++ b/src/cli/src/cmd.rs
@@ -36,6 +36,9 @@ pub use diff::DiffCmd;
 pub mod moo;
 pub use moo::MooCmd;
 
+pub mod log;
+pub use log::LogCmd;
+
 pub mod remote;
 
 pub mod schemas;

--- a/src/cli/src/cmd/log.rs
+++ b/src/cli/src/cmd/log.rs
@@ -1,0 +1,85 @@
+use async_trait::async_trait;
+use clap::{Arg, ArgMatches, Command};
+use colored::Colorize;
+use minus::Pager;
+use time::format_description;
+use std::fmt::Write;
+
+use liboxen::api;
+use liboxen::error::OxenError;
+use liboxen::model::LocalRepository;
+use liboxen::opts::LogOpts;
+
+use crate::cmd::RunCmd;
+pub const NAME: &str = "log";
+pub struct LogCmd;
+
+fn write_to_pager(output: &mut Pager, text: &str) -> Result<(), OxenError> {
+    match writeln!(output, "{}", text) {
+        Ok(_) => Ok(()),
+        Err(_) => Err(OxenError::basic_str("Could not write to pager")),
+    }
+}
+
+#[async_trait]
+impl RunCmd for LogCmd {
+
+    fn name(&self) -> &str {
+        NAME
+    }
+
+    fn args(&self) -> Command {
+        Command::new(NAME).about("See log of commits")
+        .arg(Arg::new("name").help("The commit or branch id you want to get history from. Defaults to main."))
+    }
+
+    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+    // Look up from the current dir for .oxen directory
+        let repo = LocalRepository::from_current_dir()?;
+
+        let revision = args.get_one::<String>("REVISION").map(String::from);
+    
+        let opts = LogOpts {
+            revision,
+            remote: false,
+        };
+        
+        self.log_commits(&repo, &opts).await?;
+
+        Ok(())
+    }
+
+}
+
+impl LogCmd {
+    pub async fn log_commits(&self, repo: &LocalRepository, opts: &LogOpts) -> Result<(), OxenError> {
+
+        let commits = api::local::commits::list_with_opts(&repo, &opts).await?;
+
+        // Fri, 21 Oct 2022 16:08:39 -0700
+        let format = format_description::parse(
+            "[weekday], [day] [month repr:long] [year] [hour]:[minute]:[second] [offset_hour sign:mandatory]",
+        ).unwrap();
+
+        let mut output = Pager::new();
+
+        for commit in commits {
+            let commit_id_str = format!("commit {}", commit.id).yellow();
+            write_to_pager(&mut output, &format!("{}\n", commit_id_str))?;
+            write_to_pager(&mut output, &format!("Author: {}", commit.author))?;
+            write_to_pager(
+                &mut output,
+                &format!("Date:   {}\n", commit.timestamp.format(&format).unwrap()),
+            )?;
+            write_to_pager(&mut output, &format!("    {}\n", commit.message))?;
+        }
+
+        match minus::page_all(output) {
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!("Error while paging: {}", e);
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/cli/src/cmd/log.rs
+++ b/src/cli/src/cmd/log.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use clap::{Arg, ArgMatches, Command};
+use clap::{arg, ArgMatches, Command};
 use colored::Colorize;
 use minus::Pager;
 use time::format_description;
@@ -30,7 +30,8 @@ impl RunCmd for LogCmd {
 
     fn args(&self) -> Command {
         Command::new(NAME).about("See log of commits")
-        .arg(Arg::new("name").help("The commit or branch id you want to get history from. Defaults to main."))
+        .arg(arg!([REVISION] "The commit or branch id you want to get history from. Defaults to main."),
+        )
     }
 
     async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {

--- a/src/cli/src/cmd/log.rs
+++ b/src/cli/src/cmd/log.rs
@@ -2,8 +2,8 @@ use async_trait::async_trait;
 use clap::{arg, ArgMatches, Command};
 use colored::Colorize;
 use minus::Pager;
-use time::format_description;
 use std::fmt::Write;
+use time::format_description;
 
 use liboxen::api;
 use liboxen::error::OxenError;
@@ -23,7 +23,6 @@ fn write_to_pager(output: &mut Pager, text: &str) -> Result<(), OxenError> {
 
 #[async_trait]
 impl RunCmd for LogCmd {
-
     fn name(&self) -> &str {
         NAME
     }
@@ -35,27 +34,29 @@ impl RunCmd for LogCmd {
     }
 
     async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
-    // Look up from the current dir for .oxen directory
+        // Look up from the current dir for .oxen directory
         let repo = LocalRepository::from_current_dir()?;
 
         let revision = args.get_one::<String>("REVISION").map(String::from);
-    
+
         let opts = LogOpts {
             revision,
             remote: false,
         };
-        
+
         self.log_commits(&repo, &opts).await?;
 
         Ok(())
     }
-
 }
 
 impl LogCmd {
-    pub async fn log_commits(&self, repo: &LocalRepository, opts: &LogOpts) -> Result<(), OxenError> {
-
-        let commits = api::local::commits::list_with_opts(&repo, &opts).await?;
+    pub async fn log_commits(
+        &self,
+        repo: &LocalRepository,
+        opts: &LogOpts,
+    ) -> Result<(), OxenError> {
+        let commits = api::local::commits::list_with_opts(repo, opts).await?;
 
         // Fri, 21 Oct 2022 16:08:39 -0700
         let format = format_description::parse(

--- a/src/cli/src/cmd_setup.rs
+++ b/src/cli/src/cmd_setup.rs
@@ -60,7 +60,6 @@ pub fn remote() -> Command {
         .subcommand(RemoteDfCmd.args())
         .subcommand(diff())
         .subcommand(download())
-        .subcommand(log())
         .subcommand(ls())
         .subcommand(restore())
         .subcommand(rm())
@@ -145,12 +144,6 @@ pub fn metadata() -> Command {
                 .arg(Arg::new("column").required(true))
                 .arg(Arg::new("path").required(false)),
         )
-}
-
-pub fn log() -> Command {
-    Command::new(LOG).about("See log of commits").arg(
-        arg!([REVISION] "The commit or branch id you want to get history from. Defaults to main."),
-    )
 }
 
 pub fn fetch() -> Command {

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -25,6 +25,7 @@ async fn main() {
         Box::new(cmd::CreateRemoteCmd),
         Box::new(cmd::DFCmd),
         Box::new(cmd::InitCmd),
+        Box::new(cmd::LogCmd),
         Box::new(cmd::SchemasCmd),
     ];
 
@@ -50,7 +51,6 @@ async fn main() {
         .subcommand(cmd_setup::inspect_kv_db())
         .subcommand(cmd_setup::fetch())
         .subcommand(cmd_setup::load())
-        .subcommand(cmd_setup::log())
         .subcommand(cmd_setup::merge())
         .subcommand(cmd_setup::migrate())
         .subcommand(cmd_setup::pull())
@@ -74,7 +74,6 @@ async fn main() {
         Some((cmd_setup::KVDB_INSPECT, sub_matches)) => parse_and_run::kvdb_inspect(sub_matches),
         Some((cmd_setup::FETCH, sub_matches)) => parse_and_run::fetch(sub_matches).await,
         Some((cmd_setup::LOAD, sub_matches)) => parse_and_run::load(sub_matches).await,
-        Some((cmd_setup::LOG, sub_matches)) => parse_and_run::log(sub_matches).await,
         Some((cmd_setup::MERGE, sub_matches)) => parse_and_run::merge(sub_matches),
         Some((cmd_setup::MIGRATE, sub_matches)) => parse_and_run::migrate(sub_matches).await,
         Some((cmd_setup::PULL, sub_matches)) => parse_and_run::pull(sub_matches).await,


### PR DESCRIPTION
Preliminary refactor of Oxen Log. Currently, the formatting would be a bit inconsistent with the other refactored commands, as it's coalesced in one file, as opposed to splitting functionality across files in both cli/src and lib/src. 