### PR TITLE
update metadata for column in update column endpoint

### DIFF
--- a/src/server/src/controllers/workspaces/data_frames/columns.rs
+++ b/src/server/src/controllers/workspaces/data_frames/columns.rs
@@ -186,6 +186,7 @@ pub async fn update(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
         OxenHttpError::BadRequest("Failed to parse request body into JSON".into())
     })?;
 
+    let mut metadata_json: Option<serde_json::Value> = None;
     if let Some(obj) = body_json.as_object_mut() {
         if obj.contains_key("name") {
             let name_value = obj.remove("name").unwrap(); // Safe to unwrap because we just checked it exists
@@ -197,6 +198,9 @@ pub async fn update(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
         }
 
         obj.insert("name".to_string(), json!(column_name));
+        if obj.contains_key("metadata") {
+            metadata_json = Some(obj.remove("metadata").unwrap()); // Safe to unwrap because we just checked it exists
+        }
     } else {
         return Err(OxenHttpError::BadRequest(
             "Request body is not a valid JSON object".into(),
@@ -218,6 +222,16 @@ pub async fn update(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
 
     // Get the workspace
     let workspace = repositories::workspaces::get(&repo, &workspace_id)?;
+
+    if let Some(metadata) = metadata_json {
+        repositories::workspaces::data_frames::columns::add_column_metadata(
+            &repo,
+            &workspace,
+            file_path.clone(),
+            column_name.clone(),
+            &metadata,
+        )?;
+    }
 
     // Make sure the data frame is indexed
     let is_editable = repositories::workspaces::data_frames::is_indexed(&workspace, &file_path)?;


### PR DESCRIPTION
Allow updating column metadata from update column endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced optional metadata handling for updating columns in the workspace.
	- Added a method to facilitate the addition of metadata to columns.
	- Renamed the "dtype" field to "data_type" for consistency in API requests.
	- Updated the "name" field to "new_name" and "dtype" to "new_data_type" in the update request body.

- **Bug Fixes**
	- Improved error handling during column deletion operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->