### PR TITLE
Fix version of rust-toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "1.82.0"


### PR DESCRIPTION
The tag stable depends on when rustup was updated the last time, and a change in stable rust version could break builds.
Alternatively, it would be possible to set `rust-version = "1.82"` in the Cargo.toml.  