### PR TITLE
Update put_file to accept an optional file name

### DIFF
--- a/src/server/src/services/file.rs
+++ b/src/server/src/services/file.rs
@@ -7,5 +7,5 @@ pub fn file() -> Scope {
     web::scope("/file")
         .route("/{resource:.*}", web::get().to(controllers::file::get))
         .route("/{resource:.*}", web::head().to(controllers::file::get))
-        .route("/{resource:.*}", web::put().to(controllers::file::update))
+        .route("/{resource:.*}", web::put().to(controllers::file::put))
 }


### PR DESCRIPTION
This allows the Python client fsspec integration to write the file with the correct name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced file upload functionality with more flexible input types
  - Added optional custom file name during file uploads

- **Refactor**
  - Renamed `create_or_update` method to `put_file`
  - Updated method signatures to support more flexible parameter types
  - Renamed server-side file update method from `update` to `put` for better RESTful approach

- **Tests**
  - Updated test cases to reflect new method names and signatures
<!-- end of auto-generated comment: release notes by coderabbit.ai -->