### PR TITLE
Implemented oxen df -w

### DIFF
--- a/src/cli/src/cmd/df.rs
+++ b/src/cli/src/cmd/df.rs
@@ -24,6 +24,13 @@ impl RunCmd for DFCmd {
         .arg(arg!(<DF_SPEC> ... "The DataFrame you want to process. If in the schema subcommand the schema ref."))
         .arg_required_else_help(true)
         .arg(
+            Arg::new("write")
+                .long("write")
+                .short('w')
+                .help("Write transformed data back to the file")
+                .action(clap::ArgAction::SetTrue),
+        )
+        .arg(
             Arg::new("output")
                 .long("output")
                 .short('o')
@@ -216,45 +223,87 @@ impl DFCmd {
             None
         };
 
+        let write_path: Option<PathBuf>; 
+        
+        if args.get_flag("write") {
+            write_path = args.get_one::<String>("DF_SPEC").map(std::path::PathBuf::from);
+        } else {
+            write_path = None;
+        }
+
         liboxen::opts::DFOpts {
+            write: write_path,
             output: args
                 .get_one::<String>("output")
                 .map(std::path::PathBuf::from),
-            delimiter: args.get_one::<String>("delimiter").map(String::from),
-            filter: args.get_one::<String>("filter").map(String::from),
-            slice: args.get_one::<String>("slice").map(String::from),
+            delimiter: args
+                .get_one::<String>("delimiter").map(String::from),
+            filter: args
+                .get_one::<String>("filter").map(String::from),
+            slice: args
+                .get_one::<String>("slice").map(String::from),
             page_size: args
                 .get_one::<String>("page-size")
-                .map(|x| x.parse::<usize>().expect("page-size must be valid int")),
+                .map(|x| x.parse::<usize>()
+                .expect("page-size must be valid int")),
             page: args
                 .get_one::<String>("page")
-                .map(|x| x.parse::<usize>().expect("page must be valid int")),
+                .map(|x| x.parse::<usize>()
+                .expect("page must be valid int")),
             head: args
                 .get_one::<String>("head")
-                .map(|x| x.parse::<usize>().expect("head must be valid int")),
+                .map(|x| x.parse::<usize>()
+                .expect("head must be valid int")),
             tail: args
                 .get_one::<String>("tail")
-                .map(|x| x.parse::<usize>().expect("tail must be valid int")),
+                .map(|x| x.parse::<usize>()
+                .expect("tail must be valid int")),
             row: args
                 .get_one::<String>("row")
-                .map(|x| x.parse::<usize>().expect("row must be valid int")),
-            take: args.get_one::<String>("take").map(String::from),
-            columns: args.get_one::<String>("columns").map(String::from),
-            item: args.get_one::<String>("item").map(String::from),
+                .map(|x| x.parse::<usize>()
+                .expect("row must be valid int")),
+            take: args
+                .get_one::<String>("take")
+                .map(String::from),
+            columns: args
+                .get_one::<String>("columns")
+                .map(String::from),
+            item: args
+                .get_one::<String>("item")
+                .map(String::from),
             vstack,
-            add_col: args.get_one::<String>("add-col").map(String::from),
-            add_row: args.get_one::<String>("add-row").map(String::from),
+            add_col: args
+                .get_one::<String>("add-col")
+                .map(String::from),
+            add_row: args
+                .get_one::<String>("add-row")
+                .map(String::from),
             at: args
                 .get_one::<String>("at")
-                .map(|x| x.parse::<usize>().expect("at must be valid int")),
-            delete_row: args.get_one::<String>("delete-row").map(String::from),
-            sort_by: args.get_one::<String>("sort").map(String::from),
-            sql: args.get_one::<String>("sql").map(String::from),
-            text2sql: args.get_one::<String>("text2sql").map(String::from),
-            host: args.get_one::<String>("host").map(String::from),
-            unique: args.get_one::<String>("unique").map(String::from),
-            should_randomize: args.get_flag("randomize"),
-            should_reverse: args.get_flag("reverse"),
+                .map(|x| x.parse::<usize>()
+                .expect("at must be valid int")),
+            delete_row: args
+                .get_one::<String>("delete-row")
+                .map(String::from),
+            sort_by: args
+                .get_one::<String>("sort")
+                .map(String::from),
+            sql: args
+                .get_one::<String>("sql")
+                .map(String::from),
+            text2sql: args
+                .get_one::<String>("text2sql")
+                .map(String::from),
+            host: args
+                .get_one::<String>("host")
+                .map(String::from),
+            unique: args
+                .get_one::<String>("unique")
+                .map(String::from),
+            should_randomize: args
+                .get_flag("randomize"),
+            should_reverse: args
+                .get_flag("reverse"),
         }
     }
 }

--- a/src/cli/src/cmd/df.rs
+++ b/src/cli/src/cmd/df.rs
@@ -223,87 +223,53 @@ impl DFCmd {
             None
         };
 
-        let write_path: Option<PathBuf>; 
-        
-        if args.get_flag("write") {
-            write_path = args.get_one::<String>("DF_SPEC").map(std::path::PathBuf::from);
+        let write_path: Option<PathBuf> = if args.get_flag("write") {
+            args.get_one::<String>("DF_SPEC")
+                .map(std::path::PathBuf::from)
         } else {
-            write_path = None;
-        }
+            None
+        };
 
         liboxen::opts::DFOpts {
             write: write_path,
             output: args
                 .get_one::<String>("output")
                 .map(std::path::PathBuf::from),
-            delimiter: args
-                .get_one::<String>("delimiter").map(String::from),
-            filter: args
-                .get_one::<String>("filter").map(String::from),
-            slice: args
-                .get_one::<String>("slice").map(String::from),
+            delimiter: args.get_one::<String>("delimiter").map(String::from),
+            filter: args.get_one::<String>("filter").map(String::from),
+            slice: args.get_one::<String>("slice").map(String::from),
             page_size: args
                 .get_one::<String>("page-size")
-                .map(|x| x.parse::<usize>()
-                .expect("page-size must be valid int")),
+                .map(|x| x.parse::<usize>().expect("page-size must be valid int")),
             page: args
                 .get_one::<String>("page")
-                .map(|x| x.parse::<usize>()
-                .expect("page must be valid int")),
+                .map(|x| x.parse::<usize>().expect("page must be valid int")),
             head: args
                 .get_one::<String>("head")
-                .map(|x| x.parse::<usize>()
-                .expect("head must be valid int")),
+                .map(|x| x.parse::<usize>().expect("head must be valid int")),
             tail: args
                 .get_one::<String>("tail")
-                .map(|x| x.parse::<usize>()
-                .expect("tail must be valid int")),
+                .map(|x| x.parse::<usize>().expect("tail must be valid int")),
             row: args
                 .get_one::<String>("row")
-                .map(|x| x.parse::<usize>()
-                .expect("row must be valid int")),
-            take: args
-                .get_one::<String>("take")
-                .map(String::from),
-            columns: args
-                .get_one::<String>("columns")
-                .map(String::from),
-            item: args
-                .get_one::<String>("item")
-                .map(String::from),
+                .map(|x| x.parse::<usize>().expect("row must be valid int")),
+            take: args.get_one::<String>("take").map(String::from),
+            columns: args.get_one::<String>("columns").map(String::from),
+            item: args.get_one::<String>("item").map(String::from),
             vstack,
-            add_col: args
-                .get_one::<String>("add-col")
-                .map(String::from),
-            add_row: args
-                .get_one::<String>("add-row")
-                .map(String::from),
+            add_col: args.get_one::<String>("add-col").map(String::from),
+            add_row: args.get_one::<String>("add-row").map(String::from),
             at: args
                 .get_one::<String>("at")
-                .map(|x| x.parse::<usize>()
-                .expect("at must be valid int")),
-            delete_row: args
-                .get_one::<String>("delete-row")
-                .map(String::from),
-            sort_by: args
-                .get_one::<String>("sort")
-                .map(String::from),
-            sql: args
-                .get_one::<String>("sql")
-                .map(String::from),
-            text2sql: args
-                .get_one::<String>("text2sql")
-                .map(String::from),
-            host: args
-                .get_one::<String>("host")
-                .map(String::from),
-            unique: args
-                .get_one::<String>("unique")
-                .map(String::from),
-            should_randomize: args
-                .get_flag("randomize"),
-            should_reverse: args
-                .get_flag("reverse"),
+                .map(|x| x.parse::<usize>().expect("at must be valid int")),
+            delete_row: args.get_one::<String>("delete-row").map(String::from),
+            sort_by: args.get_one::<String>("sort").map(String::from),
+            sql: args.get_one::<String>("sql").map(String::from),
+            text2sql: args.get_one::<String>("text2sql").map(String::from),
+            host: args.get_one::<String>("host").map(String::from),
+            unique: args.get_one::<String>("unique").map(String::from),
+            should_randomize: args.get_flag("randomize"),
+            should_reverse: args.get_flag("reverse"),
         }
     }
 }

--- a/src/lib/src/command/df.rs
+++ b/src/lib/src/command/df.rs
@@ -14,6 +14,11 @@ use crate::util;
 pub fn df<P: AsRef<Path>>(input: P, opts: DFOpts) -> Result<(), OxenError> {
     let mut df = tabular::show_path(input, opts.clone())?;
 
+    if let Some(write) = opts.write {
+        println!("Writing {write:?}");
+        tabular::write_df(&mut df, write)?;
+    }
+
     if let Some(output) = opts.output {
         println!("Writing {output:?}");
         tabular::write_df(&mut df, output)?;

--- a/src/lib/src/opts/df_opts.rs
+++ b/src/lib/src/opts/df_opts.rs
@@ -48,6 +48,7 @@ pub struct DFOpts {
     pub take: Option<String>,
     pub unique: Option<String>,
     pub vstack: Option<Vec<PathBuf>>,
+    pub write: Option<PathBuf>,
 }
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DFOptsView {
@@ -87,6 +88,7 @@ impl DFOpts {
             take: None,
             unique: None,
             vstack: None,
+            write: None,
         }
     }
 


### PR DESCRIPTION
Implemented the 'write' option for oxen df. This flag, if set, writes the transformations of the other df options back to the file oxen df is being called on. For example, `oxen df MyFile.csv -w` and `oxen df MyFile.csv -o MyFile.csv` have the same behavior. This can be run in conjunction with oxen df -o, in which case the file will be written to both the original file and the path specified by -o