### PR TITLE
Added default branch for oxen workspace create

### DIFF
--- a/src/cli/src/cmd/config.rs
+++ b/src/cli/src/cmd/config.rs
@@ -66,6 +66,7 @@ impl RunCmd for ConfigCmd {
                     .help("Sets the default host used to check version numbers. If empty, the CLI will not do a version check.")
                     .action(clap::ArgAction::Set),
             )
+            .arg_required_else_help(true)
     }
 
     async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {

--- a/src/cli/src/cmd/workspace/create.rs
+++ b/src/cli/src/cmd/workspace/create.rs
@@ -2,9 +2,9 @@ use async_trait::async_trait;
 use clap::{Arg, ArgMatches, Command};
 
 use liboxen::command;
+use liboxen::constants::DEFAULT_BRANCH_NAME;
 use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
-use liboxen::constants::DEFAULT_BRANCH_NAME;
 
 use crate::cmd::RunCmd;
 pub const NAME: &str = "create";

--- a/src/cli/src/cmd/workspace/create.rs
+++ b/src/cli/src/cmd/workspace/create.rs
@@ -4,6 +4,7 @@ use clap::{Arg, ArgMatches, Command};
 use liboxen::command;
 use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
+use liboxen::constants::DEFAULT_BRANCH_NAME;
 
 use crate::cmd::RunCmd;
 pub const NAME: &str = "create";
@@ -22,7 +23,7 @@ impl RunCmd for WorkspaceCreateCmd {
                 Arg::new("branch")
                     .long("branch")
                     .short('b')
-                    .required(true)
+                    .default_value(DEFAULT_BRANCH_NAME)
                     .help("The branch to create the workspace from"),
             )
             .arg(


### PR DESCRIPTION
Fixed issue where oxen workspace create wouldn't actually have its branch option set to the default branch. Also, made oxen config output its help message when called with no options