### PR TITLE
Retrieve schemas from workspace dataframes on commit

### DIFF
--- a/src/lib/src/api/local/entries.rs
+++ b/src/lib/src/api/local/entries.rs
@@ -645,8 +645,8 @@ pub fn read_unsynced_schemas(
     last_commit: &Commit,
     this_commit: &Commit,
 ) -> Result<Vec<SchemaEntry>, OxenError> {
-    let this_schema_reader = SchemaReader::new(local_repo, &this_commit.id)?;
-    let last_schema_reader = SchemaReader::new(local_repo, &last_commit.id)?;
+    let this_schema_reader = SchemaReader::new(local_repo, &this_commit.id, None)?;
+    let last_schema_reader = SchemaReader::new(local_repo, &last_commit.id, None)?;
 
     let this_schemas = this_schema_reader.list_schema_entries()?;
     let last_schemas = last_schema_reader.list_schema_entries()?;
@@ -676,7 +676,7 @@ pub fn list_tabular_files_in_repo(
     local_repo: &LocalRepository,
     commit: &Commit,
 ) -> Result<Vec<MetadataEntry>, OxenError> {
-    let schema_reader = core::index::SchemaReader::new(local_repo, &commit.id)?;
+    let schema_reader = core::index::SchemaReader::new(local_repo, &commit.id, None)?;
     let schemas = schema_reader.list_schemas()?;
 
     let mut meta_entries: Vec<MetadataEntry> = vec![];

--- a/src/lib/src/api/local/schemas.rs
+++ b/src/lib/src/api/local/schemas.rs
@@ -14,14 +14,14 @@ pub fn list(
     if let Some(commit_id) = commit_id {
         if let Some(commit) = api::local::commits::commit_from_branch_or_commit_id(repo, commit_id)?
         {
-            let schema_reader = SchemaReader::new(repo, &commit.id)?;
+            let schema_reader = SchemaReader::new(repo, &commit.id, None)?;
             schema_reader.list_schemas()
         } else {
             Err(OxenError::commit_id_does_not_exist(commit_id))
         }
     } else {
         let head_commit = api::local::commits::head_commit(repo)?;
-        let schema_reader = SchemaReader::new(repo, &head_commit.id)?;
+        let schema_reader = SchemaReader::new(repo, &head_commit.id, None)?;
         schema_reader.list_schemas()
     }
 }
@@ -34,7 +34,7 @@ pub fn list_from_ref(
     let revision = revision.as_ref();
     log::debug!("list_from_ref() listing for ref: {:?}", schema_ref.as_ref());
     if let Some(commit) = api::local::revisions::get(repo, revision)? {
-        let schema_reader = SchemaReader::new(repo, &commit.id)?;
+        let schema_reader = SchemaReader::new(repo, &commit.id, None)?;
         schema_reader.list_schemas_for_ref(schema_ref)
     } else {
         Err(OxenError::revision_not_found(revision.into()))
@@ -48,7 +48,7 @@ pub fn get_by_path(
     let path = path.as_ref();
     log::debug!("here's our repo path: {:?}", repo.path);
     let commit = api::local::commits::head_commit(repo)?;
-    let schema_reader = SchemaReader::new(repo, &commit.id)?;
+    let schema_reader = SchemaReader::new(repo, &commit.id, None)?;
     schema_reader.get_schema_for_file(path)
 }
 
@@ -63,7 +63,7 @@ pub fn get_by_path_from_ref(
     log::debug!("Getting schema for {:?} at revision {}", path, revision);
     if let Some(commit) = api::local::revisions::get(repo, revision)? {
         log::debug!("Got commit {:?} at revision {}", commit.id, revision);
-        let schema_reader = SchemaReader::new(repo, &commit.id)?;
+        let schema_reader = SchemaReader::new(repo, &commit.id, None)?;
         schema_reader.get_schema_for_file(path)
     } else {
         Err(OxenError::revision_not_found(revision.into()))

--- a/src/lib/src/command/add.rs
+++ b/src/lib/src/command/add.rs
@@ -41,7 +41,7 @@ pub fn add<P: AsRef<Path>>(repo: &LocalRepository, path: P) -> Result<(), OxenEr
     let stager = Stager::new_with_merge(repo)?;
     let commit = api::local::commits::head_commit(repo)?;
     let reader = CommitEntryReader::new(repo, &commit)?;
-    let schema_reader = SchemaReader::new(repo, &commit.id)?;
+    let schema_reader = SchemaReader::new(repo, &commit.id, None)?;
     let ignore = oxenignore::create(repo);
     log::debug!("---START--- oxen add: {:?}", path.as_ref());
 

--- a/src/lib/src/core/index/commit_writer.rs
+++ b/src/lib/src/core/index/commit_writer.rs
@@ -833,7 +833,7 @@ mod tests {
             // Create committer with no commits
             let repo_path = &repo.path;
             let entry_reader = CommitEntryReader::new_from_head(&repo)?;
-            let schema_reader = SchemaReader::new_from_head(&repo)?;
+            let schema_reader = SchemaReader::new_from_head(&repo, None)?;
             let commit_writer = CommitWriter::new(&repo)?;
 
             let train_dir = repo_path.join("training_data");

--- a/src/lib/src/core/index/entry_indexer.rs
+++ b/src/lib/src/core/index/entry_indexer.rs
@@ -564,7 +564,7 @@ impl EntryIndexer {
         commit: &Commit,
         mut limit: usize,
     ) -> Result<Vec<SchemaEntry>, OxenError> {
-        let schema_reader = SchemaReader::new(&self.repository, &commit.id)?;
+        let schema_reader = SchemaReader::new(&self.repository, &commit.id, None)?;
         let schemas = schema_reader.list_schema_entries()?;
 
         if limit == 0 {

--- a/src/lib/src/core/index/merger.rs
+++ b/src/lib/src/core/index/merger.rs
@@ -396,7 +396,7 @@ impl Merger {
         let stager = Stager::new(repo)?;
         let commit = api::local::commits::head_commit(repo)?;
         let reader = CommitEntryReader::new(repo, &commit)?;
-        let schema_reader = SchemaReader::new(repo, &commit.id)?;
+        let schema_reader = SchemaReader::new(repo, &commit.id, None)?;
         let ignore = oxenignore::create(repo);
         stager.add(&repo.path, &reader, &schema_reader, &ignore)?;
 
@@ -432,7 +432,7 @@ impl Merger {
         let stager = Stager::new(repo)?;
         let commit = api::local::commits::head_commit(repo)?;
         let reader = CommitEntryReader::new(repo, &commit)?;
-        let schema_reader = SchemaReader::new(repo, &commit.id)?;
+        let schema_reader = SchemaReader::new(repo, &commit.id, None)?;
         let ignore = oxenignore::create(repo);
         stager.add(&repo.path, &reader, &schema_reader, &ignore)?;
 

--- a/src/lib/src/core/index/schema_reader.rs
+++ b/src/lib/src/core/index/schema_reader.rs
@@ -1,393 +1,91 @@
-use crate::constants::{FILES_DIR, HISTORY_DIR, SCHEMAS_DIR, SCHEMAS_TREE_PREFIX};
-use crate::core::db;
-use crate::core::db::key_val::path_db;
-use crate::core::db::key_val::tree_db::{TreeObject, TreeObjectChild};
-
-use crate::core::index::CommitEntryWriter;
 use crate::error::OxenError;
 use crate::model::entry::commit_entry::SchemaEntry;
-use crate::model::Schema;
-use crate::util;
-
-use rocksdb::{DBWithThreadMode, MultiThreaded};
+use crate::model::workspace::Workspace;
+use crate::model::{LocalRepository, Schema};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::str;
-use std::sync::Arc;
 
-use crate::model::LocalRepository;
+pub mod duckdb_schema_reader;
+pub mod objects_schema_reader;
 
-use super::{CommitReader, ObjectDBReader};
+use duckdb_schema_reader::DuckDBSchemaReader;
+use objects_schema_reader::ObjectsSchemaReader;
 
-pub struct SchemaReader {
-    object_reader: Arc<ObjectDBReader>,
-    dir_hashes_db: DBWithThreadMode<MultiThreaded>,
-    repository: LocalRepository,
-    commit_id: String,
+pub enum SchemaReader {
+    DuckDB(DuckDBSchemaReader),
+    Objects(ObjectsSchemaReader),
 }
 
 impl SchemaReader {
-    pub fn schemas_db_dir(repo: &LocalRepository, commit_id: &str) -> PathBuf {
-        // .oxen/history/COMMIT_ID/schemas/schemas
-        util::fs::oxen_hidden_dir(&repo.path)
-            .join(HISTORY_DIR)
-            .join(commit_id)
-            .join(SCHEMAS_DIR) // double schemas/schemas is intentional because we have multiple dirs at this level
-            .join(SCHEMAS_DIR)
-    }
-
-    pub fn schema_files_db_dir(repo: &LocalRepository, commit_id: &str) -> PathBuf {
-        // .oxen/history/COMMIT_ID/schemas/files
-        util::fs::oxen_hidden_dir(&repo.path)
-            .join(HISTORY_DIR)
-            .join(commit_id)
-            .join(SCHEMAS_DIR)
-            .join(FILES_DIR)
-    }
-
-    pub fn new(repository: &LocalRepository, commit_id: &str) -> Result<SchemaReader, OxenError> {
-        let dir_hashes_db_path = CommitEntryWriter::commit_dir_hash_db(&repository.path, commit_id);
-
-        let opts = db::key_val::opts::default();
-
-        if !dir_hashes_db_path.exists() {
-            log::debug!("creating dir hashes db at path {:?}", dir_hashes_db_path);
-            std::fs::create_dir_all(&dir_hashes_db_path)?;
-            // open it then lose scope to close it
-            let _db: DBWithThreadMode<MultiThreaded> =
-                DBWithThreadMode::open(&opts, dunce::simplified(&dir_hashes_db_path))?;
-        } else {
-            log::debug!("dir hashes db exists at path {:?}", dir_hashes_db_path)
+    pub fn new(
+        repository: &LocalRepository,
+        commit_id: &str,
+        workspace: Option<&Workspace>,
+    ) -> Result<Self, OxenError> {
+        match workspace {
+            Some(workspace) => Ok(SchemaReader::DuckDB(DuckDBSchemaReader::new(
+                repository,
+                commit_id,
+                workspace.clone(),
+            )?)),
+            None => Ok(SchemaReader::Objects(ObjectsSchemaReader::new(
+                repository, commit_id,
+            )?)),
         }
-
-        let object_reader = ObjectDBReader::new(repository, commit_id)?;
-
-        Ok(SchemaReader {
-            dir_hashes_db: DBWithThreadMode::open_for_read_only(&opts, &dir_hashes_db_path, false)?,
-            object_reader,
-            repository: repository.clone(),
-            commit_id: commit_id.to_owned(),
-        })
     }
 
-    pub fn new_from_head(repository: &LocalRepository) -> Result<SchemaReader, OxenError> {
-        let commit_reader = CommitReader::new(repository)?;
-        let commit = commit_reader.head_commit()?;
-        SchemaReader::new(repository, &commit.id)
+    pub fn new_from_head(
+        repository: &LocalRepository,
+        workspace: Option<&Workspace>,
+    ) -> Result<Self, OxenError> {
+        match workspace {
+            Some(workspace) => Ok(SchemaReader::DuckDB(DuckDBSchemaReader::new_from_head(
+                repository,
+                workspace.clone(),
+            )?)),
+            None => Ok(SchemaReader::Objects(ObjectsSchemaReader::new_from_head(
+                repository,
+            )?)),
+        }
     }
 
     pub fn get_schema_for_file<P: AsRef<Path>>(
         &self,
         path: P,
     ) -> Result<Option<Schema>, OxenError> {
-        log::debug!("in get_schema_for_file path {:?}", path.as_ref());
-        let schema_path = Path::new(SCHEMAS_TREE_PREFIX).join(&path);
-        let path_parent = path.as_ref().parent().unwrap_or(Path::new(""));
-
-        // Get the parent dir hash in which the schema is stored
-        let parent_dir_hash: Option<String> = path_db::get_entry(
-            &self.dir_hashes_db,
-            path_parent.to_str().unwrap().replace('\\', "/"),
-        )?;
-
-        if parent_dir_hash.is_none() {
-            return Ok(None);
-        }
-
-        let parent_dir_hash = parent_dir_hash.unwrap();
-
-        let parent_dir_obj: TreeObject = self.object_reader.get_dir(&parent_dir_hash)?.unwrap();
-
-        // Get the hash of the schema's path
-        let full_path_str = schema_path.to_str().unwrap().replace('\\', "/");
-        let schema_path_hash_prefix = util::hasher::hash_path(full_path_str)[0..2].to_string();
-
-        // Binary search for the appropriate vnode
-        let vnode_child: Option<TreeObjectChild> = parent_dir_obj
-            .binary_search_on_path(&PathBuf::from(schema_path_hash_prefix.clone()))?;
-
-        if vnode_child.is_none() {
-            return Ok(None);
-        }
-
-        let vnode_child = vnode_child.unwrap();
-        let vnode = self.object_reader.get_vnode(vnode_child.hash())?.unwrap();
-
-        log::debug!("got vnode");
-        log::debug!("here's the vnode {:?}", vnode);
-        // Binary search for the appropriate schema
-        let schema_child: Option<TreeObjectChild> =
-            vnode.binary_search_on_path(&PathBuf::from(SCHEMAS_TREE_PREFIX).join(path))?;
-
-        if schema_child.is_none() {
-            return Ok(None);
-        }
-
-        let schema_child = schema_child.unwrap();
-        log::debug!("got this schema child {:?}", schema_child);
-
-        // Get the schema from the versions directory by hash
-        let version_path = util::fs::version_path_from_schema_hash(
-            &self.repository.path,
-            schema_child.hash().to_string(),
-        );
-
-        log::debug!("got version path {:?}", version_path);
-
-        let schema: Result<Schema, serde_json::Error> =
-            serde_json::from_reader(std::fs::File::open(version_path)?);
-
-        log::debug!("get_schema_for_file() got schema {:?}", schema);
-
-        match schema {
-            Ok(schema) => Ok(Some(schema)),
-            Err(_) => Ok(None),
+        match self {
+            SchemaReader::DuckDB(reader) => reader.get_schema_for_file(path),
+            SchemaReader::Objects(reader) => reader.get_schema_for_file(path),
         }
     }
 
     pub fn list_schemas(&self) -> Result<HashMap<PathBuf, Schema>, OxenError> {
-        log::debug!("calling list schemas");
-        let root_hash: String = path_db::get_entry(&self.dir_hashes_db, "")?.unwrap();
-        // log::debug!("list_schemas got root hash {:?}", root_hash);
-        let root_node: TreeObject = self.object_reader.get_dir(&root_hash)?.unwrap();
-        // log::debug!("list_schemas got root node {:?}", root_node);
-        let mut path_vals: HashMap<PathBuf, Schema> = HashMap::new();
-
-        self.r_list_schemas(root_node, &mut path_vals)?;
-
-        Ok(path_vals)
-    }
-
-    fn r_list_schemas(
-        &self,
-        dir_node: TreeObject,
-        path_vals: &mut HashMap<PathBuf, Schema>,
-    ) -> Result<(), OxenError> {
-        // log::debug!("calling r_list_schemas on dir_node {:?}", dir_node);
-        for vnode in dir_node.children() {
-            let vnode = self.object_reader.get_vnode(vnode.hash())?.unwrap();
-            for child in vnode.children() {
-                // log::debug!("got vnode child {:?}", child);
-                match child {
-                    TreeObjectChild::Dir { hash, .. } => {
-                        let dir_node = self.object_reader.get_dir(hash)?.unwrap();
-                        self.r_list_schemas(dir_node, path_vals)?;
-                    }
-                    TreeObjectChild::Schema { path, hash, .. } => {
-                        let stripped_path = path.strip_prefix(SCHEMAS_TREE_PREFIX).unwrap();
-                        // log::debug!("got stripped path {:?} and hash {:?}", stripped_path, hash);
-                        let found_schema = self.get_schema_by_hash(hash)?;
-                        // log::debug!("got found schema {:?}", found_schema);
-                        path_vals.insert(stripped_path.to_path_buf(), found_schema);
-                    }
-                    _ => {}
-                }
-            }
+        match self {
+            SchemaReader::DuckDB(_) => Err(OxenError::basic_str(
+                "list_schemas is not implemented for DuckDBSchemaReader",
+            )),
+            SchemaReader::Objects(reader) => reader.list_schemas(),
         }
-        Ok(())
     }
 
     pub fn list_schema_entries(&self) -> Result<Vec<SchemaEntry>, OxenError> {
-        // Root hash is stored on the commit though
-        let commit_reader = CommitReader::new(&self.repository)?;
-        let commit =
-            commit_reader
-                .get_commit_by_id(&self.commit_id)?
-                .ok_or(OxenError::basic_str(format!(
-                    "Could not find commit {}",
-                    self.commit_id
-                )))?;
-
-        let root_hash = commit
-            .root_hash
-            .ok_or(format!("Root hash not found for commit {}", self.commit_id))?;
-
-        let root_node: TreeObject =
-            self.object_reader
-                .get_dir(&root_hash)?
-                .ok_or(OxenError::basic_str(
-                    "Could not find root node in object db",
-                ))?;
-
-        let mut entries: Vec<SchemaEntry> = Vec::new();
-
-        self.r_list_schema_entries(root_node, &mut entries)?;
-
-        Ok(entries)
-    }
-
-    fn r_list_schema_entries(
-        &self,
-        dir_node: TreeObject,
-        entries: &mut Vec<SchemaEntry>,
-    ) -> Result<(), OxenError> {
-        for vnode in dir_node.children() {
-            let vnode = self.object_reader.get_vnode(vnode.hash())?.unwrap();
-            for child in vnode.children() {
-                match child {
-                    TreeObjectChild::Dir { hash, .. } => {
-                        let dir_node = self.object_reader.get_dir(hash)?.unwrap();
-                        self.r_list_schema_entries(dir_node, entries)?;
-                    }
-                    TreeObjectChild::Schema { path, hash, .. } => {
-                        let stripped_path = path.strip_prefix(SCHEMAS_TREE_PREFIX).unwrap();
-                        log::debug!("got stripped path {:?} and hash {:?}", stripped_path, hash);
-                        let found_schema = self.object_reader.get_schema(hash)?.unwrap();
-                        log::debug!("got found schema {:?}", found_schema);
-                        let found_entry = SchemaEntry {
-                            commit_id: self.commit_id.clone(),
-                            path: stripped_path.to_path_buf(),
-                            hash: found_schema.hash().clone(),
-                            num_bytes: found_schema.num_bytes(),
-                        };
-                        entries.push(found_entry);
-                    }
-                    _ => {}
-                }
-            }
+        match self {
+            SchemaReader::DuckDB(_) => Err(OxenError::basic_str(
+                "list_schema_entries is not implemented for DuckDBSchemaReader",
+            )),
+            SchemaReader::Objects(reader) => reader.list_schema_entries(),
         }
-        Ok(())
     }
 
     pub fn list_schemas_for_ref(
         &self,
         schema_ref: impl AsRef<str>,
     ) -> Result<HashMap<PathBuf, Schema>, OxenError> {
-        let all_schemas = self.list_schemas()?;
-
-        let mut found_schemas: HashMap<PathBuf, Schema> = HashMap::new();
-
-        for (path, schema) in all_schemas.iter() {
-            if path.to_string_lossy() == schema_ref.as_ref()
-                || schema.hash == schema_ref.as_ref()
-                || schema.name == Some(schema_ref.as_ref().to_string())
-            {
-                found_schemas.insert(path.clone(), schema.clone());
-            }
+        match self {
+            SchemaReader::DuckDB(_) => Err(OxenError::basic_str(
+                "list_schemas_for_ref is not implemented for DuckDBSchemaReader",
+            )),
+            SchemaReader::Objects(reader) => reader.list_schemas_for_ref(schema_ref),
         }
-        Ok(found_schemas)
-    }
-
-    fn get_schema_by_hash(&self, hash: &str) -> Result<Schema, OxenError> {
-        let version_path =
-            util::fs::version_path_from_schema_hash(&self.repository.path, hash.to_string());
-        let schema = serde_json::from_reader(std::fs::File::open(version_path)?)?;
-        Ok(schema)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::path::PathBuf;
-
-    use crate::api;
-    use crate::core::index::SchemaReader;
-    use crate::error::OxenError;
-    use crate::test;
-
-    #[test]
-    fn test_schema_reader_list_empty_schemas() -> Result<(), OxenError> {
-        test::run_training_data_repo_test_no_commits(|repo| {
-            let history = api::local::commits::list(&repo)?;
-            let last_commit = history.first().unwrap();
-            let schema_reader = SchemaReader::new(&repo, &last_commit.id)?;
-            let schemas = schema_reader.list_schemas()?;
-
-            assert_eq!(schemas.len(), 0);
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn test_schema_reader_list_committed_schemas() -> Result<(), OxenError> {
-        test::run_training_data_repo_test_fully_committed(|repo| {
-            let history = api::local::commits::list(&repo)?;
-            let last_commit = history.first().unwrap();
-            let schema_reader = SchemaReader::new(&repo, &last_commit.id)?;
-            let schemas = schema_reader.list_schemas()?;
-
-            for (k, v) in schemas.iter() {
-                println!("{}: {}", k.to_string_lossy(), v.hash);
-            }
-
-            assert_eq!(schemas.len(), 7);
-            assert!(schemas.contains_key(&PathBuf::from("annotations/train/bounding_box.csv")));
-            assert!(schemas.contains_key(&PathBuf::from("annotations/train/one_shot.csv")));
-            assert!(
-                schemas.contains_key(&PathBuf::from("nlp/classification/annotations/train.tsv"))
-            );
-            assert!(schemas.contains_key(&PathBuf::from("large_files/test.csv")));
-            assert!(schemas.contains_key(&PathBuf::from("nlp/classification/annotations/test.tsv")));
-            assert!(schemas.contains_key(&PathBuf::from("annotations/train/two_shot.csv")));
-            assert!(schemas.contains_key(&PathBuf::from("annotations/test/annotations.csv")));
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn test_schema_reader_get_schema_ref_file() -> Result<(), OxenError> {
-        test::run_training_data_repo_test_fully_committed(|repo| {
-            let history = api::local::commits::list(&repo)?;
-            let last_commit = history.first().unwrap();
-            let schema_reader = SchemaReader::new(&repo, &last_commit.id)?;
-
-            let schema_ref = &PathBuf::from("annotations")
-                .join("train")
-                .join("bounding_box.csv")
-                .to_string_lossy()
-                .to_string();
-            let schemas = schema_reader.list_schemas_for_ref(schema_ref)?;
-
-            assert_eq!(schemas.len(), 1);
-            assert!(schemas.contains_key(&PathBuf::from(schema_ref)));
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn test_schema_reader_get_schema_ref_by_name() -> Result<(), OxenError> {
-        test::run_training_data_repo_test_fully_committed(|repo| {
-            let history = api::local::commits::list(&repo)?;
-            let last_commit = history.first().unwrap();
-            let schema_reader = SchemaReader::new(&repo, &last_commit.id)?;
-
-            let schema_ref = "bounding_box";
-            let schemas = schema_reader.list_schemas_for_ref(schema_ref)?;
-
-            assert_eq!(schemas.len(), 4);
-            assert!(schemas.contains_key(&PathBuf::from("annotations/train/bounding_box.csv")));
-            assert!(schemas.contains_key(&PathBuf::from("annotations/train/one_shot.csv")));
-            assert!(schemas.contains_key(&PathBuf::from("annotations/train/two_shot.csv")));
-            assert!(schemas.contains_key(&PathBuf::from("annotations/test/annotations.csv")));
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn test_schema_reader_get_schema_ref_by_hash() -> Result<(), OxenError> {
-        test::run_training_data_repo_test_fully_committed(|repo| {
-            let history = api::local::commits::list(&repo)?;
-            let last_commit = history.first().unwrap();
-            let schema_reader = SchemaReader::new(&repo, &last_commit.id)?;
-
-            let schema_ref = "b821946753334c083124fd563377d795";
-            let schemas = schema_reader.list_schemas_for_ref(schema_ref)?;
-
-            for (k, v) in schemas.iter() {
-                println!("{}: {}", k.to_string_lossy(), v);
-            }
-
-            assert_eq!(schemas.len(), 4);
-            assert!(schemas.contains_key(&PathBuf::from("annotations/train/bounding_box.csv")));
-            assert!(schemas.contains_key(&PathBuf::from("annotations/train/one_shot.csv")));
-            assert!(schemas.contains_key(&PathBuf::from("annotations/train/two_shot.csv")));
-            assert!(schemas.contains_key(&PathBuf::from("annotations/test/annotations.csv")));
-
-            Ok(())
-        })
     }
 }

--- a/src/lib/src/core/index/schema_reader/duckdb_schema_reader.rs
+++ b/src/lib/src/core/index/schema_reader/duckdb_schema_reader.rs
@@ -1,0 +1,45 @@
+use crate::constants::TABLE_NAME;
+use crate::core::db::data_frames::df_db;
+use crate::core::index::workspaces::data_frames::duckdb_path;
+use crate::core::index::CommitReader;
+use crate::error::OxenError;
+use crate::model::{LocalRepository, Schema, Workspace};
+use std::path::Path;
+use std::str;
+
+pub struct DuckDBSchemaReader {
+    workspace: Box<Workspace>,
+}
+
+impl DuckDBSchemaReader {
+    pub fn new(
+        _repository: &LocalRepository,
+        _commit_id: &str,
+        workspace: Workspace,
+    ) -> Result<DuckDBSchemaReader, OxenError> {
+        Ok(DuckDBSchemaReader {
+            workspace: Box::new(workspace),
+        })
+    }
+
+    pub fn new_from_head(
+        repository: &LocalRepository,
+        workspace: Workspace,
+    ) -> Result<DuckDBSchemaReader, OxenError> {
+        let commit_reader = CommitReader::new(repository)?;
+        let commit = commit_reader.head_commit()?;
+        DuckDBSchemaReader::new(repository, &commit.id, workspace)
+    }
+
+    pub fn get_schema_for_file<P: AsRef<Path>>(
+        &self,
+        path: P,
+    ) -> Result<Option<Schema>, OxenError> {
+        let staged_db_path = duckdb_path(&self.workspace, &path);
+        let conn = df_db::get_connection(staged_db_path)?;
+
+        let df_schema = df_db::get_schema(&conn, TABLE_NAME)?;
+
+        Ok(Some(df_schema))
+    }
+}

--- a/src/lib/src/core/index/schema_reader/objects_schema_reader.rs
+++ b/src/lib/src/core/index/schema_reader/objects_schema_reader.rs
@@ -1,0 +1,259 @@
+use crate::constants::{FILES_DIR, HISTORY_DIR, SCHEMAS_DIR, SCHEMAS_TREE_PREFIX};
+use crate::core::db;
+use crate::core::db::key_val::path_db;
+use crate::core::db::key_val::tree_db::{TreeObject, TreeObjectChild};
+use crate::core::index::CommitEntryWriter;
+use crate::core::index::{CommitReader, ObjectDBReader};
+use crate::error::OxenError;
+use crate::model::entry::commit_entry::SchemaEntry;
+use crate::model::{LocalRepository, Schema};
+use crate::util;
+use rocksdb::{DBWithThreadMode, MultiThreaded};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::str;
+use std::sync::Arc;
+
+pub struct ObjectsSchemaReader {
+    object_reader: Arc<ObjectDBReader>,
+    dir_hashes_db: DBWithThreadMode<MultiThreaded>,
+    repository: LocalRepository,
+    commit_id: String,
+}
+
+impl ObjectsSchemaReader {
+    pub fn schemas_db_dir(repo: &LocalRepository, commit_id: &str) -> PathBuf {
+        util::fs::oxen_hidden_dir(&repo.path)
+            .join(HISTORY_DIR)
+            .join(commit_id)
+            .join(SCHEMAS_DIR)
+            .join(SCHEMAS_DIR)
+    }
+
+    pub fn schema_files_db_dir(repo: &LocalRepository, commit_id: &str) -> PathBuf {
+        util::fs::oxen_hidden_dir(&repo.path)
+            .join(HISTORY_DIR)
+            .join(commit_id)
+            .join(SCHEMAS_DIR)
+            .join(FILES_DIR)
+    }
+
+    pub fn new(
+        repository: &LocalRepository,
+        commit_id: &str,
+    ) -> Result<ObjectsSchemaReader, OxenError> {
+        let dir_hashes_db_path = CommitEntryWriter::commit_dir_hash_db(&repository.path, commit_id);
+
+        let opts = db::key_val::opts::default();
+
+        if !dir_hashes_db_path.exists() {
+            log::debug!("creating dir hashes db at path {:?}", dir_hashes_db_path);
+            std::fs::create_dir_all(&dir_hashes_db_path)?;
+            let _db: DBWithThreadMode<MultiThreaded> =
+                DBWithThreadMode::open(&opts, dunce::simplified(&dir_hashes_db_path))?;
+        } else {
+            log::debug!("dir hashes db exists at path {:?}", dir_hashes_db_path)
+        }
+
+        let object_reader = ObjectDBReader::new(repository, commit_id)?;
+
+        Ok(ObjectsSchemaReader {
+            dir_hashes_db: DBWithThreadMode::open_for_read_only(&opts, &dir_hashes_db_path, false)?,
+            object_reader,
+            repository: repository.clone(),
+            commit_id: commit_id.to_owned(),
+        })
+    }
+
+    pub fn new_from_head(repository: &LocalRepository) -> Result<ObjectsSchemaReader, OxenError> {
+        let commit_reader = CommitReader::new(repository)?;
+        let commit = commit_reader.head_commit()?;
+        ObjectsSchemaReader::new(repository, &commit.id)
+    }
+
+    pub fn get_schema_for_file<P: AsRef<Path>>(
+        &self,
+        path: P,
+    ) -> Result<Option<Schema>, OxenError> {
+        log::debug!("in get_schema_for_file path {:?}", path.as_ref());
+        let schema_path = Path::new(SCHEMAS_TREE_PREFIX).join(&path);
+        let path_parent = path.as_ref().parent().unwrap_or(Path::new(""));
+
+        let parent_dir_hash: Option<String> = path_db::get_entry(
+            &self.dir_hashes_db,
+            path_parent.to_str().unwrap().replace('\\', "/"),
+        )?;
+
+        if parent_dir_hash.is_none() {
+            return Ok(None);
+        }
+
+        let parent_dir_hash = parent_dir_hash.unwrap();
+        let parent_dir_obj: TreeObject = self.object_reader.get_dir(&parent_dir_hash)?.unwrap();
+        let full_path_str = schema_path.to_str().unwrap().replace('\\', "/");
+        let schema_path_hash_prefix = util::hasher::hash_path(full_path_str)[0..2].to_string();
+
+        let vnode_child: Option<TreeObjectChild> = parent_dir_obj
+            .binary_search_on_path(&PathBuf::from(schema_path_hash_prefix.clone()))?;
+
+        if vnode_child.is_none() {
+            return Ok(None);
+        }
+
+        let vnode_child = vnode_child.unwrap();
+        let vnode = self.object_reader.get_vnode(vnode_child.hash())?.unwrap();
+
+        log::debug!("got vnode");
+        log::debug!("here's the vnode {:?}", vnode);
+
+        let schema_child: Option<TreeObjectChild> =
+            vnode.binary_search_on_path(&PathBuf::from(SCHEMAS_TREE_PREFIX).join(path))?;
+
+        if schema_child.is_none() {
+            return Ok(None);
+        }
+
+        let schema_child = schema_child.unwrap();
+        log::debug!("got this schema child {:?}", schema_child);
+
+        let version_path = util::fs::version_path_from_schema_hash(
+            &self.repository.path,
+            schema_child.hash().to_string(),
+        );
+
+        log::debug!("got version path {:?}", version_path);
+
+        let schema: Result<Schema, serde_json::Error> =
+            serde_json::from_reader(std::fs::File::open(version_path)?);
+
+        log::debug!("get_schema_for_file() got schema {:?}", schema);
+
+        match schema {
+            Ok(schema) => Ok(Some(schema)),
+            Err(_) => Ok(None),
+        }
+    }
+
+    pub fn list_schemas(&self) -> Result<HashMap<PathBuf, Schema>, OxenError> {
+        log::debug!("calling list schemas");
+        let root_hash: String = path_db::get_entry(&self.dir_hashes_db, "")?.unwrap();
+        let root_node: TreeObject = self.object_reader.get_dir(&root_hash)?.unwrap();
+        let mut path_vals: HashMap<PathBuf, Schema> = HashMap::new();
+
+        self.r_list_schemas(root_node, &mut path_vals)?;
+
+        Ok(path_vals)
+    }
+
+    fn r_list_schemas(
+        &self,
+        dir_node: TreeObject,
+        path_vals: &mut HashMap<PathBuf, Schema>,
+    ) -> Result<(), OxenError> {
+        for vnode in dir_node.children() {
+            let vnode = self.object_reader.get_vnode(vnode.hash())?.unwrap();
+            for child in vnode.children() {
+                match child {
+                    TreeObjectChild::Dir { hash, .. } => {
+                        let dir_node = self.object_reader.get_dir(hash)?.unwrap();
+                        self.r_list_schemas(dir_node, path_vals)?;
+                    }
+                    TreeObjectChild::Schema { path, hash, .. } => {
+                        let stripped_path = path.strip_prefix(SCHEMAS_TREE_PREFIX).unwrap();
+                        let found_schema = self.get_schema_by_hash(hash)?;
+                        path_vals.insert(stripped_path.to_path_buf(), found_schema);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn list_schema_entries(&self) -> Result<Vec<SchemaEntry>, OxenError> {
+        let commit_reader = CommitReader::new(&self.repository)?;
+        let commit =
+            commit_reader
+                .get_commit_by_id(&self.commit_id)?
+                .ok_or(OxenError::basic_str(format!(
+                    "Could not find commit {}",
+                    self.commit_id
+                )))?;
+
+        let root_hash = commit
+            .root_hash
+            .ok_or(format!("Root hash not found for commit {}", self.commit_id))?;
+
+        let root_node: TreeObject =
+            self.object_reader
+                .get_dir(&root_hash)?
+                .ok_or(OxenError::basic_str(
+                    "Could not find root node in object db",
+                ))?;
+
+        let mut entries: Vec<SchemaEntry> = Vec::new();
+
+        self.r_list_schema_entries(root_node, &mut entries)?;
+
+        Ok(entries)
+    }
+
+    fn r_list_schema_entries(
+        &self,
+        dir_node: TreeObject,
+        entries: &mut Vec<SchemaEntry>,
+    ) -> Result<(), OxenError> {
+        for vnode in dir_node.children() {
+            let vnode = self.object_reader.get_vnode(vnode.hash())?.unwrap();
+            for child in vnode.children() {
+                match child {
+                    TreeObjectChild::Dir { hash, .. } => {
+                        let dir_node = self.object_reader.get_dir(hash)?.unwrap();
+                        self.r_list_schema_entries(dir_node, entries)?;
+                    }
+                    TreeObjectChild::Schema { path, hash, .. } => {
+                        let stripped_path = path.strip_prefix(SCHEMAS_TREE_PREFIX).unwrap();
+                        log::debug!("got stripped path {:?} and hash {:?}", stripped_path, hash);
+                        let found_schema = self.object_reader.get_schema(hash)?.unwrap();
+                        log::debug!("got found schema {:?}", found_schema);
+                        let found_entry = SchemaEntry {
+                            commit_id: self.commit_id.clone(),
+                            path: stripped_path.to_path_buf(),
+                            hash: found_schema.hash().clone(),
+                            num_bytes: found_schema.num_bytes(),
+                        };
+                        entries.push(found_entry);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn list_schemas_for_ref(
+        &self,
+        schema_ref: impl AsRef<str>,
+    ) -> Result<HashMap<PathBuf, Schema>, OxenError> {
+        let all_schemas = self.list_schemas()?;
+
+        let mut found_schemas: HashMap<PathBuf, Schema> = HashMap::new();
+
+        for (path, schema) in all_schemas.iter() {
+            if path.to_string_lossy() == schema_ref.as_ref()
+                || schema.hash == schema_ref.as_ref()
+                || schema.name == Some(schema_ref.as_ref().to_string())
+            {
+                found_schemas.insert(path.clone(), schema.clone());
+            }
+        }
+        Ok(found_schemas)
+    }
+
+    fn get_schema_by_hash(&self, hash: &str) -> Result<Schema, OxenError> {
+        let version_path =
+            util::fs::version_path_from_schema_hash(&self.repository.path, hash.to_string());
+        let schema = serde_json::from_reader(std::fs::File::open(version_path)?)?;
+        Ok(schema)
+    }
+}

--- a/src/lib/src/core/index/schema_writer.rs
+++ b/src/lib/src/core/index/schema_writer.rs
@@ -7,7 +7,8 @@ use rocksdb::{DBWithThreadMode, MultiThreaded};
 use std::path::Path;
 use std::str;
 
-use crate::core::index::SchemaReader;
+use crate::core::index::schema_reader::objects_schema_reader;
+
 use crate::model::LocalRepository;
 
 use super::versioner;
@@ -19,7 +20,8 @@ pub struct SchemaWriter {
 
 impl SchemaWriter {
     pub fn new(repository: &LocalRepository, commit_id: &str) -> Result<SchemaWriter, OxenError> {
-        let db_path = SchemaReader::schemas_db_dir(repository, commit_id);
+        let db_path =
+            objects_schema_reader::ObjectsSchemaReader::schemas_db_dir(repository, commit_id);
         let opts = db::key_val::opts::default();
         if !db_path.exists() {
             std::fs::create_dir_all(&db_path)?;
@@ -28,7 +30,8 @@ impl SchemaWriter {
                 DBWithThreadMode::open(&opts, dunce::simplified(&db_path))?;
         }
 
-        let schema_files_db_path = SchemaReader::schema_files_db_dir(repository, commit_id);
+        let schema_files_db_path =
+            objects_schema_reader::ObjectsSchemaReader::schema_files_db_dir(repository, commit_id);
         if !schema_files_db_path.exists() {
             std::fs::create_dir_all(&schema_files_db_path)?;
             // open it then lose scope to close it

--- a/src/lib/src/core/index/stager.rs
+++ b/src/lib/src/core/index/stager.rs
@@ -785,7 +785,7 @@ impl Stager {
             // Also add as removed to staged schema db
             if util::fs::is_tabular(path) {
                 // Get schema for this file
-                let schema_reader = SchemaReader::new(&self.repository, &entry.commit_id)?;
+                let schema_reader = SchemaReader::new(&self.repository, &entry.commit_id, None)?;
                 let schema = schema_reader.get_schema_for_file(path)?;
                 if let Some(schema) = schema {
                     let staged_schema = StagedSchema {
@@ -1015,7 +1015,7 @@ impl Stager {
         // Add all untracked files and modified files
         let (dir_paths, total) = self.list_unstaged_files_in_dir(dir);
         // log::debug!("Stager.add_dir {:?} -> {}", dir, total);
-        let schema_reader = SchemaReader::new(&self.repository, &entry_reader.commit_id)?;
+        let schema_reader = SchemaReader::new(&self.repository, &entry_reader.commit_id, None)?;
         // println!("Adding files in directory: {short_path:?}");
         let size: u64 = unsafe { std::mem::transmute(total) };
         let msg = format!("Adding directory {short_path:?}");
@@ -1668,7 +1668,7 @@ mod tests {
             let commit_reader = CommitReader::new(&repo)?;
             let commit = commit_reader.head_commit()?;
             let entry_reader = CommitEntryReader::new(&stager.repository, &commit)?;
-            let schema_reader = SchemaReader::new(&stager.repository, &commit.id)?;
+            let schema_reader = SchemaReader::new(&stager.repository, &commit.id, None)?;
 
             let repo_path = &stager.repository.path;
             let hello_file = test::add_txt_file_to_dir(repo_path, "Hello World")?;
@@ -1706,7 +1706,7 @@ mod tests {
             // Create entry_reader with no commits
             let head_commit = CommitReader::new(&stager.repository)?.head_commit()?;
             let entry_reader = CommitEntryReader::new_from_head(&stager.repository)?;
-            let schema_reader = SchemaReader::new(&stager.repository, &head_commit.id)?;
+            let schema_reader = SchemaReader::new(&stager.repository, &head_commit.id, None)?;
             // Make sure we have a valid file
             let repo_path = &stager.repository.path;
             let hello_file = test::add_txt_file_to_dir(repo_path, "Hello World")?;
@@ -1729,7 +1729,7 @@ mod tests {
             // Create entry_reader with no commits
             let head_commit = CommitReader::new(&stager.repository)?.head_commit()?;
             let entry_reader = CommitEntryReader::new_from_head(&stager.repository)?;
-            let schema_reader = SchemaReader::new(&stager.repository, &head_commit.id)?;
+            let schema_reader = SchemaReader::new(&stager.repository, &head_commit.id, None)?;
             // Make sure we have a valid file
             let repo_path = &stager.repository.path;
             let hello_file = test::add_txt_file_to_dir(repo_path, "Hello World")?;
@@ -1744,7 +1744,7 @@ mod tests {
             stager.unstage()?;
 
             // try to add it again
-            let schema_reader = SchemaReader::new(&stager.repository, &commit.id)?;
+            let schema_reader = SchemaReader::new(&stager.repository, &commit.id, None)?;
             let entry_reader = CommitEntryReader::new(&repo, &commit)?;
             stager.add_file(&hello_file, &entry_reader, &schema_reader)?;
 
@@ -1761,7 +1761,7 @@ mod tests {
         test::run_empty_stager_test(|stager, _repo| {
             // Create entry_reader with no commits
             let entry_reader = CommitEntryReader::new_from_head(&stager.repository)?;
-            let schema_reader = SchemaReader::new_from_head(&stager.repository)?;
+            let schema_reader = SchemaReader::new_from_head(&stager.repository, None)?;
             let hello_file = PathBuf::from("non-existant.txt");
             if stager
                 .add_file(&hello_file, &entry_reader, &schema_reader)
@@ -1780,7 +1780,7 @@ mod tests {
         test::run_empty_stager_test(|stager, _repo| {
             // Create entry_reader with no commits
             let entry_reader = CommitEntryReader::new_from_head(&stager.repository)?;
-            let schema_reader = SchemaReader::new_from_head(&stager.repository)?;
+            let schema_reader = SchemaReader::new_from_head(&stager.repository, None)?;
             let hello_file = test::add_txt_file_to_dir(&stager.repository.path, "Hello 1")?;
             stager.add_file(&hello_file, &entry_reader, &schema_reader)?;
 
@@ -1823,7 +1823,7 @@ mod tests {
         test::run_empty_stager_test(|stager, _repo| {
             // Create entry_reader with no commits
             let entry_reader = CommitEntryReader::new_from_head(&stager.repository)?;
-            let schema_reader = SchemaReader::new_from_head(&stager.repository)?;
+            let schema_reader = SchemaReader::new_from_head(&stager.repository, None)?;
             // Write two files to directories
             let repo_path = &stager.repository.path;
             let sub_dir = repo_path.join("training_data").join("deeper");
@@ -1870,7 +1870,7 @@ mod tests {
         test::run_empty_stager_test(|stager, _repo| {
             // Create entry_reader with no commits
             let entry_reader = CommitEntryReader::new_from_head(&stager.repository)?;
-            let schema_reader = SchemaReader::new_from_head(&stager.repository)?;
+            let schema_reader = SchemaReader::new_from_head(&stager.repository, None)?;
 
             let repo_path = &stager.repository.path;
             let hello_file = test::add_txt_file_to_dir(repo_path, "Hello World")?;
@@ -1893,7 +1893,7 @@ mod tests {
         test::run_empty_stager_test(|stager, _repo| {
             // Create entry_reader with no commits
             let entry_reader = CommitEntryReader::new_from_head(&stager.repository)?;
-            let schema_reader = SchemaReader::new_from_head(&stager.repository)?;
+            let schema_reader = SchemaReader::new_from_head(&stager.repository, None)?;
             let repo_path = &stager.repository.path;
             let hello_file = test::add_txt_file_to_dir(repo_path, "Hello World")?;
             let relative_path = util::fs::path_relative_to_dir(&hello_file, repo_path)?;
@@ -1916,7 +1916,7 @@ mod tests {
         test::run_empty_stager_test(|stager, _repo| {
             // Create entry_reader with no commits
             let entry_reader = CommitEntryReader::new_from_head(&stager.repository)?;
-            let schema_reader = SchemaReader::new_from_head(&stager.repository)?;
+            let schema_reader = SchemaReader::new_from_head(&stager.repository, None)?;
             // Write two files to a sub directory
             let repo_path = &stager.repository.path;
             let sub_dir = repo_path.join("training_data");
@@ -1945,7 +1945,7 @@ mod tests {
         test::run_empty_stager_test(|stager, _repo| {
             // Create entry_reader with no commits
             let entry_reader = CommitEntryReader::new_from_head(&stager.repository)?;
-            let schema_reader = SchemaReader::new_from_head(&stager.repository)?;
+            let schema_reader = SchemaReader::new_from_head(&stager.repository, None)?;
             // Write two files to a sub directory
             let repo_path = &stager.repository.path;
             let training_data_dir = PathBuf::from("training_data");
@@ -2039,7 +2039,7 @@ mod tests {
         test::run_empty_stager_test(|stager, repo| {
             // Create entry_reader with no commits
             let entry_reader = CommitEntryReader::new_from_head(&stager.repository)?;
-            let schema_reader = SchemaReader::new_from_head(&stager.repository)?;
+            let schema_reader = SchemaReader::new_from_head(&stager.repository, None)?;
             let repo_path = &stager.repository.path;
             let hello_file = test::add_txt_file_to_dir(repo_path, "Hello 1")?;
 
@@ -2130,7 +2130,7 @@ mod tests {
             let commit_reader = CommitReader::new(&repo)?;
             let commit = commit_reader.head_commit()?;
             let entry_reader = CommitEntryReader::new(&repo, &commit)?;
-            let schema_reader = SchemaReader::new(&repo, &commit.id)?;
+            let schema_reader = SchemaReader::new(&repo, &commit.id, None)?;
             // Write two files to a sub directory
             let repo_path = &stager.repository.path;
             let annotations_dir = PathBuf::from("annotations");
@@ -2284,7 +2284,7 @@ mod tests {
             let commit_reader = CommitReader::new(&repo)?;
             let commit = commit_reader.head_commit()?;
             let entry_reader = CommitEntryReader::new(&stager.repository, &commit)?;
-            let schema_reader = SchemaReader::new(&stager.repository, &commit.id)?;
+            let schema_reader = SchemaReader::new(&stager.repository, &commit.id, None)?;
 
             // Create 2 sub directories, one with  Write two files to a sub directory
             let repo_path = &stager.repository.path;

--- a/src/lib/src/core/index/workspaces/files.rs
+++ b/src/lib/src/core/index/workspaces/files.rs
@@ -21,7 +21,7 @@ pub fn add(workspace: &Workspace, filepath: &Path) -> Result<PathBuf, OxenError>
     log::debug!("core::index::workspaces::files::add adding file {filepath:?}");
     // Add a schema_reader to stager.add_file for?
 
-    let schema_reader = SchemaReader::new(repo, &commit.id)?;
+    let schema_reader = SchemaReader::new(workspace_repo, &commit.id, Some(workspace))?;
 
     stager.add_file(filepath.as_ref(), &reader, &schema_reader)?;
     log::debug!("done adding file in the stager");

--- a/src/server/src/controllers/branches.rs
+++ b/src/server/src/controllers/branches.rs
@@ -271,7 +271,7 @@ pub async fn list_entry_versions(
     for (commit, entry) in commits_with_versions {
         // For each version, get the schema hash if one exists.
         let maybe_schema_hash = if util::fs::is_tabular(&entry.path) {
-            let schema_reader = SchemaReader::new(&repo, &commit.id)?;
+            let schema_reader = SchemaReader::new(&repo, &commit.id, None)?;
             let maybe_schema = schema_reader.get_schema_for_file(&entry.path)?;
             match maybe_schema {
                 Some(schema) => Some(schema.hash),


### PR DESCRIPTION
When changing the schema of a df in a workspace, we use to base our commit off of the last versioned schema. This made it so the new schema changes were ignored.

This fixes that by adding logic that retrieves the actual current workspace schema from the indexed df.