### PR TITLE
Properly format JSON when calling the Workspaces API

### DIFF
--- a/src/lib/src/api/remote/workspaces.rs
+++ b/src/lib/src/api/remote/workspaces.rs
@@ -50,20 +50,16 @@ pub async fn create_with_path(
     let url = api::endpoint::url_from_repo(remote_repo, "/workspaces")?;
     log::debug!("create workspace {}\n", url);
 
-    let body = serde_json::to_string(&NewWorkspace {
+    let body = NewWorkspace {
         branch_name: branch_name.to_string(),
         workspace_id: workspace_id.to_string(),
         // These two are needed for the oxen hub right now, ignored by the server
         resource_path: Some(path.to_str().unwrap().to_string()),
         entity_type: Some("user".to_string()),
-    })?;
+    };
 
     let client = client::new_for_url(&url)?;
-    let res = client
-        .put(&url)
-        .body(reqwest::Body::from(body))
-        .send()
-        .await?;
+    let res = client.put(&url).json(&body).send().await?;
 
     let body = client::parse_json_body(&url, res).await?;
     log::debug!("create workspace got body: {}", body);

--- a/src/lib/src/api/remote/workspaces/commits.rs
+++ b/src/lib/src/api/remote/workspaces/commits.rs
@@ -12,15 +12,10 @@ pub async fn commit(
 ) -> Result<Commit, OxenError> {
     let uri = format!("/workspaces/{identifier}/commit/{branch_name}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
-    let body = serde_json::to_string(&commit).unwrap();
-    log::debug!("commit_staged {}\n{}", url, body);
+    log::debug!("commit_staged {}\n{:?}", url, commit);
 
     let client = client::new_for_url(&url)?;
-    let res = client
-        .post(&url)
-        .body(reqwest::Body::from(body))
-        .send()
-        .await?;
+    let res = client.post(&url).json(&commit).send().await?;
 
     let body = client::parse_json_body(&url, res).await?;
     log::debug!("commit_staged got body: {}", body);

--- a/src/lib/src/command/migrate/create_merkle_trees.rs
+++ b/src/lib/src/command/migrate/create_merkle_trees.rs
@@ -113,7 +113,7 @@ pub fn create_merkle_trees_up(repo: &LocalRepository) -> Result<(), OxenError> {
         let dir_hashes_db: DBWithThreadMode<MultiThreaded> =
             DBWithThreadMode::open_for_read_only(&db::opts::default(), &dir_hashes_db_dir, false)?;
 
-        let root_hash: String = path_db::get_entry(&dir_hashes_db, &PathBuf::from(""))?.unwrap();
+        let root_hash: String = path_db::get_entry(&dir_hashes_db, PathBuf::from(""))?.unwrap();
 
         commit_to_update.update_root_hash(root_hash);
 

--- a/src/lib/src/core/index/puller.rs
+++ b/src/lib/src/core/index/puller.rs
@@ -338,7 +338,7 @@ fn working_dir_paths_from_small_entries(entries: &[Entry], dst: &Path) -> Vec<(S
 fn working_dir_paths_from_large_entries(entries: &[Entry], dst: &Path) -> Vec<PathBuf> {
     let mut paths: Vec<PathBuf> = vec![];
     for entry in entries.iter() {
-        let working_path = dst.join(&entry.path());
+        let working_path = dst.join(entry.path());
         paths.push(working_path);
     }
     paths

--- a/src/lib/src/core/index/stager.rs
+++ b/src/lib/src/core/index/stager.rs
@@ -956,7 +956,7 @@ impl Stager {
                     if let Some(is_added) = &dir_entry.client_state {
                         if !*is_added {
                             let path = util::fs::path_relative_to_dir(
-                                &dir_entry.path(),
+                                dir_entry.path(),
                                 &self.repository.path,
                             )
                             .unwrap();


### PR DESCRIPTION
This updates the create and commit workspace requests so they properly send JSON, adding the content-type `application/json`.