### PR TITLE
enable querying workspace df, add schema fetching route

### DIFF
--- a/src/lib/src/repositories/workspaces/data_frames.rs
+++ b/src/lib/src/repositories/workspaces/data_frames.rs
@@ -152,7 +152,7 @@ pub fn query(
     log::debug!("query_staged_df() got db_path: {:?}", db_path);
     log::debug!("query() opts: {:?}", opts);
 
-    let conn = df_db::get_connection(db_path)?;
+    let mut conn = df_db::get_connection(db_path)?;
 
     // Get the schema of this commit entry
     let schema = df_db::get_schema(&conn, TABLE_NAME)?;
@@ -167,7 +167,7 @@ pub fn query(
         log::debug!("querying embeddings: {:?}", embedding_opts);
         repositories::workspaces::data_frames::embeddings::query(workspace, &embedding_opts)?
     } else if let Some(sql) = &opts.sql {
-        df_db::select_str(&conn, sql, true, Some(&full_schema), Some(opts))?
+        sql::query_df(&mut conn, sql.clone(), None)?
     } else {
         let select = Select::new().select(&col_names).from(TABLE_NAME);
         df_db::select(&conn, &select, true, Some(&full_schema), Some(opts))?

--- a/src/server/src/services/workspaces/data_frames.rs
+++ b/src/server/src/services/workspaces/data_frames.rs
@@ -30,6 +30,10 @@ pub fn data_frames() -> Scope {
             web::get().to(controllers::workspaces::data_frames::get),
         )
         .route(
+            "/schema/{path:.*}",
+            web::get().to(controllers::workspaces::data_frames::get_schema),
+        )
+        .route(
             "/resource/{path:.*}",
             web::put().to(controllers::workspaces::data_frames::put),
         )


### PR DESCRIPTION
Fix schema response when querying a workspace df, add route to fetch indexed df schema


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new endpoint to retrieve schema information for data frames.
	- Added functionality to exclude specific columns from SQL query results.

- **Bug Fixes**
	- Improved error handling for SQL queries and schema retrieval processes.

- **Documentation**
	- Updated import statements to support new functionalities related to data frame operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->