### PR TITLE
Speed up `status` command with a few options

### DIFF
--- a/data/test/csvs/spam_ham_data_w_quote.tsv
+++ b/data/test/csvs/spam_ham_data_w_quote.tsv
@@ -1,0 +1,101 @@
+category	text
+ham	Go until jurong point, crazy.. Available only in bugis n great world la e buffet... Cine there got amore wat...
+ham	Ok lar... Joking wif u oni...
+spam	Free entry in 2 a wkly comp to win FA Cup final tkts 21st May 2005. Text FA to 87121 to receive entry question(std txt rate)T&C's apply 08452810075over18's
+ham	U dun say so early hor... U c already then say...
+ham	Nah I don't think he goes to usf, he lives around here though
+spam	FreeMsg Hey there darling it's been 3 week's now and no word back! I'd like some fun you up for it still? Tb ok! XxX std chgs to send, £1.50 to rcv
+ham	Even my brother is not like to speak with me. They treat me like aids patent.
+ham	As per your request 'Melle Melle (Oru Minnaminunginte Nurungu Vettam)' has been set as your callertune for all Callers. Press *9 to copy your friends Callertune
+spam	WINNER!! As a valued network customer you have been selected to receivea £900 prize reward! To claim call 09061701461. Claim code KL341. Valid 12 hours only.
+spam	Had your mobile 11 months or more? U R entitled to Update to the latest colour mobiles with camera for Free! Call The Mobile Update Co FREE on 08002986030
+ham	I'm gonna be home soon and i don't want to talk about this stuff anymore tonight, k? I've cried enough today.
+spam	SIX chances to win CASH! From 100 to 20,000 pounds txt> CSH11 and send to 87575. Cost 150p/day, 6days, 16+ TsandCs apply Reply HL 4 info
+spam	URGENT! You have won a 1 week FREE membership in our £100,000 Prize Jackpot! Txt the word: CLAIM to No: 81010 T&C www.dbuk.net LCCLTD POBOX 4403LDNW1A7RW18
+ham	I've been searching for the right words to thank you for this breather. I promise i wont take your help for granted and will fulfil my promise. You have been wonderful and a blessing at all times.
+ham	I HAVE A DATE ON SUNDAY WITH WILL!!
+spam	XXXMobileMovieClub: To use your credit, click the WAP link in the next txt message or click here>> http://wap. xxxmobilemovieclub.com?n=QJKGIGHJJGCBL
+ham	Oh k...i'm watching here:)
+ham	Eh u remember how 2 spell his name... Yes i did. He v naughty make until i v wet.
+ham	Fine if thats the way u feel. Thats the way its gota b
+spam	England v Macedonia - dont miss the goals/team news. Txt ur national team to 87077 eg ENGLAND to 87077 Try:WALES, SCOTLAND 4txt/ú1.20 POBOXox36504W45WQ 16+
+ham	Is that seriously how you spell his name?
+ham	I‘m going to try for 2 months ha ha only joking
+ham	So ü pay first lar... Then when is da stock comin...
+ham	Aft i finish my lunch then i go str down lor. Ard 3 smth lor. U finish ur lunch already?
+ham	Ffffffffff. Alright no way I can meet up with you sooner?
+ham	Just forced myself to eat a slice. I'm really not hungry tho. This sucks. Mark is getting worried. He knows I'm sick when I turn down pizza. Lol
+ham	Lol your always so convincing.
+ham	Did you catch the bus ? Are you frying an egg ? Did you make a tea? Are you eating your mom's left over dinner ? Do you feel my Love ?
+ham	I'm back &amp; we're packing the car now, I'll let you know if there's room
+ham	Ahhh. Work. I vaguely remember that! What does it feel like? Lol
+ham	Wait that's still not all that clear, were you not sure about me being sarcastic or that that's why x doesn't want to live with us
+ham	Yeah he got in at 2 and was v apologetic. n had fallen out and she was actin like spoilt child and he got caught up in that. Till 2! But we won't go there! Not doing too badly cheers. You? 
+ham	K tell me anything about you.
+ham	For fear of fainting with the of all that housework you just did? Quick have a cuppa
+spam	Thanks for your subscription to Ringtone UK your mobile will be charged £5/month Please confirm by replying YES or NO. If you reply NO you will not be charged
+ham	Yup... Ok i go home look at the timings then i msg ü again... Xuhui going to learn on 2nd may too but her lesson is at 8am
+ham	Oops, I'll let you know when my roommate's done
+ham	I see the letter B on my car
+ham	Anything lor... U decide...
+ham	Hello! How's you and how did saturday go? I was just texting to see if you'd decided to do anything tomo. Not that i'm trying to invite myself or anything!
+ham	Pls go ahead with watts. I just wanted to be sure. Do have a great weekend. Abiola
+ham	Did I forget to tell you ? I want you , I need you, I crave you ... But most of all ... I love you my sweet Arabian steed ... Mmmmmm ... Yummy
+spam	07732584351 - Rodger Burns - MSG = We tried to call you re your reply to our sms for a free nokia mobile + free camcorder. Please call now 08000930705 for delivery tomorrow
+ham	WHO ARE YOU SEEING?
+ham	Great! I hope you like your man well endowed. I am  &lt;#&gt;  inches...
+ham	No calls..messages..missed calls
+ham	Didn't you get hep b immunisation in nigeria.
+ham	Fair enough, anything going on?
+ham	Yeah hopefully, if tyler can't do it I could maybe ask around a bit
+ham	U don't know how stubborn I am. I didn't even want to go to the hospital. I kept telling Mark I'm not a weak sucker. Hospitals are for weak suckers.
+ham	What you thinked about me. First time you saw me in class.
+ham	A gram usually runs like  &lt;#&gt; , a half eighth is smarter though and gets you almost a whole second gram for  &lt;#&gt;
+ham	K fyi x has a ride early tomorrow morning but he's crashing at our place tonight
+ham	Wow. I never realized that you were so embarassed by your accomodations. I thought you liked it, since i was doing the best i could and you always seemed so happy about "the cave". I'm sorry I didn't and don't have more to give. I'm sorry i offered. I'm sorry your room was so embarassing.
+spam	SMS. ac Sptv: The New Jersey Devils and the Detroit Red Wings play Ice Hockey. Correct or Incorrect? End? Reply END SPTV
+ham	Do you know what Mallika Sherawat did yesterday? Find out now @  &lt;URL&gt;
+spam	Congrats! 1 year special cinema pass for 2 is yours. call 09061209465 now! C Suprman V, Matrix3, StarWars3, etc all 4 FREE! bx420-ip4-5we. 150pm. Dont miss out! 
+ham	Sorry, I'll call later in meeting.
+ham	Tell where you reached
+ham	Yes..gauti and sehwag out of odi series.
+ham	Your gonna have to pick up a $1 burger for yourself on your way home. I can't even move. Pain is killing me.
+ham	Ha ha ha good joke. Girls are situation seekers.
+ham	Its a part of checking IQ
+ham	Sorry my roommates took forever, it ok if I come by now?
+ham	Ok lar i double check wif da hair dresser already he said wun cut v short. He said will cut until i look nice.
+spam	As a valued customer, I am pleased to advise you that following recent review of your Mob No. you are awarded with a £1500 Bonus Prize, call 09066364589
+ham	Today is "song dedicated day.." Which song will u dedicate for me? Send this to all ur valuable frnds but first rply me...
+spam	Urgent UR awarded a complimentary trip to EuroDisinc Trav, Aco&Entry41 Or £1000. To claim txt DIS to 87121 18+6*£1.50(moreFrmMob. ShrAcomOrSglSuplt)10, LS1 3AJ
+spam	Did you hear about the new "Divorce Barbie"? It comes with all of Ken's stuff!
+ham	I plane to give on this month end.
+ham	Wah lucky man... Then can save money... Hee...
+ham	Finished class where are you.
+ham	HI BABE IM AT HOME NOW WANNA DO SOMETHING? XX
+ham	K..k:)where are you?how did you performed?
+ham	U can call me now...
+ham	I am waiting machan. Call me once you free.
+ham	Thats cool. i am a gentleman and will treat you with dignity and respect.
+ham	I like you peoples very much:) but am very shy pa.
+ham	Does not operate after  &lt;#&gt;  or what
+ham	Its not the same here. Still looking for a job. How much do Ta's earn there.
+ham	Sorry, I'll call later
+ham	K. Did you call me just now ah? 
+ham	Ok i am on the way to home hi hi
+ham	You will be in the place of that man
+ham	Yup next stop.
+ham	I call you later, don't have network. If urgnt, sms me.
+ham	For real when u getting on yo? I only need 2 more tickets and one more jacket and I'm done. I already used all my multis.
+ham	Yes I started to send requests to make it but pain came back so I'm back in bed. Double coins at the factory too. I gotta cash in all my nitros.
+ham	I'm really not up to it still tonight babe
+ham	Ela kano.,il download, come wen ur free..
+ham	Yeah do! Don‘t stand to close tho- you‘ll catch something!
+ham	Sorry to be a pain. Is it ok if we meet another night? I spent late afternoon in casualty and that means i haven't done any of y stuff42moro and that includes all my time sheets and that. Sorry. 
+ham	Smile in Pleasure Smile in Pain Smile when trouble pours like Rain Smile when sum1 Hurts U Smile becoz SOMEONE still Loves to see u Smiling!!
+spam	Please call our customer service representative on 0800 169 6031 between 10am-9pm as you have WON a guaranteed £1000 cash or £5000 prize!
+ham	Havent planning to buy later. I check already lido only got 530 show in e afternoon. U finish work already?
+spam	Your free ringtone is waiting to be collected. Simply text the password "MIX" to 85069 to verify. Get Usher and Britney. FML, PO Box 5249, MK17 92H. 450Ppw 16
+ham	Watching telugu movie..wat abt u?
+ham	i see. When we finish we have loads of loans to pay
+ham	Hi. Wk been ok - on hols now! Yes on for a bit of a run. Forgot that i have hairdressers appointment at four so need to get home n shower beforehand. Does that cause prob for u?"
+ham	I see a cup of coffee animation

--- a/src/cli/src/cmd/status.rs
+++ b/src/cli/src/cmd/status.rs
@@ -1,10 +1,12 @@
 use async_trait::async_trait;
 use clap::{Arg, ArgMatches, Command};
 
+use glob::glob;
 use liboxen::error::OxenError;
 use liboxen::model::staged_data::StagedDataOpts;
 use liboxen::model::LocalRepository;
 use liboxen::repositories;
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use crate::helpers::check_repo_migration_needed;
@@ -38,18 +40,29 @@ impl RunCmd for StatusCmd {
                     .action(clap::ArgAction::Set),
             )
             .arg(
+                Arg::new("ignore")
+                    .long("ignore")
+                    .short('i')
+                    .help("Ignore files at this path.")
+                    .action(clap::ArgAction::Set)
+                    .required(false),
+            )
+            .arg(
                 Arg::new("print_all")
                     .long("print_all")
                     .short('a')
                     .help("If present, does not truncate the output of status at all.")
                     .action(clap::ArgAction::SetTrue),
             )
-            .arg(Arg::new("path").required(false))
+            .arg(
+                Arg::new("paths")
+                    .num_args(0..)
+                    .trailing_var_arg(true)  // Collect all remaining args as paths
+                    .help("Specify one or more paths")
+            )
     }
 
     async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
-        let directory = args.get_one::<String>("path").map(PathBuf::from);
-
         let skip = args
             .get_one::<String>("skip")
             .expect("Must supply skip")
@@ -62,19 +75,24 @@ impl RunCmd for StatusCmd {
             .expect("limit must be a valid integer.");
         let print_all = args.get_flag("print_all");
 
+        let repository = LocalRepository::from_current_dir()?;
+        check_repo_migration_needed(&repository)?;
+
+        let paths = args
+            .get_many::<String>("paths")
+            .map(|vals| vals.map(|v| repository.path.join(v)).collect())
+            .unwrap_or_else(|| vec![repository.path.clone()]);
         let is_remote = false;
         let opts = StagedDataOpts {
+            paths,
             skip,
             limit,
             print_all,
             is_remote,
+            ignore: parse_ignore_files(args.get_one::<String>("ignore")),
         };
 
-        let repository = LocalRepository::from_current_dir()?;
-        check_repo_migration_needed(&repository)?;
-
-        let directory = directory.unwrap_or(repository.path.clone());
-        let repo_status = repositories::status_from_dir(&repository, &directory)?;
+        let repo_status = repositories::status::status_from_opts(&repository, &opts)?;
 
         if let Some(current_branch) = repositories::branches::current_branch(&repository)? {
             println!(
@@ -91,5 +109,23 @@ impl RunCmd for StatusCmd {
         repo_status.print_with_params(&opts);
 
         Ok(())
+    }
+}
+
+fn parse_ignore_files(paths: Option<&String>) -> Option<HashSet<PathBuf>> {
+    let paths_str = paths?;
+
+    match glob(paths_str) {
+        Ok(paths) => {
+            let mut results: HashSet<PathBuf> = HashSet::new();
+            for path in paths.flatten() {
+                results.insert(path);
+            }
+            Some(results)
+        }
+        Err(err) => {
+            log::error!("Err: {err:?}");
+            None
+        }
     }
 }

--- a/src/cli/src/cmd/workspace/status.rs
+++ b/src/cli/src/cmd/workspace/status.rs
@@ -83,10 +83,12 @@ impl RunCmd for WorkspaceStatusCmd {
 
         let is_remote = true;
         let opts = StagedDataOpts {
+            paths: vec![PathBuf::from("")],
             skip,
             limit,
             print_all,
             is_remote,
+            ignore: None,
         };
 
         let repo_dir = util::fs::get_repo_root_from_current_dir()

--- a/src/cli/src/helpers.rs
+++ b/src/cli/src/helpers.rs
@@ -43,7 +43,8 @@ pub async fn check_remote_version(host: impl AsRef<str>) -> Result<(), OxenError
             }
         }
         Err(err) => {
-            eprintln!("Err checking remote version:\n{err}")
+            // Don't fully print in case they are just off network and working locally
+            log::debug!("Err checking remote version:\n{err}")
         }
     }
     Ok(())

--- a/src/lib/src/core/df/tabular.rs
+++ b/src/lib/src/core/df/tabular.rs
@@ -1615,4 +1615,12 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_parse_file_with_unmatched_quotes() -> Result<(), OxenError> {
+        let df = tabular::read_df("data/test/csvs/spam_ham_data_w_quote.tsv", DFOpts::empty())?;
+        assert_eq!(df.width(), 2);
+        assert_eq!(df.height(), 100);
+        Ok(())
+    }
 }

--- a/src/lib/src/core/v0_19_0/index/commit_merkle_tree.rs
+++ b/src/lib/src/core/v0_19_0/index/commit_merkle_tree.rs
@@ -448,7 +448,7 @@ impl CommitMerkleTree {
     }
 
     /// This uses the dir_hashes db to skip right to a file in the tree
-    fn read_file(
+    pub fn read_file(
         repo: &LocalRepository,
         dir_hashes: &HashMap<PathBuf, MerkleHash>,
         path: impl AsRef<Path>,
@@ -468,18 +468,12 @@ impl CommitMerkleTree {
         // Look up the directory hash
         let node_hash: Option<MerkleHash> = dir_hashes.get(parent_path).cloned();
         let Some(node_hash) = node_hash else {
-            return Err(OxenError::basic_str(format!(
-                "Merkle tree hash not found for parent: {:?}",
-                parent_path
-            )));
+            return Ok(None);
         };
 
         // Read the directory node at depth 2 to get all the vnodes and their children
         let Some(dir_node) = CommitMerkleTree::read_depth(repo, &node_hash, 2)? else {
-            return Err(OxenError::basic_str(format!(
-                "Merkle tree hash not found for parent: {:?}",
-                parent_path
-            )));
+            return Ok(None);
         };
         // log::debug!(
         //     "read_file got {} dir_node children",

--- a/src/lib/src/core/v0_19_0/rm.rs
+++ b/src/lib/src/core/v0_19_0/rm.rs
@@ -1,5 +1,6 @@
 use crate::core::db;
 use crate::error::OxenError;
+use crate::model::staged_data::StagedDataOpts;
 use crate::model::LocalRepository;
 use crate::opts::RmOpts;
 use crate::repositories;
@@ -116,7 +117,9 @@ fn list_modified_files(
     repo: &LocalRepository,
     paths: &HashSet<PathBuf>,
 ) -> Result<Vec<PathBuf>, OxenError> {
-    let status = repositories::status(repo)?;
+    let paths_vec: Vec<PathBuf> = paths.iter().map(|p| repo.path.join(p)).collect();
+    let opts = StagedDataOpts::from_paths(&paths_vec);
+    let status = repositories::status::status_from_opts(repo, &opts)?;
     log::debug!("status modified_files: {:?}", status.modified_files);
     log::debug!("paths: {:?}", paths);
     let modified: Vec<PathBuf> = status

--- a/src/lib/src/core/v0_19_0/status.rs
+++ b/src/lib/src/core/v0_19_0/status.rs
@@ -6,6 +6,7 @@ use crate::core::v0_19_0::structs::StagedMerkleTreeNode;
 use crate::error::OxenError;
 use crate::model::merkle_tree::node::FileNode;
 use crate::model::metadata::generic_metadata::GenericMetadata;
+use crate::model::staged_data::StagedDataOpts;
 use crate::model::{
     Commit, LocalRepository, MerkleHash, StagedData, StagedDirStats, StagedEntry,
     StagedEntryStatus, StagedSchema, SummarizedStagedDirStats,
@@ -28,12 +29,23 @@ use crate::model::merkle_tree::node::EMerkleTreeNode;
 use crate::model::merkle_tree::node::MerkleTreeNode;
 
 pub fn status(repo: &LocalRepository) -> Result<StagedData, OxenError> {
-    status_from_dir(repo, Path::new(""))
+    status_from_dir(repo, &repo.path)
 }
 
 pub fn status_from_dir(
     repo: &LocalRepository,
     dir: impl AsRef<Path>,
+) -> Result<StagedData, OxenError> {
+    let opts = StagedDataOpts {
+        paths: vec![dir.as_ref().to_path_buf()],
+        ..StagedDataOpts::default()
+    };
+    status_from_opts(repo, &opts)
+}
+
+pub fn status_from_opts(
+    repo: &LocalRepository,
+    opts: &StagedDataOpts,
 ) -> Result<StagedData, OxenError> {
     if repo.is_shallow_clone() {
         return Err(OxenError::basic_str(
@@ -41,25 +53,35 @@ pub fn status_from_dir(
         ));
     }
 
-    log::debug!("status_from_dir {:?}", dir.as_ref());
+    log::debug!("status_from_opts {:?}", opts.paths);
     let staged_db_maybe = open_staged_db(repo)?;
     let head_commit = repositories::commits::head_commit_maybe(repo)?;
     let dir_hashes = get_dir_hashes(repo, &head_commit)?;
-    let relative_dir = util::fs::path_relative_to_dir(dir.as_ref(), &repo.path)?;
 
     let read_progress = ProgressBar::new_spinner();
     read_progress.set_style(ProgressStyle::default_spinner());
     read_progress.enable_steady_tick(Duration::from_millis(100));
 
     let mut total_entries = 0;
-    let (untracked, modified, removed) = find_changes(
-        repo,
-        &relative_dir,
-        &staged_db_maybe,
-        &dir_hashes,
-        &read_progress,
-        &mut total_entries,
-    )?;
+
+    let mut untracked = UntrackedData::new();
+    let mut modified = HashSet::new();
+    let mut removed = HashSet::new();
+
+    for dir in opts.paths.iter() {
+        let relative_dir = util::fs::path_relative_to_dir(dir, &repo.path)?;
+        let (sub_untracked, sub_modified, sub_removed) = find_changes(
+            repo,
+            &relative_dir,
+            &staged_db_maybe,
+            &dir_hashes,
+            &read_progress,
+            &mut total_entries,
+        )?;
+        untracked.merge(sub_untracked);
+        modified.extend(sub_modified);
+        removed.extend(sub_removed);
+    }
 
     log::debug!("find_changes untracked: {:?}", untracked);
     log::debug!("find_changes modified: {:?}", modified);
@@ -85,8 +107,13 @@ pub fn status_from_dir(
         return Ok(staged_data);
     };
 
-    let (dir_entries, _) = read_staged_entries_below_path(repo, &staged_db, &dir, &read_progress)?;
-    // log::debug!("status_from_dir dir_entries: {:?}", dir_entries);
+    let mut dir_entries = HashMap::new();
+    for dir in opts.paths.iter() {
+        let (sub_dir_entries, _) =
+            read_staged_entries_below_path(repo, &staged_db, dir, &read_progress)?;
+        dir_entries.extend(sub_dir_entries);
+        // log::debug!("status_from_dir dir_entries: {:?}", dir_entries);
+    }
     read_progress.finish_and_clear();
 
     status_from_dir_entries(&mut staged_data, dir_entries)
@@ -307,37 +334,44 @@ pub fn read_staged_entries_below_path(
 
 fn find_changes(
     repo: &LocalRepository,
-    relative_dir: impl AsRef<Path>,
+    relative_path: impl AsRef<Path>,
     staged_db: &Option<DBWithThreadMode<SingleThreaded>>,
     dir_hashes: &HashMap<PathBuf, MerkleHash>,
     progress: &ProgressBar,
     total_entries: &mut u64,
 ) -> Result<(UntrackedData, HashSet<PathBuf>, HashSet<PathBuf>), OxenError> {
-    let relative_dir = relative_dir.as_ref();
-    log::debug!("find_changes dir: {:?}", relative_dir);
+    let relative_path = relative_path.as_ref();
+    log::debug!("find_changes dir: {:?}", relative_path);
     let mut untracked = UntrackedData::new();
     let mut modified = HashSet::new();
     let mut removed = HashSet::new();
     let gitignore = oxenignore::create(repo);
 
-    let full_dir = repo.path.join(relative_dir);
+    let full_path = repo.path.join(relative_path);
 
-    let Ok(entries) = std::fs::read_dir(&full_dir) else {
-        return Err(OxenError::basic_str(format!(
-            "Could not read dir {:?}",
-            full_dir
-        )));
-    };
+    let mut entries: Vec<PathBuf> = Vec::new();
+    if full_path.is_dir() {
+        let Ok(dir_entries) = std::fs::read_dir(&full_path) else {
+            return Err(OxenError::basic_str(format!(
+                "Could not read dir {:?}",
+                full_path
+            )));
+        };
+        for entry in dir_entries {
+            entries.push(entry?.path());
+        }
+    } else {
+        entries.push(full_path.to_owned());
+    }
     let mut untracked_count = 0;
-    let dir_node = get_dir_node(repo, dir_hashes, relative_dir)?;
+    let dir_node = maybe_get_dir_node(repo, dir_hashes, relative_path)?;
 
-    for entry in entries.flatten() {
+    for path in entries {
         progress.set_message(format!(
             "🐂 checking ({total_entries} files) scanning {:?}",
-            relative_dir
+            relative_path
         ));
         *total_entries += 1;
-        let path = entry.path();
         let relative_path = util::fs::path_relative_to_dir(&path, &repo.path)?;
 
         if is_ignored(&relative_path, &gitignore, path.is_dir()) {
@@ -373,37 +407,45 @@ fn find_changes(
                 modified.insert(relative_path.clone());
             }
         } else {
-            // If it's none of the above conditions, then it's untracked
-            untracked.add_file(relative_path.clone());
-            untracked_count += 1;
+            // If it's none of the above conditions
+            // then check if it's untracked or modified
+            if let Some(node) = CommitMerkleTree::read_file(repo, dir_hashes, &relative_path)? {
+                if is_modified(&node, &path)? {
+                    modified.insert(relative_path.clone());
+                }
+            } else {
+                untracked.add_file(relative_path.clone());
+                untracked_count += 1;
+            }
         }
     }
 
     // Only add the untracked directory if it's not the root directory
     // and it's not staged
     if untracked.all_untracked
-        && relative_dir != Path::new("")
-        && !is_staged(relative_dir, staged_db)?
+        && relative_path != Path::new("")
+        && !is_staged(relative_path, staged_db)?
+        && full_path.is_dir()
     {
-        untracked.add_dir(relative_dir.to_path_buf(), untracked_count);
+        untracked.add_dir(relative_path.to_path_buf(), untracked_count);
         // Clear individual files as they're now represented by the directory
         untracked.files.clear();
     }
 
     // Check for removed files
-    if let Some(dir_hash) = dir_hashes.get(relative_dir) {
+    if let Some(dir_hash) = dir_hashes.get(relative_path) {
         let dir_node = CommitMerkleTree::read_depth(repo, dir_hash, 2)?;
         if let Some(node) = dir_node {
             for child in CommitMerkleTree::node_files_and_folders(&node)? {
                 if let EMerkleTreeNode::File(file) = &child.node {
-                    let file_path = full_dir.join(&file.name);
+                    let file_path = full_path.join(&file.name);
                     if !file_path.exists() {
-                        removed.insert(relative_dir.join(&file.name));
+                        removed.insert(relative_path.join(&file.name));
                     }
                 } else if let EMerkleTreeNode::Directory(dir) = &child.node {
-                    let dir_path = full_dir.join(&dir.name);
+                    let dir_path = full_path.join(&dir.name);
                     if !dir_path.exists() {
-                        removed.insert(relative_dir.join(&dir.name));
+                        removed.insert(relative_path.join(&dir.name));
                     }
                 }
             }
@@ -440,7 +482,7 @@ fn get_dir_hashes(
     }
 }
 
-fn get_dir_node(
+fn maybe_get_dir_node(
     repo: &LocalRepository,
     dir_hashes: &HashMap<PathBuf, MerkleHash>,
     dir: impl AsRef<Path>,

--- a/src/lib/src/model/staged_data.rs
+++ b/src/lib/src/model/staged_data.rs
@@ -26,19 +26,32 @@ pub const MSG_OXEN_SHOW_SCHEMA_STAGED: &str =
 
 #[derive(Debug, Clone)]
 pub struct StagedDataOpts {
+    pub paths: Vec<PathBuf>, // Paths to start the search at
     pub skip: usize,
     pub limit: usize,
     pub print_all: bool,
     pub is_remote: bool,
+    pub ignore: Option<HashSet<PathBuf>>,
+}
+
+impl StagedDataOpts {
+    pub fn from_paths(paths: &[PathBuf]) -> StagedDataOpts {
+        StagedDataOpts {
+            paths: paths.to_owned(),
+            ..Default::default()
+        }
+    }
 }
 
 impl Default for StagedDataOpts {
     fn default() -> StagedDataOpts {
         StagedDataOpts {
+            paths: vec![PathBuf::from("")],
             skip: 0,
             limit: 10,
             print_all: false,
             is_remote: false,
+            ignore: None,
         }
     }
 }

--- a/src/lib/src/repositories/metadata/image.rs
+++ b/src/lib/src/repositories/metadata/image.rs
@@ -19,7 +19,7 @@ pub fn get_metadata(path: impl AsRef<Path>) -> Result<MetadataImage, OxenError> 
     match reader.into_dimensions() {
         Ok((width, height)) => Ok(MetadataImage::new(width, height)),
         Err(e) => {
-            log::error!("Could not get image metadata {:?}", e);
+            log::debug!("Could not get image metadata {:?}", e);
             Err(OxenError::basic_str("Could not get image metadata"))
         }
     }

--- a/src/lib/src/test.rs
+++ b/src/lib/src/test.rs
@@ -1373,7 +1373,7 @@ where
     });
 
     // Remove repo dir
-    // util::fs::remove_dir_all(&repo_dir)?;
+    util::fs::remove_dir_all(&repo_dir)?;
 
     // Assert everything okay after we cleanup the repo dir
     match result {


### PR DESCRIPTION
I added a few CLI parameters to the `oxen status` command to speed up status if you know you have a large directory that hasn't changed.

You can either specify path(s) that you want status on:

```
oxen status README.md test/
```

Or you can ignore a large directory with `-i`

```
oxen status -i images/
```