### PR TITLE
Add column ops feedback

### DIFF
--- a/src/lib/src/core/db/data_frames/columns.rs
+++ b/src/lib/src/core/db/data_frames/columns.rs
@@ -68,7 +68,12 @@ pub fn record_column_change(
 
     if operation == "deleted" {
         if let Some(column) = &column_before {
-            if let Some(previous_change) = data_frame_column_changes_db::get_data_frame_column_change(&db, &column.column_name)? {
+            if let Some(previous_change) =
+                data_frame_column_changes_db::get_data_frame_column_change(
+                    &db,
+                    &column.column_name,
+                )?
+            {
                 if previous_change.operation == "added" {
                     // If we're deleting a previously added column, just remove the change
                     return revert_column_changes(&db, &column.column_name);

--- a/src/server/src/controllers/workspaces/data_frames.rs
+++ b/src/server/src/controllers/workspaces/data_frames.rs
@@ -193,7 +193,13 @@ pub async fn diff(
 
     df_schema.update_metadata_from_schema(&og_schema);
 
-    let df_views = JsonDataFrameViews::from_df_and_opts(diff_df, df_schema, &opts);
+    let mut df_views = JsonDataFrameViews::from_df_and_opts(diff_df, df_schema, &opts);
+
+    index::workspaces::data_frames::columns::decorate_fields_with_column_diffs(
+        &workspace,
+        &file_path,
+        &mut df_views,
+    )?;
 
     let resource = ResourceVersion {
         path: file_path.to_string_lossy().to_string(),


### PR DESCRIPTION
1) return schema diff in workspace df diff call.
2) When we add and then delete a column, we remove this column from the diff as there are no changes relative to the og schema.