### PR TITLE
fix stack overflow issue on column add

### DIFF
--- a/src/lib/src/model/data_frame/schema/data_type.rs
+++ b/src/lib/src/model/data_frame/schema/data_type.rs
@@ -115,6 +115,7 @@ impl DataType {
             },
             DataType::Null => "null",
             DataType::Unknown => {
+                // DO NOT USE {} HERE, IT WILL CAUSE A MEMORY LEAK
                 log::error!("TODO: as_str unknown DataType::Unknown type {:?}", self);
                 "?"
             }

--- a/src/lib/src/model/data_frame/schema/data_type.rs
+++ b/src/lib/src/model/data_frame/schema/data_type.rs
@@ -115,7 +115,7 @@ impl DataType {
             },
             DataType::Null => "null",
             DataType::Unknown => {
-                log::error!("TODO: as_str unknown DataType::Unknown type {}", self);
+                log::error!("TODO: as_str unknown DataType::Unknown type {:?}", self);
                 "?"
             }
         }

--- a/src/lib/src/model/data_frame/schema/data_type.rs
+++ b/src/lib/src/model/data_frame/schema/data_type.rs
@@ -115,7 +115,7 @@ impl DataType {
             },
             DataType::Null => "null",
             DataType::Unknown => {
-                // DO NOT USE {} HERE, IT WILL CAUSE A MEMORY LEAK
+                // DO NOT USE {} HERE, IT WILL CAUSE A STACK OVERFLOW
                 log::error!("TODO: as_str unknown DataType::Unknown type {:?}", self);
                 "?"
             }


### PR DESCRIPTION
The problem was that inside as_str(), it tries to log the self value using {} formatting, which:
Calls Display again
Which calls as_str() again
Which tries to log again
And so on...
For all other data types, as_str() just returns a string literal without trying to format self, so there's no recursion.
To fix this, we just used  {:?} in the error log instead of {}.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for unknown data types by updating logging to prevent potential stack overflow issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->