### PR TITLE
Fix/data frame export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Oxen"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "actix-files",
  "actix-http",
@@ -3314,7 +3314,7 @@ checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "liboxen"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "actix-files",
  "actix-web",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "oxen-cli"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "async-trait",
  "bytesize",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "oxen-server"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "actix-files",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Oxen"
-version = "0.24.2"
+version = "0.24.3"
 edition = "2021"
 license-file = "LICENSE"
 description = "Oxen is a fast, unstructured data version control, to help version large machine learning datasets written in Rust."

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxen-cli"
-version = "0.24.2"
+version = "0.24.3"
 edition = "2021"
 
 [dependencies]

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liboxen"
-version = "0.24.2"
+version = "0.24.3"
 edition = "2021"
 license-file = "LICENSE"
 description = "Oxen is a fast, unstructured data version control, to help version datasets, written in Rust."

--- a/src/lib/src/core/df/sql.rs
+++ b/src/lib/src/core/df/sql.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use crate::core::df::tabular;
 use crate::model::LocalRepository;
 use crate::opts::DFOpts;
 use crate::repositories;
@@ -30,7 +31,11 @@ pub fn query_df_from_repo(
 
     let db_path = repositories::workspaces::data_frames::duckdb_path(&workspace, path);
     let mut conn = df_db::get_connection(db_path)?;
-    query_df(&mut conn, sql, Some(opts))
+    let df = query_df(&mut conn, sql, Some(opts))?;
+
+    // If we are doing this from the CLI, we don't want to export the hidden Oxen columns
+    let df = tabular::strip_excluded_cols(df)?;
+    Ok(df)
 }
 
 pub fn query_df(

--- a/src/server/Cargo.toml
+++ b/src/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxen-server"
-version = "0.24.2"
+version = "0.24.3"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
When exporting a df with the `--sql` flag on the command line, we were also exporting the oxen hidden fields that automatically get indexed.

```
oxen df data/questions.parquet --sql "SELECT * FROM df WHERE is_answerable = true;" -o ~/Downloads/exported.parquet
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Version Updates**
	- Updated package versions from 0.24.2 to 0.24.3 across multiple components:
		- Main package
		- CLI
		- Library
		- Server

- **New Features**
	- Enhanced DataFrame query functionality to strip excluded columns when outputting results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->