### PR TITLE
Print docs and support links in CLI

### DIFF
--- a/src/cli/src/cmd/init.rs
+++ b/src/cli/src/cmd/init.rs
@@ -12,6 +12,14 @@ use liboxen::repositories;
 
 pub const INIT: &str = "init";
 
+const AFTER_INIT_MSG: &str = "
+    📖 If this is your first time using Oxen, check out the CLI docs at:
+            https://docs.oxen.ai/getting-started/cli
+
+    💬 For more support, or to chat with the Oxen team, join our Discord:
+            https://discord.gg/s3tBEn7Ptg
+";
+
 pub struct InitCmd;
 
 #[async_trait]
@@ -52,6 +60,7 @@ impl RunCmd for InitCmd {
         let directory = util::fs::canonicalize(PathBuf::from(&path))?;
         repositories::init::init_with_version(&directory, oxen_version)?;
         println!("🐂 repository initialized at: {directory:?}");
+        println!("{}", AFTER_INIT_MSG);
         Ok(())
     }
 }

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -8,6 +8,18 @@ use liboxen::util;
 pub mod cmd;
 pub mod helpers;
 
+const SHORT_ABOUT: &str = "🐂 is the AI and machine learning data management toolchain";
+
+const LONG_ABOUT: &str = "
+🐂 is the AI and machine learning data management toolchain
+
+    📖 If this is your first time using Oxen, check out the CLI docs at:
+            https://docs.oxen.ai/getting-started/cli
+
+    💬 For more support, or to chat with the Oxen team, join our Discord:
+            https://discord.gg/s3tBEn7Ptg
+";
+
 #[tokio::main]
 async fn main() -> ExitCode {
     util::logging::init_logging();
@@ -52,7 +64,8 @@ async fn main() -> ExitCode {
 
     let mut command = Command::new("oxen")
         .version(liboxen::constants::OXEN_VERSION)
-        .about("🐂 is a machine learning dataset management toolchain")
+        .about(SHORT_ABOUT)
+        .long_about(LONG_ABOUT)
         .subcommand_required(true)
         .arg_required_else_help(true)
         .allow_external_subcommands(true);

--- a/src/lib/src/core/v_latest/init.rs
+++ b/src/lib/src/core/v_latest/init.rs
@@ -30,6 +30,11 @@ pub fn init_with_version(
 
     std::fs::create_dir_all(hidden_dir)?;
     let config_path = util::fs::config_filepath(path);
+    if config_path.try_exists()? {
+        let err = format!("Oxen repository already exists: {path:?}");
+        return Err(OxenError::basic_str(err));
+    }
+
     let repo = LocalRepository::new_from_version(path, version.to_string())?;
     repo.save(&config_path)?;
 

--- a/src/server/src/controllers/workspaces.rs
+++ b/src/server/src/controllers/workspaces.rs
@@ -33,7 +33,12 @@ pub async fn get_or_create(
     };
 
     let Some(branch) = repositories::branches::get_by_name(&repo, &data.branch_name)? else {
-        return Ok(HttpResponse::BadRequest().json(StatusMessage::error(format!("Branch not found: {}", data.branch_name))));
+        return Ok(
+            HttpResponse::BadRequest().json(StatusMessage::error(format!(
+                "Branch not found: {}",
+                data.branch_name
+            ))),
+        );
     };
 
     // Return workspace if it already exists
@@ -109,7 +114,12 @@ pub async fn create(
     };
 
     let Some(branch) = repositories::branches::get_by_name(&repo, &data.branch_name)? else {
-        return Ok(HttpResponse::BadRequest().json(StatusMessage::error(format!("Branch not found: {}", data.branch_name))));
+        return Ok(
+            HttpResponse::BadRequest().json(StatusMessage::error(format!(
+                "Branch not found: {}",
+                data.branch_name
+            ))),
+        );
     };
 
     let workspace_id = &data.workspace_id;

--- a/src/server/src/main.rs
+++ b/src/server/src/main.rs
@@ -36,6 +36,16 @@ const START_SERVER_USAGE: &str = "Usage: `oxen-server start -i 0.0.0.0 -p 3000`"
 
 const INVALID_PORT_MSG: &str = "Port must a valid number between 0-65535";
 
+const ABOUT: &str = "Oxen Server is the storage backend for Oxen, the AI and machine learning data management toolchain";
+
+const SUPPORT: &str = "
+    📖 Documentation on running oxen-server can be found at:
+            https://docs.oxen.ai/getting-started/oxen-server
+
+    💬 For more support, or to chat with the Oxen team, join our Discord:
+            https://discord.gg/s3tBEn7Ptg
+";
+
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     dotenv().ok();
@@ -54,13 +64,14 @@ async fn main() -> std::io::Result<()> {
 
     let command = Command::new("oxen-server")
         .version(VERSION)
-        .about("Oxen Server")
+        .about(ABOUT)
+        .long_about(format!("{ABOUT}\n{SUPPORT}"))
         .subcommand_required(true)
         .arg_required_else_help(true)
         .allow_external_subcommands(true)
         .subcommand(
             Command::new("start")
-                .about(START_SERVER_USAGE)
+                .about("Starts the server on the given host and port")
                 .arg(
                     Arg::new("ip")
                         .long("ip")
@@ -89,12 +100,12 @@ async fn main() -> std::io::Result<()> {
         )
         .subcommand(
             Command::new("add-user")
-                .about(ADD_USER_USAGE)
+                .about("Create a new user in the server and output the config file for that user")
                 .arg(
                     Arg::new("email")
                         .long("email")
                         .short('e')
-                        .help("Users email address")
+                        .help("User's email address")
                         .required(true)
                         .action(clap::ArgAction::Set),
                 )
@@ -102,7 +113,7 @@ async fn main() -> std::io::Result<()> {
                     Arg::new("name")
                         .long("name")
                         .short('n')
-                        .help("Users name that will show up in the commits")
+                        .help("User's name that will show up in the commits")
                         .required(true)
                         .action(clap::ArgAction::Set),
                 )
@@ -127,6 +138,7 @@ async fn main() -> std::io::Result<()> {
                 (Some(host), Some(port)) => {
                     let port: u16 = port.parse::<u16>().expect(INVALID_PORT_MSG);
                     println!("🐂 v{VERSION}");
+                    println!("{SUPPORT}");
                     println!("Running on {host}:{port}");
                     println!("Syncing to directory: {sync_dir}");
                     let enable_auth = sub_matches.get_flag("auth");


### PR DESCRIPTION
Also changed the `init` behavior to not destroy existing config if you run it on a directory that is already initialized 😬.

The printed messages look like this:

```
    📖 If this is your first time using Oxen, check out the CLI docs at:
            https://docs.oxen.ai/getting-started/cli

    💬 For more support, or to chat with the Oxen team, join our Discord:
            https://discord.gg/s3tBEn7Ptg
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a post-initialization message that guides users with links to documentation and community support.
  - Enhanced CLI and server command descriptions, making it clearer how to start the server and manage users.
  - Improved error handling during repository initialization to prevent conflicts when an existing configuration is found.

- **Documentation**
  - Updated help text and about sections with more detailed information and support resources for an improved user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->