### PR TITLE
Optimise download

### DIFF
--- a/benchmark/generate_text_repo.py
+++ b/benchmark/generate_text_repo.py
@@ -1,7 +1,6 @@
 import os
 import argparse
 from tqdm import tqdm
-import pandas as pd
 
 def generate_text_files(num_files, output_dir):
     print(f"Generating {num_files} text files in {output_dir}")
@@ -12,8 +11,7 @@ def generate_text_files(num_files, output_dir):
     texts_dir = os.path.join(output_dir, "texts")
     os.makedirs(texts_dir, exist_ok=True)
 
-    # return all the text file paths
-    file_paths = []
+    # Generate files
     for i in tqdm(range(num_files)):
         # Generate minimal content (just a number)
         content = f"File content {i}"
@@ -23,27 +21,14 @@ def generate_text_files(num_files, output_dir):
         with open(path, 'w') as f:
             f.write(content)
 
-        # Get the relative path to the output_dir
-        relative_path = os.path.relpath(path, output_dir)
-        file_paths.append(relative_path)
-
-    return file_paths
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--num_files", type=int, default=10000)
     parser.add_argument("--output_dir", type=str, default="text_files")
     args = parser.parse_args()
 
-    file_paths = generate_text_files(args.num_files, args.output_dir)
+    generate_text_files(args.num_files, args.output_dir)
     print("Text file generation complete!")
-
-    # create random labels for each file of positive or negative
-    labels = np.random.choice(["positive", "negative"], size=args.num_files)
-
-    # write dataframe
-    df = pd.DataFrame({"files": file_paths, "labels": labels})
-    df.to_csv(os.path.join(args.output_dir, "files.csv"), index=False)
 
     with open(os.path.join(args.output_dir, "README.md"), "w") as f:
         f.write(f"# Sample Repo\n\nGenerated {args.num_files} text files in {args.output_dir}")

--- a/benchmark/generate_text_repo.py
+++ b/benchmark/generate_text_repo.py
@@ -1,0 +1,49 @@
+import os
+import argparse
+from tqdm import tqdm
+import pandas as pd
+
+def generate_text_files(num_files, output_dir):
+    print(f"Generating {num_files} text files in {output_dir}")
+    # Create the output directory if it doesn't exist
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Make the texts dir
+    texts_dir = os.path.join(output_dir, "texts")
+    os.makedirs(texts_dir, exist_ok=True)
+
+    # return all the text file paths
+    file_paths = []
+    for i in tqdm(range(num_files)):
+        # Generate minimal content (just a number)
+        content = f"File content {i}"
+
+        # Save the text file
+        path = os.path.join(texts_dir, f"file_{i}.txt")
+        with open(path, 'w') as f:
+            f.write(content)
+
+        # Get the relative path to the output_dir
+        relative_path = os.path.relpath(path, output_dir)
+        file_paths.append(relative_path)
+
+    return file_paths
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num_files", type=int, default=10000)
+    parser.add_argument("--output_dir", type=str, default="text_files")
+    args = parser.parse_args()
+
+    file_paths = generate_text_files(args.num_files, args.output_dir)
+    print("Text file generation complete!")
+
+    # create random labels for each file of positive or negative
+    labels = np.random.choice(["positive", "negative"], size=args.num_files)
+
+    # write dataframe
+    df = pd.DataFrame({"files": file_paths, "labels": labels})
+    df.to_csv(os.path.join(args.output_dir, "files.csv"), index=False)
+
+    with open(os.path.join(args.output_dir, "README.md"), "w") as f:
+        f.write(f"# Sample Repo\n\nGenerated {args.num_files} text files in {args.output_dir}")

--- a/src/lib/src/core/v0_19_0/download.rs
+++ b/src/lib/src/core/v0_19_0/download.rs
@@ -60,6 +60,32 @@ async fn r_download_entries(
     pull_progress: &Arc<PullProgress>,
 ) -> Result<(), OxenError> {
     log::debug!("downloading entries for {:?}", directory);
+
+    if let EMerkleTreeNode::VNode(_) = &node.node {
+        let mut entries: Vec<Entry> = vec![];
+
+        for child in &node.children {
+            if let EMerkleTreeNode::File(file_node) = &child.node {
+                entries.push(Entry::CommitEntry(CommitEntry {
+                    commit_id: file_node.last_commit_id.to_string(),
+                    path: directory.join(&file_node.name),
+                    hash: child.hash.to_string(),
+                    num_bytes: file_node.num_bytes,
+                    last_modified_seconds: file_node.last_modified_seconds,
+                    last_modified_nanoseconds: file_node.last_modified_nanoseconds,
+                }));
+            }
+        }
+
+        log::debug!("downloading {} entries to working dir", entries.len());
+        core::v0_10_0::index::puller::pull_entries_to_working_dir(
+            remote_repo,
+            &entries,
+            local_repo_path,
+            pull_progress,
+        )
+        .await?;
+    }
     for child in &node.children {
         log::debug!("downloading entry {:?}", child.hash);
 
@@ -76,32 +102,6 @@ async fn r_download_entries(
                 &new_directory,
                 pull_progress,
             ))
-            .await?;
-        }
-
-        if let EMerkleTreeNode::VNode(_) = &node.node {
-            let mut entries: Vec<Entry> = vec![];
-
-            for child in &node.children {
-                if let EMerkleTreeNode::File(file_node) = &child.node {
-                    entries.push(Entry::CommitEntry(CommitEntry {
-                        commit_id: file_node.last_commit_id.to_string(),
-                        path: directory.join(&file_node.name),
-                        hash: child.hash.to_string(),
-                        num_bytes: file_node.num_bytes,
-                        last_modified_seconds: file_node.last_modified_seconds,
-                        last_modified_nanoseconds: file_node.last_modified_nanoseconds,
-                    }));
-                }
-            }
-
-            log::debug!("downloading {} entries to working dir", entries.len());
-            core::v0_10_0::index::puller::pull_entries_to_working_dir(
-                remote_repo,
-                &entries,
-                local_repo_path,
-                pull_progress,
-            )
             .await?;
         }
     }


### PR DESCRIPTION
The issue was:

The outer loop was iterating over all children
For EACH child, we checked if the PARENT node is a VNode
If the parent is a VNode, we process ALL children again
This means if a VNode has 1000 children, we called r_download_entries 4 times (for 4 VNodes) and for every children, we recheked if the parent was a VNode and added entries all over again.

To fix this we move the vnode check outside of the loop that iterates over the children.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a script for generating a large number of text files in a specified directory
	- Included progress bar for file generation process

- **Chores**
	- Updated download handling logic for repository entries in the core library

<!-- end of auto-generated comment: release notes by coderabbit.ai -->