### PR TITLE
Improve commit history endpoint

### DIFF
--- a/src/lib/src/api/remote/commits.rs
+++ b/src/lib/src/api/remote/commits.rs
@@ -155,7 +155,7 @@ async fn list_commit_history_paginated(
 ) -> Result<PaginatedCommits, OxenError> {
     let page_num = page_opts.page_num;
     let page_size = page_opts.page_size;
-    let uri = format!("/commits/{revision}/history?page={page_num}&page_size={page_size}");
+    let uri = format!("/commits/history/{revision}?page={page_num}&page_size={page_size}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
     let client = client::new_for_url(&url)?;

--- a/src/server/src/controllers/commits.rs
+++ b/src/server/src/controllers/commits.rs
@@ -1399,7 +1399,7 @@ mod tests {
             &uri,
             namespace,
             repo_name,
-            "commit_or_branch",
+            "resource",
             branch_name,
         );
 
@@ -1452,7 +1452,7 @@ mod tests {
             &uri,
             namespace,
             repo_name,
-            "commit_or_branch",
+            "resource",
             og_branch.name,
         );
 

--- a/src/server/src/controllers/commits.rs
+++ b/src/server/src/controllers/commits.rs
@@ -1378,7 +1378,7 @@ mod tests {
         command::add(&repo, path)?;
         command::commit(&repo, "second commit")?;
 
-        let uri = format!("/oxen/{namespace}/{repo_name}/commits/{branch_name}/history");
+        let uri = format!("/oxen/{namespace}/{repo_name}/commits/history/{branch_name}");
         let req = test::repo_request_with_param(
             &sync_dir,
             queue,
@@ -1429,7 +1429,7 @@ mod tests {
 
         // List commits from the first branch
         let uri = format!(
-            "/oxen/{}/{}/commits/{}/history",
+            "/oxen/{}/{}/commits/history/{}",
             namespace, repo_name, og_branch.name
         );
         let req = test::repo_request_with_param(

--- a/src/server/src/services/commits.rs
+++ b/src/server/src/services/commits.rs
@@ -44,7 +44,7 @@ pub fn commits() -> Scope {
             web::post().to(controllers::commits::upload_chunk),
         )
         .route(
-            "/{commit_or_branch:.*}/history",
+            "/history/{resource:.*}",
             web::get().to(controllers::commits::commit_history),
         )
         .route(


### PR DESCRIPTION
3 main changes.

The structure of the route changes to avoid collision with branches that contain a slash and "history" in their name

We improve the logic to retrieve the latest commit for an entry, instead of listing all of the changes containing a commit for the particular file and retrieving the last, we iterate commits from latest to earliest, and as soon as we find a hash difference for the particular file we know that that is the latest commit. So we don't need to iterate over all repo commits.

We also now allow clients to pass in a full resource (branch, commit, dir or file) and we will return the list of commits that affect that particular entry.