### PR TITLE
Fix/migration for vnode lookup

### DIFF
--- a/src/lib/src/api/client/dir.rs
+++ b/src/lib/src/api/client/dir.rs
@@ -98,7 +98,6 @@ mod tests {
     use crate::repositories;
     use crate::test;
     use crate::util;
-    use crate::view::StatusMessage;
 
     use std::path::Path;
 

--- a/src/lib/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
+++ b/src/lib/src/command/migrate/m20250111083535_add_child_counts_to_nodes.rs
@@ -1,13 +1,22 @@
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
+use std::str::FromStr;
+use rocksdb::{DBWithThreadMode, SingleThreaded};
 
 use super::Migrate;
 
 use crate::config::RepositoryConfig;
+use crate::core::db;
+use crate::core::db::merkle_node::MerkleNodeDB;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
-use crate::model::merkle_tree::node::{DirNode, EMerkleTreeNode, VNode};
-use crate::model::{Commit, LocalRepository};
+use crate::model::merkle_tree::node::vnode::VNodeOpts;
+use crate::model::merkle_tree::node::{CommitNode, DirNode, EMerkleTreeNode, MerkleTreeNode, VNode};
+use crate::model::{Commit, LocalRepository, MerkleHash};
+use crate::core::v_old::v0_19_0::index::CommitMerkleTree as OldCommitMerkleTree;
+use crate::core::v_latest::index::CommitMerkleTree as NewCommitMerkleTree;
 
+use crate::util::hasher;
 use crate::util::progress_bar::{oxen_progress_bar, ProgressBarType};
 use crate::{repositories, util};
 
@@ -88,61 +97,58 @@ fn run_on_one_repo(repo: &LocalRepository) -> Result<(), OxenError> {
     Ok(())
 }
 
-fn run_on_commit(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenError> {
+fn run_on_commit(repository: &LocalRepository, commit: &Commit) -> Result<(), OxenError> {
     log::info!(
         "Running add_child_counts_to_nodes on commit: {} for repo: {:?}",
-        commit.id,
-        repo.path
+        commit,
+        repository.path
     );
-    let old_repo = repo.clone();
+    let old_repo = repository.clone();
 
-    let Some(mut root_node) = repositories::tree::get_root_with_children(&old_repo, commit)? else {
-        return Err(OxenError::basic_str("Root node not found"));
-    };
-
-    log::debug!("old tree");
+    println!("old tree for commit {}", commit);
     repositories::tree::print_tree(&old_repo, commit)?;
 
     // Iterate over the nodes, find the VNode and DirNode, and add the child counts
-    let mut new_repo = repo.clone();
+    let mut new_repo = repository.clone();
     new_repo.set_min_version(MinOxenVersion::from_string("0.25.0")?);
 
     // *******************************************************************
     // We need to load all the children of all the VNodes for each DirNode
-    // Then re-assign the children to new VNodes based on their full path
+    // Then re-split the children to new VNodes based on their path name
+    // this way we can look up files by path faster, which is what this
+    // migration is all about.
     // *******************************************************************
 
-    root_node.walk_tree_mut(|node| {
-        match &mut node.node {
-            EMerkleTreeNode::Directory(dir) => {
-                let child_count = node.children.len() as u64;
-                log::debug!("walk dir {} child_count: {}", dir, child_count);
-                let opts = dir.get_opts();
-                let mut new_dir = DirNode::new(&new_repo, opts).expect("Failed to create dir");
-                new_dir.set_num_entries(child_count);
-                *dir = new_dir;
-            }
-            EMerkleTreeNode::VNode(vnode) => {
-                let opts = vnode.get_opts();
-                let child_count = node.children.len() as u64;
-                log::debug!("walk vnode {} child_count: {}", vnode, child_count);
-                let mut new_vnode = VNode::new(&new_repo, opts).expect("Failed to create vnode");
-                new_vnode.set_num_entries(child_count);
-                *vnode = new_vnode;
-            }
-            _ => {
-                // pass, FileNode was not changed, so it is on the latest version
-            }
-        }
-    });
+    let Some(root_node) = repositories::tree::get_root_with_children(&old_repo, commit)? else {
+        return Err(OxenError::basic_str("Root node not found"));
+    };
+    let EMerkleTreeNode::Commit(commit_node) = root_node.node.clone() else {
+        return Err(OxenError::basic_str("Root node must be CommitNode"));
+    };
 
-    log::debug!("new tree");
+    let root_dir_node = repositories::tree::get_root_dir(&root_node)?;
+    let EMerkleTreeNode::Directory(dir_node) = root_dir_node.node.clone() else {
+        return Err(OxenError::basic_str("Root node must be CommitNode"));
+    };
+
+    // ✍️ Do all the rewriting
+    let num_children = root_dir_node.children.len();
+    log::debug!("setting num children {} for root dir on commit {}", num_children, commit);
+    let mut dir_node_opts = dir_node.get_opts();
+    dir_node_opts.num_entries = num_children as u64;
+    let dir_node = DirNode::new(&new_repo, dir_node_opts)?;
+
+    // Write a new commit db
+    let commit_node = CommitNode::from_commit(commit.clone());
+    let mut root_commit_db = MerkleNodeDB::open_read_write(&old_repo, &commit_node, root_node.parent_id)?;
+    root_commit_db.add_child(&dir_node)?;
+
+    let mut root_dir_db = MerkleNodeDB::open_read_write(&old_repo, &dir_node, root_dir_node.parent_id)?;
+    let current_path = Path::new("");
+    rewrite_nodes(&old_repo, &new_repo, &root_node, &mut root_dir_db, &current_path)?;
+
+    println!("new tree for commit {}", commit);
     repositories::tree::print_tree(&new_repo, commit)?;
-
-    // Write the tree back to disk
-    repositories::tree::write_tree(&new_repo, &root_node)?;
-
-    log::debug!("new tree written to disk");
 
     // Set the oxen version to 0.25.0
     let mut config = RepositoryConfig::from_repo(&new_repo)?;
@@ -150,6 +156,144 @@ fn run_on_commit(repo: &LocalRepository, commit: &Commit) -> Result<(), OxenErro
     let path = util::fs::config_filepath(&new_repo.path);
     config.save(&path)?;
 
+    Ok(())
+}
+
+// Forgive me if you are reading this for reference, we don't have great writers for the
+// merkle tree yet - so there is a lot of duplicate logic with `commit_writer.rs`
+fn rewrite_nodes(
+    old_repo: &LocalRepository,
+    new_repo: &LocalRepository,
+    node: &MerkleTreeNode,
+    parent_db: &mut MerkleNodeDB,
+    current_dir: &Path
+) -> Result<(), OxenError> {
+    for child in node.children.iter() {
+        match &child.node {
+            EMerkleTreeNode::Directory(dir) => {
+                // Load all the children of children (files and folders)
+                // Then redistribute into buckets...
+                // and then just use the MerkleNodeDB to write the nodes
+                // to the new tree
+                let dir_children = repositories::tree::list_files_and_folders(child)?;
+                let current_dir = current_dir.join(dir.name());
+
+                log::debug!("rewrite_nodes {} children on current_dir {:?} DIRECTORY {} {}", dir_children.len(), current_dir, dir.hash(), dir);
+
+                let total_children = dir_children.len();
+                let vnode_size = old_repo.vnode_size();
+                let num_vnodes = (total_children as f32 / vnode_size as f32).ceil() as u128;
+                
+                // Create our new DirNode
+                let mut dir_node_opts = dir.get_opts();
+                dir_node_opts.num_entries = total_children as u64;
+                let dir = DirNode::new(&new_repo, dir_node_opts)?;
+                let mut dir_db = MerkleNodeDB::open_read_write(old_repo, &dir, node.parent_id)?;
+
+                log::debug!(
+                    "rewrite_nodes {} VNodes for {} children in {} with vnode size {}",
+                    num_vnodes,
+                    total_children,
+                    dir,
+                    vnode_size
+                );
+
+                // Compute buckets
+                let mut buckets: Vec<Vec<MerkleTreeNode>> =
+                    vec![vec![]; num_vnodes as usize];
+                for dir_child in dir_children {
+                    let path = current_dir.join(dir_child.maybe_path().unwrap());
+                    let hash = hasher::hash_buffer_128bit(
+                        path
+                            .to_str()
+                            .unwrap()
+                            .as_bytes(),
+                    );
+                    let bucket_idx = hash % num_vnodes;
+                    log::debug!("\trewrite_nodes dir_child {:?} bucket {} num_vnodes {} hash {} {}", path, bucket_idx, num_vnodes, hash, dir_child);
+                    buckets[bucket_idx as usize].push(dir_child);
+                }
+
+                // Compute hashes and sort entries to get vnode buckets
+                let mut vnodes: Vec<(MerkleHash, Vec<MerkleTreeNode>)> = vec![];
+                for bucket in buckets.iter_mut() {
+                    // Sort the entries in the vnode by path
+                    // to make searching for entries faster
+                    bucket.sort_by(|a, b| {
+                        a.maybe_path()
+                          .unwrap()
+                          .cmp(&b.maybe_path().unwrap())
+                    });
+
+                    // Compute hash for the vnode
+                    let mut vnode_hasher = xxhash_rust::xxh3::Xxh3::new();
+                    vnode_hasher.update(b"vnode");
+                    // add the dir name to the vnode hash
+                    vnode_hasher.update(dir.name().as_bytes());
+
+                    for entry in bucket.iter() {
+                        if let EMerkleTreeNode::File(file_node) = &entry.node {
+                            vnode_hasher.update(&file_node.combined_hash().to_le_bytes());
+                        } else if let EMerkleTreeNode::Directory(dir_node) = &entry.node {
+                            vnode_hasher.update(&dir_node.hash().to_le_bytes());
+                        }
+                    }
+
+                    let vnode_id = MerkleHash::new(vnode_hasher.digest128());
+                    vnodes.push((vnode_id, bucket.clone()));
+                }
+
+                log::debug!("rewrite_nodes count vnodes: {}", vnodes.len());
+                for (hash, entries) in vnodes.iter() {
+                    // create a new vnode obj and add the the db
+                    let opts = VNodeOpts {
+                        hash: hash.clone(),
+                        num_entries: entries.len() as u64,
+                    };
+                    let vnode_obj = VNode::new(new_repo, opts)?;
+                    log::debug!("rewrite_nodes adding VNode to DirNode! {:?}", vnode_obj);
+                    dir_db.add_child(&vnode_obj)?;
+
+                    let mut vnode_db = MerkleNodeDB::open_read_write(
+                        new_repo,
+                        &vnode_obj,
+                        Some(dir_db.node_id),
+                    )?;
+                    
+                    log::debug!("rewrite_nodes count entries {}", entries.len());
+                    for entry in entries {
+                        match &entry.node {
+                            EMerkleTreeNode::File(f_node) => {
+                                log::debug!("rewrite_nodes adding FileNode to VNode! {}", f_node);
+                                vnode_db.add_child(f_node)?;
+                            },
+                            EMerkleTreeNode::Directory(d_node) => {
+                                let mut d_node_opts = d_node.get_opts();
+                                let d_children = repositories::tree::list_files_and_folders(entry)?;
+                                d_node_opts.num_entries = d_children.len() as u64;
+                                log::debug!("rewrite_nodes adding DirNode to VNode with {} num_entries {}", d_node_opts.num_entries, d_node);
+                                let d_node = DirNode::new(&new_repo, d_node_opts)?;
+                                vnode_db.add_child(&d_node)?;
+                            },
+                            _ => {
+                                panic!("Shouldn't reach here.")
+                            }
+                        }
+                    }
+                }
+
+                rewrite_nodes(old_repo, new_repo, child, &mut dir_db, &current_dir)?;
+            }
+            EMerkleTreeNode::VNode(_) => {
+                // VNode just needs to traverse to the next dirnode
+                rewrite_nodes(old_repo, new_repo, child, parent_db, current_dir)?;
+            }
+            _ => {
+                // pass, FileNode was not changed, so it is on the latest version
+            }
+        }
+    }
+    
     Ok(())
 }
 
@@ -262,7 +406,7 @@ mod tests {
         test::run_empty_dir_test(|dir| {
             // Instantiate an older repository
             let mut repo = repositories::init::init_with_version(dir, MinOxenVersion::V0_19_0)?;
-            // Set the vnode size to 5
+            // Set the vnode size to 3
             repo.set_vnode_size(3);
 
             // Populate the repo with some files
@@ -302,7 +446,9 @@ mod tests {
             // Run the migration
             run_on_one_repo(&repo)?;
 
-            let repo = LocalRepository::from_dir(&repo.path)?;
+            let mut repo = LocalRepository::from_dir(&repo.path)?;
+            repo.set_vnode_size(3);
+
             let latest_commit = repositories::commits::latest_commit(&repo)?;
             let commit_node_version =
                 repositories::tree::get_commit_node_version(&repo, &latest_commit)?;
@@ -343,6 +489,8 @@ mod tests {
                 }
             });
 
+            println!("Checking files on latest_commit: {}", latest_commit);
+
             // Make sure we can get an individual file
             let file_node = repositories::tree::get_node_by_path(
                 &repo,
@@ -351,16 +499,16 @@ mod tests {
             )?;
             assert!(file_node.is_some());
 
-            for i in 0..3 {
-                let path = PathBuf::from("train").join(format!("dog_{}.jpg", i));
-                log::debug!("LOOKING UP DOG: {:?}", path);
+            for i in 1..3 {
+                let path = PathBuf::from("train").join(format!("cat_{}.jpg", i));
+                log::debug!("LOOKING UP CAT: {:?}", path);
                 let file_node = repositories::tree::get_node_by_path(&repo, &latest_commit, &path)?;
                 assert!(file_node.is_some());
             }
 
-            for i in 0..2 {
-                let path = PathBuf::from("train").join(format!("cat_{}.jpg", i));
-                log::debug!("LOOKING UP CAT: {:?}", path);
+            for i in 1..4 {
+                let path = PathBuf::from("train").join(format!("dog_{}.jpg", i));
+                log::debug!("LOOKING UP DOG: {:?}", path);
                 let file_node = repositories::tree::get_node_by_path(&repo, &latest_commit, &path)?;
                 assert!(file_node.is_some());
             }

--- a/src/lib/src/core/v_latest/index/commit_merkle_tree.rs
+++ b/src/lib/src/core/v_latest/index/commit_merkle_tree.rs
@@ -474,13 +474,8 @@ impl CommitMerkleTree {
 
         // Calculate the total number of children in the vnodes
         // And use this to skip to the correct vnode
-        log::debug!("read_file dir_node {:?}", dir_node);
+        // log::debug!("read_file dir_node {:?}", dir_node);
         let total_children = dir_node.num_entries();
-
-        // let total_children = vnodes
-        //     .iter()
-        //     .map(|vnode| vnode.vnode().unwrap().num_entries())
-        //     .sum::<u64>();
         let vnode_size = repo.vnode_size();
         let num_vnodes = (total_children as f32 / vnode_size as f32).ceil() as u128;
 
@@ -495,7 +490,6 @@ impl CommitMerkleTree {
 
         // Calculate the bucket to skip to based on the path and the number of vnodes
         let path_hash = hasher::hash_buffer_128bit(path.to_str().unwrap().as_bytes());
-        log::debug!("read_file path_hash: {}", path_hash);
         let bucket = path_hash % num_vnodes;
 
         log::debug!("read_file bucket: {}", bucket);

--- a/src/lib/src/core/v_latest/index/commit_merkle_tree.rs
+++ b/src/lib/src/core/v_latest/index/commit_merkle_tree.rs
@@ -474,7 +474,9 @@ impl CommitMerkleTree {
 
         // Calculate the total number of children in the vnodes
         // And use this to skip to the correct vnode
+        log::debug!("read_file dir_node {:?}", dir_node);
         let total_children = dir_node.num_entries();
+
         // let total_children = vnodes
         //     .iter()
         //     .map(|vnode| vnode.vnode().unwrap().num_entries())
@@ -492,7 +494,9 @@ impl CommitMerkleTree {
         }
 
         // Calculate the bucket to skip to based on the path and the number of vnodes
-        let bucket = hasher::hash_buffer_128bit(path.to_str().unwrap().as_bytes()) % num_vnodes;
+        let path_hash = hasher::hash_buffer_128bit(path.to_str().unwrap().as_bytes());
+        log::debug!("read_file path_hash: {}", path_hash);
+        let bucket = path_hash % num_vnodes;
 
         log::debug!("read_file bucket: {}", bucket);
 

--- a/src/lib/src/core/v_latest/index/commit_merkle_tree.rs
+++ b/src/lib/src/core/v_latest/index/commit_merkle_tree.rs
@@ -475,6 +475,10 @@ impl CommitMerkleTree {
         // Calculate the total number of children in the vnodes
         // And use this to skip to the correct vnode
         let total_children = dir_node.num_entries();
+        // let total_children = vnodes
+        //     .iter()
+        //     .map(|vnode| vnode.vnode().unwrap().num_entries())
+        //     .sum::<u64>();
         let vnode_size = repo.vnode_size();
         let num_vnodes = (total_children as f32 / vnode_size as f32).ceil() as u128;
 
@@ -498,7 +502,7 @@ impl CommitMerkleTree {
         // Load the children for the vnode
         let vnode_with_children =
             CommitMerkleTree::read_depth(repo, &vnode_without_children.hash, 0)?;
-        log::debug!("read_file vnode_with_children: {:?}", vnode_with_children);
+        // log::debug!("read_file vnode_with_children: {:?}", vnode_with_children);
         let Some(vnode_with_children) = vnode_with_children else {
             return Ok(None);
         };

--- a/src/lib/src/core/v_old/v0_19_0/model/merkle_tree/node/dir_node.rs
+++ b/src/lib/src/core/v_old/v0_19_0/model/merkle_tree/node/dir_node.rs
@@ -60,12 +60,12 @@ impl TDirNode for DirNodeData {
     }
 
     fn num_entries(&self) -> u64 {
-        log::warn!("num_entries is not supported for v0.19.0");
+        // log::warn!("num_entries is not supported for v0.19.0");
         0
     }
 
     fn set_num_entries(&mut self, _: u64) {
-        log::warn!("set_num_entries is not supported for v0.19.0");
+        // log::warn!("set_num_entries is not supported for v0.19.0");
     }
 
     fn num_bytes(&self) -> u64 {

--- a/src/lib/src/core/v_old/v0_19_0/model/merkle_tree/node/vnode.rs
+++ b/src/lib/src/core/v_old/v0_19_0/model/merkle_tree/node/vnode.rs
@@ -28,11 +28,11 @@ impl TVNode for VNodeData {
     }
 
     fn num_entries(&self) -> u64 {
-        log::warn!("VNodeData(0.19.0) does not have num_entries");
+        // log::warn!("VNodeData(0.19.0) does not have num_entries");
         0
     }
 
     fn set_num_entries(&mut self, _: u64) {
-        log::warn!("VNodeData(0.19.0) does not have num_entries");
+        // log::warn!("VNodeData(0.19.0) does not have num_entries");
     }
 }

--- a/src/lib/src/repositories/commits/commit_writer.rs
+++ b/src/lib/src/repositories/commits/commit_writer.rs
@@ -1564,7 +1564,8 @@ mod tests {
                 let dir_num = i % 2;
                 let new_file = repo
                     .path
-                    .join(format!("files/dir_{}", dir_num))
+                    .join("files")
+                    .join(format!("dir_{}", dir_num))
                     .join(format!("new_file_{}.txt", i));
                 util::fs::write_to_path(&new_file, format!("New fileeeee {}", i))?;
                 repositories::add(&repo, &new_file)?;

--- a/src/lib/src/repositories/commits/commit_writer.rs
+++ b/src/lib/src/repositories/commits/commit_writer.rs
@@ -698,7 +698,7 @@ fn split_into_vnodes(
             // Compute hash for the vnode
             let mut vnode_hasher = xxhash_rust::xxh3::Xxh3::new();
             vnode_hasher.update(b"vnode");
-            // generate a uuid for the vnode
+            // add the dir name to the vnode hash
             vnode_hasher.update(directory.to_str().unwrap().as_bytes());
 
             let mut has_new_entries = false;

--- a/src/lib/src/repositories/commits/commit_writer.rs
+++ b/src/lib/src/repositories/commits/commit_writer.rs
@@ -1559,12 +1559,13 @@ mod tests {
             let dir_1_node = first_tree.get_by_path(Path::new("files/dir_1"))?.unwrap();
             assert_eq!(dir_1_node.num_vnodes(), 3);
 
-            // Add a news files
+            // Add a new files
             for i in 0..10 {
                 let dir_num = i % 2;
                 let new_file = repo
                     .path
-                    .join(format!("files/dir_{}/new_file_{}.txt", dir_num, i));
+                    .join(format!("files/dir_{}", dir_num))
+                    .join(format!("new_file_{}.txt", i));
                 util::fs::write_to_path(&new_file, format!("New fileeeee {}", i))?;
                 repositories::add(&repo, &new_file)?;
             }
@@ -1582,6 +1583,21 @@ mod tests {
             // Read the second merkle tree
             let second_tree = CommitMerkleTree::from_commit(&repo, &second_commit)?;
             second_tree.print();
+
+            // Make sure we can read the new files
+            for i in 0..10 {
+                let dir_num = i % 2;
+                let file_path = Path::new("files")
+                    .join(format!("dir_{}", dir_num))
+                    .join(format!("new_file_{}.txt", i));
+
+                let file_node = second_tree.get_by_path(&file_path)?;
+                assert!(file_node.is_some());
+
+                let file_node =
+                    repositories::tree::get_node_by_path(&repo, &second_commit, &file_path)?;
+                assert!(file_node.is_some());
+            }
 
             Ok(())
         })

--- a/src/lib/src/repositories/merge.rs
+++ b/src/lib/src/repositories/merge.rs
@@ -391,11 +391,7 @@ mod tests {
             let contents = util::fs::read_from_path(&world_file)?;
             assert_eq!(contents, og_contents);
 
-            let commit = repositories::merge::merge(&repo, branch_name)?.unwrap();
-
-            // Make sure the merge commit has two parents
-            // Well shoot - we have to fix this bug too....merges should have two parents
-            assert_eq!(commit.parent_ids.len(), 2);
+            repositories::merge::merge(&repo, branch_name)?.unwrap();
 
             // Now that we've merged in, world file should be new content
             assert!(world_file.exists(), "World file should exist after merge");

--- a/src/lib/src/repositories/merge.rs
+++ b/src/lib/src/repositories/merge.rs
@@ -391,7 +391,11 @@ mod tests {
             let contents = util::fs::read_from_path(&world_file)?;
             assert_eq!(contents, og_contents);
 
-            repositories::merge::merge(&repo, branch_name)?.unwrap();
+            let commit = repositories::merge::merge(&repo, branch_name)?.unwrap();
+
+            // Make sure the merge commit has two parents
+            // Well shoot - we have to fix this bug too....merges should have two parents
+            assert_eq!(commit.parent_ids.len(), 2);
 
             // Now that we've merged in, world file should be new content
             assert!(world_file.exists(), "World file should exist after merge");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Removed unused import in directory API client
	- Updated logging behavior in various merkle tree node implementations
	- Modified vnode hash generation logic during commit process

- **Refactor**
	- Enhanced migration logic for merkle tree nodes
	- Improved commit merkle tree file reading process
	- Adjusted directory and vnode entry counting methods

Note: These changes primarily enhance the code structure and logging, with minimal direct user-facing impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->