### PR TITLE
add commit response to repo creation

### DIFF
--- a/src/lib/src/core/index/commit_db_reader.rs
+++ b/src/lib/src/core/index/commit_db_reader.rs
@@ -28,7 +28,7 @@ impl CommitDBReader {
         }
 
         if latest_commit.is_none() {
-            return Err(OxenError::basic_str("no commits found"));
+            return Err(OxenError::no_commits_found());
         }
 
         Ok(latest_commit.unwrap())

--- a/src/lib/src/error.rs
+++ b/src/lib/src/error.rs
@@ -55,6 +55,7 @@ pub enum OxenError {
     RevisionNotFound(Box<StringError>),
     RootCommitDoesNotMatch(Box<Commit>),
     NothingToCommit(StringError),
+    NoCommitsFound(StringError),
     HeadNotFound(StringError),
 
     // Resources (paths, uris, etc.)
@@ -207,6 +208,10 @@ impl OxenError {
 
     pub fn root_commit_does_not_match(commit: Commit) -> Self {
         OxenError::RootCommitDoesNotMatch(Box::new(commit))
+    }
+
+    pub fn no_commits_found() -> Self {
+        OxenError::NoCommitsFound(StringError::from("\n No commits found.\n"))
     }
 
     pub fn local_repo_not_found() -> OxenError {

--- a/src/lib/src/view/repository.rs
+++ b/src/lib/src/view/repository.rs
@@ -1,4 +1,4 @@
-use crate::model::{EntryDataType, RemoteRepository};
+use crate::model::{Commit, EntryDataType, RemoteRepository};
 use serde::{Deserialize, Serialize};
 
 use super::{DataTypeCount, StatusMessage};
@@ -8,6 +8,13 @@ use std::str::FromStr;
 pub struct RepositoryView {
     pub namespace: String,
     pub name: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RepositoryCreationView {
+    pub namespace: String,
+    pub name: String,
+    pub latest_commit: Option<Commit>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -23,6 +30,13 @@ pub struct RepositoryResponse {
     pub status: String,
     pub status_message: String,
     pub repository: RepositoryView,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RepositoryCreationResponse {
+    pub status: String,
+    pub status_message: String,
+    pub repository: RepositoryCreationView,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
In order to avoid calling the server to list commits after a repo creation (and avoid a possible race condition). We add a latest_commit field to the create repo response payload.