### PR TITLE
Status/rm dirs

### DIFF
--- a/src/lib/src/core/v0_19_0/add.rs
+++ b/src/lib/src/core/v0_19_0/add.rs
@@ -140,11 +140,18 @@ fn add_files(
         } else {
             // TODO: Should there be a way to add non-existant dirs? I think it's safer to just require rm for those?
             log::debug!(
-                "Found nonexistant path {path:?}. Staging for removal. Recursive flag not set"
+                "Found nonexistant path {path:?}. Staging for removal. Recursive flag set"
             );
             let mut opts = RmOpts::from_path(path);
             opts.recursive = true;
-            repositories::rm(repo, &opts)?;
+            match repositories::rm(repo, &opts) {
+                Ok(_) => {},
+                Err(_) => {
+                    return Err(OxenError::basic_str(format!(
+                    "Error: Unable to add file {:?}", path)
+                    ));
+                }
+            }
         }
     }
 

--- a/src/lib/src/core/v0_19_0/add.rs
+++ b/src/lib/src/core/v0_19_0/add.rs
@@ -139,17 +139,16 @@ fn add_files(
             }
         } else {
             // TODO: Should there be a way to add non-existant dirs? I think it's safer to just require rm for those?
-            log::debug!(
-                "Found nonexistant path {path:?}. Staging for removal. Recursive flag set"
-            );
+            log::debug!("Found nonexistant path {path:?}. Staging for removal. Recursive flag set");
             let mut opts = RmOpts::from_path(path);
             opts.recursive = true;
             match repositories::rm(repo, &opts) {
-                Ok(_) => {},
+                Ok(_) => {}
                 Err(_) => {
                     return Err(OxenError::basic_str(format!(
-                    "Error: Unable to add file {:?}", path)
-                    ));
+                        "Error: Unable to add file {:?}",
+                        path
+                    )));
                 }
             }
         }

--- a/src/lib/src/core/v0_19_0/index/commit_writer.rs
+++ b/src/lib/src/core/v0_19_0/index/commit_writer.rs
@@ -100,7 +100,7 @@ pub fn commit_with_cfg(
     commit_progress_bar.enable_steady_tick(Duration::from_millis(100));
 
     // Read all the staged entries
-    let (dir_entries, total_changes) =
+    let (dir_entries, _, total_changes) =
         status::read_staged_entries(repo, &staged_db, &commit_progress_bar)?;
     commit_progress_bar.set_message(format!("Committing {} changes", total_changes));
 

--- a/src/lib/src/core/v0_19_0/status.rs
+++ b/src/lib/src/core/v0_19_0/status.rs
@@ -255,8 +255,6 @@ pub fn read_staged_entries_below_path(
                 }
                 let entry: StagedMerkleTreeNode = rmp_serde::from_slice(&value).unwrap();
                 log::debug!("read_staged_entries key {key} entry: {entry} path: {path:?}");
-                let full_path = repo.path.join(path);
-
 
                 // if the entry is a dir, add it as a key in dir_entries, and add its status to dir_status
                 if let EMerkleTreeNode::Directory(_) = &entry.node.node {
@@ -438,7 +436,7 @@ fn get_dir_node(
 
 fn is_ignored(path: &Path, gitignore: &Option<Gitignore>, is_dir: bool) -> bool {
     // Skip hidden .oxen files
-    if path.starts_with(OXEN_HIDDEN_DIR) | path.starts_with("data") | path.starts_with(".git") | path.starts_with("target") | path.starts_with("src") {
+    if path.starts_with(OXEN_HIDDEN_DIR) {
         return true;
     }
     if let Some(gitignore) = gitignore {

--- a/src/lib/src/core/v0_19_0/status.rs
+++ b/src/lib/src/core/v0_19_0/status.rs
@@ -78,7 +78,8 @@ pub fn status_from_dir(
         return Ok(staged_data);
     };
 
-    let (dir_entries, dir_status, _) = read_staged_entries_below_path(repo, &staged_db, &dir, &read_progress)?;
+    let (dir_entries, dir_status, _) =
+        read_staged_entries_below_path(repo, &staged_db, &dir, &read_progress)?;
     // log::debug!("status_from_dir dir_entries: {:?}", dir_entries);
     read_progress.finish_and_clear();
 
@@ -228,7 +229,14 @@ pub fn read_staged_entries(
     repo: &LocalRepository,
     db: &DBWithThreadMode<SingleThreaded>,
     read_progress: &ProgressBar,
-) -> Result<(HashMap<PathBuf, Vec<StagedMerkleTreeNode>>, HashMap<PathBuf, StagedEntryStatus>, u64), OxenError> {
+) -> Result<
+    (
+        HashMap<PathBuf, Vec<StagedMerkleTreeNode>>,
+        HashMap<PathBuf, StagedEntryStatus>,
+        u64,
+    ),
+    OxenError,
+> {
     read_staged_entries_below_path(repo, db, Path::new(""), read_progress)
 }
 
@@ -237,7 +245,14 @@ pub fn read_staged_entries_below_path(
     db: &DBWithThreadMode<SingleThreaded>,
     start_path: impl AsRef<Path>,
     read_progress: &ProgressBar,
-) -> Result<(HashMap<PathBuf, Vec<StagedMerkleTreeNode>>, HashMap<PathBuf, StagedEntryStatus>, u64), OxenError> {
+) -> Result<
+    (
+        HashMap<PathBuf, Vec<StagedMerkleTreeNode>>,
+        HashMap<PathBuf, StagedEntryStatus>,
+        u64,
+    ),
+    OxenError,
+> {
     let start_path = util::fs::path_relative_to_dir(start_path.as_ref(), &repo.path)?;
     let mut total_entries = 0;
     let iter = db.iterator(IteratorMode::Start);

--- a/src/lib/src/core/v0_19_0/status.rs
+++ b/src/lib/src/core/v0_19_0/status.rs
@@ -95,7 +95,6 @@ pub fn status_from_dir_entries(
         total_files: 0,
         paths: HashMap::new(),
     };
-    println!("dir_status: {dir_status:?}");
     log::debug!("dir_entries.len(): {:?}", dir_entries.len());
     for (dir, entries) in dir_entries {
         log::debug!(
@@ -255,21 +254,20 @@ pub fn read_staged_entries_below_path(
                     continue;
                 }
                 let entry: StagedMerkleTreeNode = rmp_serde::from_slice(&value).unwrap();
-                println!("read_staged_entries key {key} entry: {entry} path: {path:?}");
+                log::debug!("read_staged_entries key {key} entry: {entry} path: {path:?}");
                 let full_path = repo.path.join(path);
-                println!("full path: {full_path:?}");
 
 
                 // if the entry is a dir, add it as a key in dir_entries, and add its status to dir_status
                 if let EMerkleTreeNode::Directory(_) = &entry.node.node {
-                    println!("read_staged_entries adding dir {:?}", path);
+                    log::debug!("read_staged_entries adding dir {:?}", path);
                     dir_entries.entry(path.to_path_buf()).or_default();
                     dir_status.insert(path.to_path_buf(), entry.status.clone());
                 }
 
                 // add the file or dir as an entry under its parent dir
                 if let Some(parent) = path.parent() {
-                    println!(
+                    log::debug!(
                         "read_staged_entries adding file {:?} to parent {:?}",
                         path,
                         parent
@@ -294,9 +292,9 @@ pub fn read_staged_entries_below_path(
         dir_entries.len()
     );
     for (dir, entries) in dir_entries.iter() {
-        println!("commit dir_entries dir {:?}", dir);
+        log::debug!("commit dir_entries dir {:?}", dir);
         for entry in entries.iter() {
-            println!("\tcommit dir_entries entry {}", entry);
+            log::debug!("\tcommit dir_entries entry {}", entry);
         }
     }
 

--- a/src/lib/src/core/v0_19_0/workspaces.rs
+++ b/src/lib/src/core/v0_19_0/workspaces.rs
@@ -66,7 +66,7 @@ pub fn commit(
     let commit_progress_bar = ProgressBar::new_spinner();
 
     // Read all the staged entries
-    let (dir_entries, _) = core::v0_19_0::status::read_staged_entries(
+    let (dir_entries, _, _) = core::v0_19_0::status::read_staged_entries(
         &workspace.workspace_repo,
         &staged_db,
         &commit_progress_bar,

--- a/src/lib/src/core/v0_19_0/workspaces/commit.rs
+++ b/src/lib/src/core/v0_19_0/workspaces/commit.rs
@@ -53,7 +53,7 @@ pub fn commit(
     let commit_progress_bar = ProgressBar::new_spinner();
 
     // Read all the staged entries
-    let (dir_entries, _) = core::v0_19_0::status::read_staged_entries(
+    let (dir_entries, _, _) = core::v0_19_0::status::read_staged_entries(
         &workspace.workspace_repo,
         &staged_db,
         &commit_progress_bar,

--- a/src/lib/src/core/v0_19_0/workspaces/status.rs
+++ b/src/lib/src/core/v0_19_0/workspaces/status.rs
@@ -27,7 +27,7 @@ pub fn status(workspace: &Workspace, directory: impl AsRef<Path>) -> Result<Stag
         DBWithThreadMode::open_for_read_only(&opts, dunce::simplified(&db_path), true)?;
 
     let read_progress = ProgressBar::new_spinner();
-    let (dir_entries, _) = core::v0_19_0::status::read_staged_entries_below_path(
+    let (dir_entries, dir_status, _) = core::v0_19_0::status::read_staged_entries_below_path(
         &workspace.workspace_repo,
         &db,
         dir,
@@ -35,5 +35,5 @@ pub fn status(workspace: &Workspace, directory: impl AsRef<Path>) -> Result<Stag
     )?;
 
     let mut staged_data = StagedData::empty();
-    core::v0_19_0::status::status_from_dir_entries(&mut staged_data, dir_entries)
+    core::v0_19_0::status::status_from_dir_entries(&mut staged_data, dir_entries, dir_status)
 }


### PR DESCRIPTION
QOL update: Status will now correctly display removed dirs as 'removed' instead of added. There's also a more suitable error message for adding non-existant files.
