### PR TITLE
Process background tasks in separate threads

### DIFF
--- a/src/server/src/main.rs
+++ b/src/server/src/main.rs
@@ -1,11 +1,7 @@
-use liboxen::config::UserConfig;
-
 use dotenv::dotenv;
 use dotenv::from_filename;
-use liboxen::core::cache::cacher_status::CacherStatus;
-use liboxen::core::cache::commit_cacher;
+use liboxen::config::UserConfig;
 use liboxen::model::User;
-use std::env;
 
 pub mod app_data;
 pub mod auth;
@@ -14,6 +10,7 @@ pub mod errors;
 pub mod helpers;
 pub mod middleware;
 pub mod params;
+pub mod queue_poller;
 pub mod queues;
 pub mod routes;
 pub mod tasks;
@@ -30,14 +27,9 @@ use actix_web_httpauth::middleware::HttpAuthentication;
 use clap::{Arg, Command};
 use env_logger::Env;
 
+use std::env;
 use std::io::Write;
-
 use std::path::{Path, PathBuf};
-use std::time::Duration;
-use tokio::time::sleep;
-
-use crate::queues::{InMemoryTaskQueue, RedisTaskQueue, TaskQueue};
-use crate::tasks::{Runnable, Task};
 
 const VERSION: &str = liboxen::constants::OXEN_VERSION;
 
@@ -76,65 +68,6 @@ async fn main() -> std::io::Result<()> {
         Ok(dir) => dir,
         Err(_) => String::from("data"),
     };
-
-    // Polling worker setup
-    async fn poll_queue(mut queue: TaskQueue) {
-        log::debug!("Starting queue poller");
-        loop {
-            match queue.pop() {
-                Some(task) => {
-                    log::debug!("Got queue item: {:?}", task);
-                    let result = std::panic::catch_unwind(|| {
-                        task.run();
-                    });
-                    if let Err(e) = result {
-                        log::error!("Error or panic processing commit {:?}", e);
-                        // Set the task to failed
-                        match task {
-                            Task::PostPushComplete(post_push_complete) => {
-                                let repo = post_push_complete.repo;
-                                let commit = post_push_complete.commit;
-
-                                match commit_cacher::set_all_cachers_status(
-                                    &repo,
-                                    &commit,
-                                    CacherStatus::failed("Panic in commit cache"),
-                                ) {
-                                    Ok(_) => {
-                                        log::debug!("Set all cachers to failed status");
-                                    }
-                                    Err(e) => {
-                                        log::error!(
-                                            "Error setting all cachers to failed status: {:?}",
-                                            e
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                None => {
-                    // log::debug!("No queue items found, sleeping");
-                    sleep(Duration::from_millis(1000)).await;
-                }
-            }
-        }
-    }
-
-    // If redis connection is available, use redis queue, else in-memory
-    pub fn init_queue() -> TaskQueue {
-        match helpers::get_redis_connection() {
-            Ok(pool) => {
-                println!("connecting to redis established, initializing queue");
-                TaskQueue::Redis(RedisTaskQueue { pool })
-            }
-            Err(_) => {
-                println!("Failed to connect to Redis. Falling back to in-memory queue.");
-                TaskQueue::InMemory(InMemoryTaskQueue::new())
-            }
-        }
-    }
 
     let command = Command::new("oxen-server")
         .version(VERSION)
@@ -216,12 +149,12 @@ async fn main() -> std::io::Result<()> {
                     let enable_auth = sub_matches.get_flag("auth");
 
                     log::debug!("initializing queue");
-                    let queue = init_queue();
+                    let queue = queue_poller::init_queue();
                     log::debug!("initialized queue");
                     let data = app_data::OxenAppData::new(PathBuf::from(sync_dir), queue.clone());
                     // Poll for post-commit tasks in background
                     log::debug!("initialized app data, spawning polling worker");
-                    tokio::spawn(async move { poll_queue(queue.clone()).await });
+                    tokio::spawn(async move { queue_poller::poll_queue(queue.clone()).await });
 
                     HttpServer::new(move || {
                         App::new()

--- a/src/server/src/queue_poller.rs
+++ b/src/server/src/queue_poller.rs
@@ -42,9 +42,7 @@ pub async fn poll_queue(mut queue: TaskQueue) {
                             }
                         }
                     }
-                })
-                .await
-                .expect("Task execution failed");
+                });
             }
             None => {
                 // log::debug!("No queue items found, sleeping");

--- a/src/server/src/queue_poller.rs
+++ b/src/server/src/queue_poller.rs
@@ -1,0 +1,69 @@
+use liboxen::core::cache::cacher_status::CacherStatus;
+use liboxen::core::cache::commit_cacher;
+use std::time::Duration;
+use tokio::time::sleep;
+
+use crate::helpers::get_redis_connection;
+use crate::queues::{InMemoryTaskQueue, RedisTaskQueue, TaskQueue};
+use crate::tasks::{Runnable, Task};
+
+pub async fn poll_queue(mut queue: TaskQueue) {
+    log::debug!("Starting queue poller");
+    loop {
+        match queue.pop() {
+            Some(task) => {
+                log::debug!("Got queue item: {:?}", task);
+
+                // to ensure we don't block the poller, we run the task in an OS thread.
+                tokio::task::spawn_blocking(move || {
+                    let result = std::panic::catch_unwind(|| {
+                        task.run();
+                    });
+                    if let Err(e) = result {
+                        log::error!("Error or panic processing task {:?}", e);
+                        // Handle task failure
+                        // Set the task to failed
+                        match task {
+                            Task::PostPushComplete(post_push_complete) => {
+                                let repo = post_push_complete.repo;
+                                let commit = post_push_complete.commit;
+
+                                match commit_cacher::set_all_cachers_status(
+                                    &repo,
+                                    &commit,
+                                    CacherStatus::failed("Panic in task execution"),
+                                ) {
+                                    Ok(_) => log::debug!("Set all cachers to failed status"),
+                                    Err(e) => log::error!(
+                                        "Error setting all cachers to failed status: {:?}",
+                                        e
+                                    ),
+                                }
+                            }
+                        }
+                    }
+                })
+                .await
+                .expect("Task execution failed");
+            }
+            None => {
+                // log::debug!("No queue items found, sleeping");
+                sleep(Duration::from_millis(1000)).await;
+            }
+        }
+    }
+}
+
+// If redis connection is available, use redis queue, else in-memory
+pub fn init_queue() -> TaskQueue {
+    match get_redis_connection() {
+        Ok(pool) => {
+            println!("connecting to redis established, initializing queue");
+            TaskQueue::Redis(RedisTaskQueue { pool })
+        }
+        Err(_) => {
+            println!("Failed to connect to Redis. Falling back to in-memory queue.");
+            TaskQueue::InMemory(InMemoryTaskQueue::new())
+        }
+    }
+}


### PR DESCRIPTION
This uses `tokio::task::spawn_blocking` to start the background tasks in tokio's thread pool meant for code that's blocking.

The queue poller remains an async task, but will spawn new threads as soon as messages come.

This also extracts the code related to the poller out of main.