### PR TITLE
Fix incorrect arguments in delete-remote subcommand

### DIFF
--- a/src/cli/src/cmd/config.rs
+++ b/src/cli/src/cmd/config.rs
@@ -47,7 +47,7 @@ impl RunCmd for ConfigCmd {
             .arg(
                 Arg::new("delete-remote")
                     .long("delete-remote")
-                    .number_of_values(2)
+                    .value_name("REMOTE_NAME")
                     .help("Delete a remote from the current working repository.")
                     .action(clap::ArgAction::Set),
             )


### PR DESCRIPTION
The argument parser was requiring two args for delete-remote, so it would error when you gave it the correct arguments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved clarity of the command-line interface by updating the `delete-remote` argument to specify expected input more clearly in the help documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->