### PR TITLE
convert download opts to be more consistent with clone

### DIFF
--- a/src/cli/src/cmd/download.rs
+++ b/src/cli/src/cmd/download.rs
@@ -72,7 +72,7 @@ impl RunCmd for DownloadCmd {
 
         // Get the host from the url
         let parsed_url = url::Url::parse(&opts.url)
-            .map_err(|e| OxenError::basic_str(&format!("Invalid URL: {}", e)))?;
+            .map_err(|e| OxenError::basic_str(format!("Invalid URL: {}", e)))?;
 
         let mut host = parsed_url
             .host_str()

--- a/src/cli/src/cmd/download.rs
+++ b/src/cli/src/cmd/download.rs
@@ -1,5 +1,8 @@
 use async_trait::async_trait;
+
+use clap::arg;
 use clap::{Arg, Command};
+
 use liboxen::api;
 use liboxen::error::OxenError;
 use std::path::PathBuf;
@@ -8,7 +11,6 @@ use liboxen::opts::DownloadOpts;
 use liboxen::repositories;
 
 use crate::helpers::check_remote_version_blocking;
-use liboxen::constants::{DEFAULT_HOST, DEFAULT_REMOTE_NAME};
 
 use crate::cmd::RunCmd;
 pub const NAME: &str = "download";
@@ -23,6 +25,7 @@ impl RunCmd for DownloadCmd {
     fn args(&self) -> Command {
         Command::new(NAME)
         .about("Download a specific file from the remote repository")
+        .arg(arg!(<URL> "URL of the repository you want to download from"))
         .arg(
             Arg::new("paths")
                 .required(true)
@@ -36,18 +39,6 @@ impl RunCmd for DownloadCmd {
                 .action(clap::ArgAction::Set),
         )
         .arg(
-            Arg::new("host")
-                .long("host")
-                .help("Host to download from, for example: 'hub.oxen.ai'")
-                .action(clap::ArgAction::Set),
-        )
-        .arg(
-            Arg::new("remote")
-                .long("remote")
-                .help("Remote to download from, for example: 'origin'")
-                .action(clap::ArgAction::Set),
-        )
-        .arg(
             Arg::new("revision")
                 .long("revision")
                 .help("The branch or commit id to download the data from. Defaults to main branch. If a branch is specified, it will download the latest commit from that branch.")
@@ -58,6 +49,10 @@ impl RunCmd for DownloadCmd {
     async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
         // Parse args
         let opts = DownloadOpts {
+            url: args
+                .get_one::<String>("URL")
+                .expect("Must supply a url")
+                .to_string(),
             paths: args
                 .get_many::<String>("paths")
                 .expect("Must supply paths")
@@ -67,14 +62,6 @@ impl RunCmd for DownloadCmd {
                 .get_one::<String>("output")
                 .map(PathBuf::from)
                 .unwrap_or(PathBuf::from(".")),
-            remote: args
-                .get_one::<String>("remote")
-                .map(String::from)
-                .unwrap_or(DEFAULT_REMOTE_NAME.to_string()),
-            host: args
-                .get_one::<String>("host")
-                .map(String::from)
-                .unwrap_or(DEFAULT_HOST.to_string()),
             revision: args.get_one::<String>("revision").map(String::from),
         };
 
@@ -83,22 +70,30 @@ impl RunCmd for DownloadCmd {
             return Err(OxenError::basic_str("Must supply a path to download."));
         }
 
-        check_remote_version_blocking(opts.clone().host).await?;
+        // Get the host from the url
+        let parsed_url = url::Url::parse(&opts.url)
+            .map_err(|e| OxenError::basic_str(&format!("Invalid URL: {}", e)))?;
+
+        let mut host = parsed_url
+            .host_str()
+            .ok_or_else(|| OxenError::basic_str("Could not extract host from URL"))?
+            .to_string();
+
+        if let Some(port) = parsed_url.port() {
+            host = format!("{}:{}", host, port);
+        }
+
+        check_remote_version_blocking(host).await?;
 
         // Check if the first path is a valid remote repo
-        let name = paths[0].to_string_lossy();
-        if let Some(remote_repo) =
-            api::client::repositories::get_by_name_host_and_remote(&name, &opts.host, &opts.remote)
-                .await?
-        {
+        if let Some(remote_repo) = api::client::repositories::get_by_url(&opts.url).await? {
             // Download from the remote without having to have a local repo directory
-            let remote_paths = paths[1..].to_vec();
             let commit_id = opts.remote_commit_id(&remote_repo).await?;
-            for path in remote_paths {
+            for path in paths {
                 repositories::download(&remote_repo, &path, &opts.dst, &commit_id).await?;
             }
         } else {
-            eprintln!("Repository does not exist {}", name);
+            eprintln!("Repository does not exist {}", opts.url);
         }
 
         Ok(())

--- a/src/lib/src/api/client/repositories.rs
+++ b/src/lib/src/api/client/repositories.rs
@@ -84,6 +84,14 @@ pub async fn exists(repo: &RemoteRepository) -> Result<bool, OxenError> {
     Ok(repo.is_some())
 }
 
+pub async fn get_by_url(url: &str) -> Result<Option<RemoteRepository>, OxenError> {
+    let remote = Remote {
+        name: String::from(DEFAULT_REMOTE_NAME),
+        url: url.to_string(),
+    };
+    get_by_remote(&remote).await
+}
+
 pub async fn get_by_remote(remote: &Remote) -> Result<Option<RemoteRepository>, OxenError> {
     let url = api::endpoint::url_from_remote(remote, "")?;
     log::debug!("get_by_remote url: {}", url);

--- a/src/lib/src/opts/download_opts.rs
+++ b/src/lib/src/opts/download_opts.rs
@@ -3,10 +3,9 @@ use std::path::PathBuf;
 
 #[derive(Clone, Debug)]
 pub struct DownloadOpts {
+    pub url: String,
     pub paths: Vec<PathBuf>,
     pub dst: PathBuf,
-    pub host: String,
-    pub remote: String,
     pub revision: Option<String>,
 }
 


### PR DESCRIPTION
To mirror clone, I changed the download opts

```
oxen download $URL $PATH_TO_FILE -o $OUTPUT_FILE --revision $BRANCH_OR_COMMIT_ID
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new required `<URL>` argument for the download command, simplifying the command-line interface.
	- Added a new asynchronous function to retrieve repositories directly using a URL.

- **Bug Fixes**
	- Enhanced error handling for invalid URLs, providing clearer feedback.

- **Refactor**
	- Removed unnecessary parameters (`host` and `remote`) from the download options, streamlining the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->