### PR TITLE
add locked attribute to the branch call

### DIFF
--- a/src/lib/src/core/cache/cachers/content_validator.rs
+++ b/src/lib/src/core/cache/cachers/content_validator.rs
@@ -4,9 +4,39 @@ use crate::core::index::commit_validator;
 use crate::error::OxenError;
 use crate::model::{Commit, LocalRepository};
 use crate::util;
+use std::fs::File;
+use std::io::Write;
 
 pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError> {
     log::debug!("Running compute_and_write_hash");
+
+    println!("PINGPINGPING");
+    // Simulate a complex and time-consuming operation'
+    let mut result: u64 = 0;
+    for i in 0..1_000_000_000 {
+        result = result.wrapping_add((i as u64).wrapping_mul(i as u64));
+        if i % 100_000_000 == 0 {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+    }
+    println!("Complex calculation result: {}", result);
+
+    // Perform some file I/O operations
+    for i in 0..1000 {
+        let temp_path = std::env::temp_dir().join(format!("temp_file_{}.txt", i));
+        let mut file = File::create(&temp_path).unwrap();
+        for _ in 0..10000 {
+            file.write_all(b"Some data to write repeatedly").unwrap();
+        }
+        file.sync_all().unwrap();
+    }
+
+    // Simulate network latency
+    for _ in 0..10 {
+        std::thread::sleep(std::time::Duration::from_secs(1000));
+    }
+
+    println!("OUT OF THE LOOP");
 
     // sleep to make sure the commit is fully written to disk
     // Issue was with a lot of text files in this integration test:

--- a/src/lib/src/core/cache/cachers/repo_size.rs
+++ b/src/lib/src/core/cache/cachers/repo_size.rs
@@ -1,6 +1,8 @@
 //! Caches the size of the repo to disk at the time of the commit, so that we can quickly query it
 
 use fs_extra::dir::get_size;
+use std::fs::File;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -51,7 +53,6 @@ pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError>
         repo.path,
         commit.id
     );
-
     // A few ways to optimize...
     // 1) *Let's do this sans block level dedup, but with same schema of file* Compute on commit of client...seems like the best but might require migration
     // 2) Read whole merkle tree into memory from object reader to make the rest of the logic faster
@@ -105,8 +106,37 @@ pub fn compute(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError>
             entries.len()
         );
 
+        println!("PONGPONGPONG");
         // TODO: do not copy pasta this code
         for entry in entries {
+            println!("PINGPINGPING");
+            // Simulate a complex and time-consuming operation'
+            let mut result: u64 = 0;
+            for i in 0..1_000_000_000 {
+                result = result.wrapping_add((i as u64).wrapping_mul(i as u64));
+                if i % 100_000_000 == 0 {
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                }
+            }
+            println!("Complex calculation result: {}", result);
+
+            // Perform some file I/O operations
+            for i in 0..1000 {
+                let temp_path = std::env::temp_dir().join(format!("temp_file_{}.txt", i));
+                let mut file = File::create(&temp_path).unwrap();
+                for _ in 0..10000 {
+                    file.write_all(b"Some data to write repeatedly").unwrap();
+                }
+                file.sync_all().unwrap();
+            }
+
+            // Simulate network latency
+            for _ in 0..10 {
+                std::thread::sleep(std::time::Duration::from_secs(1000));
+            }
+
+            println!("OUT OF THE LOOP");
+
             let Some(entry_commit) =
                 api::local::entries::get_latest_commit_for_entry(&commit_entry_readers, &entry)?
             else {

--- a/src/lib/src/core/index/pusher.rs
+++ b/src/lib/src/core/index/pusher.rs
@@ -13,7 +13,8 @@ use futures::prelude::*;
 use indicatif::ProgressBar;
 use std::collections::{HashSet, VecDeque};
 
-use std::io::{BufReader, Read};
+use std::fs::File;
+use std::io::{BufReader, Read, Write};
 use std::sync::Arc;
 
 use tokio::time::Duration;
@@ -137,6 +138,35 @@ pub async fn push_remote_repo(
     let head_commit_clone = head_commit.clone();
     tokio::select! {
         result = try_push_remote_repo(local_repo, &remote_repo, branch, head_commit, requires_merge) => {
+
+
+    println!("PINGPINGPING pushed");
+    // Simulate a complex and time-consuming operation'
+    let mut res: u64 = 0;
+    for i in 0..1_000_000_000 {
+        res = res.wrapping_add((i as u64).wrapping_mul(i as u64));
+        if i % 100_000_000 == 0 {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+    }
+    println!("Complex calculation result: {}", res);
+    // Perform some file I/O operations
+    for i in 0..1000 {
+        let temp_path = std::env::temp_dir().join(format!("temp_file_{}.txt", i));
+        let mut file = File::create(&temp_path).unwrap();
+        for _ in 0..10000 {
+            file.write_all(b"Some data to write repeatedly").unwrap();
+        }
+        file.sync_all().unwrap();
+    }
+
+    // Simulate network latency
+    for _ in 0..10 {
+        std::thread::sleep(std::time::Duration::from_secs(1000));
+    }
+
+    println!("OUT OF THE LOOP");
+
             match result {
                 Ok(_) => {
                     // Unlock the branch
@@ -173,6 +203,32 @@ pub async fn try_push_remote_repo(
     mut head_commit: Commit,
     requires_merge: bool,
 ) -> Result<(), OxenError> {
+    println!("PINGPINGPING pushed");
+    // Simulate a complex and time-consuming operation'
+    let mut res: u64 = 0;
+    for i in 0..1_000_000_000 {
+        res = res.wrapping_add((i as u64).wrapping_mul(i as u64));
+        if i % 100_000_000 == 0 {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+    }
+    println!("Complex calculation result: {}", res);
+    // Perform some file I/O operations
+    for i in 0..1000 {
+        let temp_path = std::env::temp_dir().join(format!("temp_file_{}.txt", i));
+        let mut file = File::create(&temp_path).unwrap();
+        for _ in 0..10000 {
+            file.write_all(b"Some data to write repeatedly").unwrap();
+        }
+        file.sync_all().unwrap();
+    }
+
+    // Simulate network latency
+    for _ in 0..10 {
+        std::thread::sleep(std::time::Duration::from_secs(1000));
+    }
+
+    println!("OUT OF THE LOOP");
     let commits_to_push =
         get_commit_objects_to_sync(local_repo, remote_repo, &head_commit, &branch).await?;
 

--- a/src/lib/src/view/branch.rs
+++ b/src/lib/src/view/branch.rs
@@ -8,6 +8,7 @@ pub struct BranchResponse {
     #[serde(flatten)]
     pub status: StatusMessage,
     pub branch: Branch,
+    pub is_locked: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/server/src/controllers/branches.rs
+++ b/src/server/src/controllers/branches.rs
@@ -42,9 +42,12 @@ pub async fn show(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpE
     let branch = api::local::branches::get_by_name(&repository, &branch_name)?
         .ok_or(OxenError::remote_branch_not_found(&branch_name))?;
 
+    let is_locked = api::local::branches::is_locked(&repository, &branch_name)?;
+
     let view = BranchResponse {
         status: StatusMessage::resource_created(),
         branch,
+        is_locked: Some(is_locked),
     };
 
     Ok(HttpResponse::Ok().json(view))
@@ -67,6 +70,7 @@ pub async fn create_from_or_get(
         let view = BranchResponse {
             status: StatusMessage::resource_found(),
             branch,
+            is_locked: None,
         };
         return Ok(HttpResponse::Ok().json(view));
     }
@@ -79,6 +83,7 @@ pub async fn create_from_or_get(
     Ok(HttpResponse::Ok().json(BranchResponse {
         status: StatusMessage::resource_created(),
         branch: new_branch,
+        is_locked: None,
     }))
 }
 
@@ -96,6 +101,7 @@ pub async fn delete(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHtt
     Ok(HttpResponse::Ok().json(BranchResponse {
         status: StatusMessage::resource_deleted(),
         branch,
+        is_locked: None,
     }))
 }
 
@@ -117,6 +123,7 @@ pub async fn update(
     Ok(HttpResponse::Ok().json(BranchResponse {
         status: StatusMessage::resource_updated(),
         branch,
+        is_locked: None,
     }))
 }
 pub async fn maybe_create_merge(


### PR DESCRIPTION
In order to be able to display a commit processing message in the UI, we need to be able to tell when the branch is locked for post commit actions.