### PR TITLE
Fix deleted columns not appearing in schema

### DIFF
--- a/src/lib/src/api/remote/workspaces/data_frames/columns.rs
+++ b/src/lib/src/api/remote/workspaces/data_frames/columns.rs
@@ -148,6 +148,7 @@ mod tests {
     use crate::config::UserConfig;
     use crate::constants::DEFAULT_BRANCH_NAME;
     use crate::error::OxenError;
+    use crate::model::schema::field::Changes;
     use crate::opts::DFOpts;
     use crate::test;
 
@@ -273,7 +274,7 @@ mod tests {
             )
             .await?;
 
-            if let Some((_index, _field)) = df
+            if let Some((_index, field)) = df
                 .data_frame
                 .unwrap()
                 .view
@@ -283,7 +284,13 @@ mod tests {
                 .enumerate()
                 .find(|(_index, field)| field.name == column.name)
             {
-                panic!("Column {} still exists in the data frame", column.name);
+                if <std::option::Option<Changes> as Clone>::clone(&field.changes)
+                    .unwrap()
+                    .status
+                    != "deleted"
+                {
+                    panic!("Column {} still exists in the data frame", column.name);
+                }
             }
 
             Ok(remote_repo)

--- a/src/lib/src/core/index/workspaces/data_frames/columns.rs
+++ b/src/lib/src/core/index/workspaces/data_frames/columns.rs
@@ -1,5 +1,5 @@
 use polars::frame::DataFrame;
-use rocksdb::DB;
+use rocksdb::{IteratorMode, DB};
 
 use crate::constants::TABLE_NAME;
 use crate::core::db;
@@ -309,6 +309,8 @@ pub fn decorate_fields_with_column_diffs(
 
     let db = db_open_result?;
 
+    reinsert_deleted_columns_into_schema(&db, df_views)?;
+
     df_views
         .source
         .schema
@@ -412,4 +414,58 @@ pub fn handle_data_frame_column_change(
         }
         _ => Ok(None),
     }
+}
+
+pub fn reinsert_deleted_columns_into_schema(
+    db: &DB,
+    df_views: &mut JsonDataFrameViews,
+) -> Result<(), OxenError> {
+    let mut deleted_columns = Vec::new();
+
+    for item in db.iterator(IteratorMode::Start) {
+        match item {
+            Ok((_key, value_bytes)) => {
+                let column_change: DataFrameColumnChange = serde_json::from_slice(&value_bytes)
+                    .map_err(|_| OxenError::basic_str("Error deserializing value"))?;
+
+                if column_change.operation == "deleted" {
+                    deleted_columns.push(column_change.column_before);
+                }
+            }
+            Err(_) => return Err(OxenError::basic_str("Error reading from db")),
+        }
+    }
+
+    for deleted_column in &deleted_columns {
+        let before_column = deleted_column.clone().ok_or(OxenError::basic_str(
+            "A deleted column needs to have a column before value",
+        ))?;
+
+        df_views.source.schema.fields.push(Field {
+            name: before_column.column_name.clone(),
+            dtype: before_column
+                .column_data_type
+                .clone()
+                .ok_or(OxenError::basic_str(
+                    "A deleted column needs to have a before datatype value",
+                ))?
+                .clone(),
+            metadata: None,
+            changes: None,
+        });
+
+        df_views.view.schema.fields.push(Field {
+            name: before_column.column_name.clone(),
+            dtype: before_column
+                .column_data_type
+                .ok_or(OxenError::basic_str(
+                    "A deleted column needs to have a before datatype value",
+                ))?
+                .clone(),
+            metadata: None,
+            changes: None,
+        });
+    }
+
+    Ok(())
 }

--- a/src/lib/src/model/schema.rs
+++ b/src/lib/src/model/schema.rs
@@ -204,7 +204,18 @@ impl Schema {
     }
 
     pub fn fields_names(&self) -> Vec<String> {
-        self.fields.iter().map(|f| f.name.to_owned()).collect()
+        self.fields
+            .iter()
+            .filter(|f| {
+                println!("{:?}", f);
+
+                // Perform the actual filter condition check
+                f.changes
+                    .as_ref()
+                    .map_or(true, |changes| changes.status != "deleted")
+            })
+            .map(|f| f.name.clone()) // Assuming name is a String and needs to be cloned
+            .collect()
     }
 
     /// Compare the schemas, looking for added fields

--- a/src/server/src/controllers/workspaces/data_frames/columns.rs
+++ b/src/server/src/controllers/workspaces/data_frames/columns.rs
@@ -107,7 +107,6 @@ pub async fn delete(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
         return Err(OxenHttpError::DatasetNotIndexed(file_path.into()));
     }
 
-    println!("DEBUG 1");
     let column_df =
         index::workspaces::data_frames::columns::delete(&workspace, &file_path, &column_to_delete)?;
 


### PR DESCRIPTION
Given that the schema of a dataframe is retrieved by a simple sql query, when a column is deleted, this column no longer appears in the schema. 

In order to be able to display the proper diff in the fields of the dataframe, we go over the diff map and reinsert deleted columns with the proper operation tag and reinsert these columns into the schema object.