### PR TITLE
Add metadata entries to create repo response

### DIFF
--- a/src/lib/src/model/repository/local_repository.rs
+++ b/src/lib/src/model/repository/local_repository.rs
@@ -4,7 +4,7 @@ use crate::constants::{self, DEFAULT_VNODE_SIZE, MIN_OXEN_VERSION};
 use crate::core::versions::MinOxenVersion;
 use crate::error;
 use crate::error::OxenError;
-use crate::model::{Remote, RemoteRepository};
+use crate::model::{MetadataEntry, Remote, RemoteRepository};
 use crate::util;
 use crate::view::RepositoryView;
 
@@ -21,6 +21,12 @@ pub struct LocalRepository {
     vnode_size: Option<u64>,     // Size of the vnodes
     subtree_paths: Option<Vec<PathBuf>>, // If the user clones a subtree, we store the paths here so that we know we don't have the full tree
     depth: Option<i32>, // If the user clones with a depth, we store the depth here so that we know we don't have the full tree
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct LocalRepositoryWithEntries {
+    pub local_repo: LocalRepository,
+    pub entries: Option<Vec<MetadataEntry>>,
 }
 
 impl LocalRepository {

--- a/src/lib/src/repositories.rs
+++ b/src/lib/src/repositories.rs
@@ -410,7 +410,7 @@ pub fn create(root_dir: &Path, new_repo: RepoNew) -> Result<LocalRepositoryWithE
             .filter_map(|file| {
                 repositories::entries::get_meta_entry(
                     &local_repo,
-                    &commit.as_ref().unwrap(),
+                    commit.as_ref().unwrap(),
                     &file.path,
                 )
                 .ok()

--- a/src/lib/src/view/repository.rs
+++ b/src/lib/src/view/repository.rs
@@ -1,4 +1,4 @@
-use crate::model::{Commit, EntryDataType, RemoteRepository};
+use crate::model::{Commit, EntryDataType, MetadataEntry, RemoteRepository};
 use serde::{Deserialize, Serialize};
 
 use super::{DataTypeCount, StatusMessage};
@@ -49,6 +49,7 @@ pub struct RepositoryCreationResponse {
     pub status: String,
     pub status_message: String,
     pub repository: RepositoryCreationView,
+    pub metadata_entries: Option<Vec<MetadataEntry>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/server/src/controllers/repositories.rs
+++ b/src/server/src/controllers/repositories.rs
@@ -152,7 +152,7 @@ fn handle_json_creation(
     let repo_new: RepoNew = data.into_inner();
     let repo_new_clone = repo_new.clone();
     match repositories::create(&app_data.path, repo_new) {
-        Ok(repo) => match repositories::commits::latest_commit(&repo) {
+        Ok(repo) => match repositories::commits::latest_commit(&repo.local_repo) {
             Ok(latest_commit) => Ok(HttpResponse::Ok().json(RepositoryCreationResponse {
                 status: STATUS_SUCCESS.to_string(),
                 status_message: MSG_RESOURCE_FOUND.to_string(),
@@ -160,8 +160,9 @@ fn handle_json_creation(
                     namespace: repo_new_clone.namespace.clone(),
                     latest_commit: Some(latest_commit.clone()),
                     name: repo_new_clone.name.clone(),
-                    min_version: Some(repo.min_version().to_string()),
+                    min_version: Some(repo.local_repo.min_version().to_string()),
                 },
+                metadata_entries: None,
             })),
             Err(OxenError::NoCommitsFound(_)) => {
                 Ok(HttpResponse::Ok().json(RepositoryCreationResponse {
@@ -171,8 +172,9 @@ fn handle_json_creation(
                         namespace: repo_new_clone.namespace.clone(),
                         latest_commit: None,
                         name: repo_new_clone.name.clone(),
-                        min_version: Some(repo.min_version().to_string()),
+                        min_version: Some(repo.local_repo.min_version().to_string()),
                     },
+                    metadata_entries: None,
                 }))
             }
             Err(err) => {
@@ -290,7 +292,7 @@ async fn handle_multipart_creation(
 
     // Create repository
     match repositories::create(&app_data.path, repo_data) {
-        Ok(repo) => match repositories::commits::latest_commit(&repo) {
+        Ok(repo) => match repositories::commits::latest_commit(&repo.local_repo) {
             Ok(latest_commit) => Ok(HttpResponse::Ok().json(RepositoryCreationResponse {
                 status: STATUS_SUCCESS.to_string(),
                 status_message: MSG_RESOURCE_FOUND.to_string(),
@@ -298,8 +300,9 @@ async fn handle_multipart_creation(
                     namespace: repo_data_clone.namespace,
                     latest_commit: Some(latest_commit),
                     name: repo_data_clone.name,
-                    min_version: Some(repo.min_version().to_string()),
+                    min_version: Some(repo.local_repo.min_version().to_string()),
                 },
+                metadata_entries: repo.entries,
             })),
             Err(OxenError::NoCommitsFound(_)) => {
                 Ok(HttpResponse::Ok().json(RepositoryCreationResponse {
@@ -309,8 +312,9 @@ async fn handle_multipart_creation(
                         namespace: repo_data_clone.namespace,
                         latest_commit: None,
                         name: repo_data_clone.name,
-                        min_version: Some(repo.min_version().to_string()),
+                        min_version: Some(repo.local_repo.min_version().to_string()),
                     },
+                    metadata_entries: repo.entries,
                 }))
             }
             Err(err) => {


### PR DESCRIPTION
This pr adds uploaded files metadata info to the response of the repo creation call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new struct to encapsulate local repository and metadata entries.
	- Enhanced repository creation to return metadata entries alongside the repository.
	- Updated response structure to include metadata entries for repository creation.

- **Bug Fixes**
	- Improved logic for retrieving the latest commit and handling metadata during repository creation.

- **Documentation**
	- Updated method signatures to reflect changes in return types and response structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->