### PR TITLE
Implement named workspaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,6 @@ jobs:
           brew install pkg-config || brew upgrade pkg-config
           brew install ffmpeg imagemagick ruby
 
-
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -530,6 +530,7 @@ jobs:
     needs: [release_mac_13, release_mac_14, release_mac_15]
     uses: oxen-ai/homebrew-oxen/.github/workflows/update-formula.yml@main
     with:
+      token: ${{ secrets.HOMEBREW_DEPLOY_PAT }}
       version: ${{ github.ref_name != '' && startsWith(github.ref_name, 'v') }}
 
   release_homebrew_oxen_server:
@@ -539,6 +540,7 @@ jobs:
     needs: [release_mac_13, release_mac_14, release_mac_15]
     uses: oxen-ai/homebrew-oxen-server/.github/workflows/update-formula.yml@main
     with:
+      token: ${{ secrets.HOMEBREW_DEPLOY_PAT }}
       version: ${{ github.ref_name != '' && startsWith(github.ref_name, 'v') }}
 
   stop-self-hosted-runner:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -530,8 +530,9 @@ jobs:
     needs: [release_mac_13, release_mac_14, release_mac_15]
     uses: oxen-ai/homebrew-oxen/.github/workflows/update-formula.yml@main
     with:
-      token: ${{ secrets.HOMEBREW_DEPLOY_PAT }}
       version: ${{ github.ref_name != '' && startsWith(github.ref_name, 'v') }}
+    secrets:
+      token: ${{ secrets.HOMEBREW_DEPLOY_PAT }}
 
   release_homebrew_oxen_server:
     permissions:
@@ -540,8 +541,9 @@ jobs:
     needs: [release_mac_13, release_mac_14, release_mac_15]
     uses: oxen-ai/homebrew-oxen-server/.github/workflows/update-formula.yml@main
     with:
-      token: ${{ secrets.HOMEBREW_DEPLOY_PAT }}
       version: ${{ github.ref_name != '' && startsWith(github.ref_name, 'v') }}
+    secrets:
+      token: ${{ secrets.HOMEBREW_DEPLOY_PAT }}
 
   stop-self-hosted-runner:
     name: Stop self-hosted EC2 runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.83.0 as builder
+FROM rust:1.84.1 as builder
 
 USER root
 RUN apt-get update

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.84.0"  
+channel = "1.84.1"  

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.84.1"  
+channel = "1.84.1"

--- a/src/cli/src/cmd/workspace/create.rs
+++ b/src/cli/src/cmd/workspace/create.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use clap::{Arg, ArgMatches, Command};
 
+use colored::Colorize;
 use liboxen::error::OxenError;
 use liboxen::model::LocalRepository;
 use liboxen::{api, repositories};
@@ -62,8 +63,21 @@ impl RunCmd for WorkspaceCreateCmd {
             &name,
         )
         .await?;
-
-        println!("{}", workspace.id);
+        match workspace.status.as_str() {
+            "resource_created" => {
+                println!("{}", "Workspace created successfully!".green().bold());
+            }
+            "resource_found" => {
+                println!("{}", "Workspace already exists".yellow().bold());
+            }
+            other => {
+                println!(
+                    "{}",
+                    format!("Unexpected workspace status: {}", other).red()
+                );
+            }
+        }
+        println!("{} {}", "Workspace ID:".green().bold(), workspace.id.bold());
 
         Ok(())
     }

--- a/src/cli/src/cmd/workspace/delete.rs
+++ b/src/cli/src/cmd/workspace/delete.rs
@@ -16,23 +16,50 @@ impl RunCmd for WorkspaceDeleteCmd {
     }
 
     fn args(&self) -> Command {
-        Command::new(NAME).about("Deletes a workspace").arg(
-            Arg::new("id")
-                .required(true)
-                .help("The id of the workspace to delete"),
-        )
+        Command::new(NAME)
+            .about("Deletes a workspace")
+            .arg(
+                Arg::new("workspace-id")
+                    .long("workspace-id")
+                    .short('w')
+                    .required_unless_present("workspace-name")
+                    .help("The workspace ID of the workspace")
+                    .conflicts_with("workspace-name"),
+            )
+            .arg(
+                Arg::new("workspace-name")
+                    .long("workspace-name")
+                    .short('n')
+                    .required_unless_present("workspace-id")
+                    .help("The name of the workspace")
+                    .conflicts_with("workspace-id"),
+            )
+            .arg_required_else_help(true)
     }
 
     async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
         let repo = LocalRepository::from_current_dir()?;
+        let remote_repo = api::client::repositories::get_default_remote(&repo).await?;
+        let workspace_name = args.get_one::<String>("workspace-name");
+        let workspace_id = args.get_one::<String>("workspace-id");
 
-        let Some(id) = args.get_one::<String>("id") else {
-            return Err(OxenError::basic_str("Must supply id"));
+        let workspace_identifier = match workspace_id {
+            Some(id) => id,
+            None => {
+                // If no ID is provided, try to get the workspace by name
+                if let Some(name) = workspace_name {
+                    name
+                } else {
+                    return Err(OxenError::basic_str(
+                        "Either workspace-id or workspace-name must be provided.",
+                    ));
+                }
+            }
         };
 
-        let remote_repo = api::client::repositories::get_default_remote(&repo).await?;
-        api::client::workspaces::delete(&remote_repo, &id).await?;
-
+        // Now call the delete API using the resolved workspace id.
+        api::client::workspaces::delete(&remote_repo, &workspace_identifier).await?;
+        println!("Workspace '{}' deleted successfully", workspace_identifier);
         Ok(())
     }
 }

--- a/src/lib/src/api/client/repositories.rs
+++ b/src/lib/src/api/client/repositories.rs
@@ -727,12 +727,16 @@ mod tests {
 
             // List the files in the repo
             let readme =
-                api::client::entries::get_entry(&repository, "README", DEFAULT_BRANCH_NAME).await?;
+                api::client::entries::get_entry(&repository, "README", DEFAULT_BRANCH_NAME)
+                    .await?
+                    .unwrap();
             let csv = api::client::entries::get_entry(&repository, "data.csv", DEFAULT_BRANCH_NAME)
-                .await?;
+                .await?
+                .unwrap();
             let png =
                 api::client::entries::get_entry(&repository, "image.png", DEFAULT_BRANCH_NAME)
-                    .await?;
+                    .await?
+                    .unwrap();
 
             assert_eq!(readme.filename, "README");
             assert_eq!(csv.filename, "data.csv");

--- a/src/lib/src/api/client/workspaces.rs
+++ b/src/lib/src/api/client/workspaces.rs
@@ -541,13 +541,8 @@ mod tests {
                 author: "Test User".to_string(),
                 email: "test@oxen.ai".to_string(),
             };
-            api::client::workspaces::commit(
-                &remote_repo,
-                DEFAULT_BRANCH_NAME,
-                workspace_id,
-                &body,
-            )
-            .await?;
+            api::client::workspaces::commit(&remote_repo, DEFAULT_BRANCH_NAME, workspace_id, &body)
+                .await?;
             let get_result = api::client::workspaces::get(&remote_repo, &workspace_id).await?;
 
             assert!(get_result.is_none());

--- a/src/lib/src/api/client/workspaces.rs
+++ b/src/lib/src/api/client/workspaces.rs
@@ -544,7 +544,7 @@ mod tests {
             api::client::workspaces::commit(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,
-                &workspace_id,
+                workspace_id,
                 &body,
             )
             .await?;
@@ -583,7 +583,7 @@ mod tests {
             api::client::workspaces::commit(
                 &remote_repo,
                 DEFAULT_BRANCH_NAME,
-                &workspace_name,
+                workspace_name,
                 &body,
             )
             .await?;

--- a/src/lib/src/api/client/workspaces.rs
+++ b/src/lib/src/api/client/workspaces.rs
@@ -39,11 +39,12 @@ pub async fn get(
     let client = client::new_for_url(&url)?;
     let res = client.get(&url).send().await?;
     let body_result = client::parse_json_body(&url, res).await;
-    
-    let workspace = body_result.ok()
+
+    let workspace = body_result
+        .ok()
         .and_then(|body| serde_json::from_str::<WorkspaceResponseView>(&body).ok())
         .map(|val| val.workspace);
-        
+
     Ok(workspace)
 }
 
@@ -227,7 +228,10 @@ mod tests {
 
             let workspace = get(&remote_repo, &workspace_id).await?;
             assert!(workspace.is_some());
-            assert_eq!(workspace.as_ref().unwrap().name, Some(workspace_name.to_string()));
+            assert_eq!(
+                workspace.as_ref().unwrap().name,
+                Some(workspace_name.to_string())
+            );
             assert_eq!(workspace.as_ref().unwrap().id, workspace_id);
 
             let workspace = get_by_name(&remote_repo, &workspace_name).await?;

--- a/src/lib/src/core/v_latest/workspaces/commit.rs
+++ b/src/lib/src/core/v_latest/workspaces/commit.rs
@@ -101,6 +101,15 @@ pub fn commit(
 
     // Cleanup workspace on commit
     repositories::workspaces::delete(workspace)?;
+    if let Some(workspace_name) = &workspace.name {
+        repositories::workspaces::create_with_name(
+            &workspace.base_repo,
+            &commit,
+            workspace.id.clone(),
+            Some(workspace_name.clone()),
+            true,
+        )?;
+    }
 
     Ok(commit)
 }

--- a/src/lib/src/model/workspace.rs
+++ b/src/lib/src/model/workspace.rs
@@ -10,7 +10,7 @@ use crate::util;
 pub struct WorkspaceConfig {
     pub workspace_commit_id: String,
     pub is_editable: bool,
-    pub workspace_name: String,
+    pub workspace_name: Option<String>,
     pub workspace_id: Option<String>,
 }
 

--- a/src/lib/src/repositories/workspaces.rs
+++ b/src/lib/src/repositories/workspaces.rs
@@ -194,9 +194,7 @@ fn check_existing_workspace_name(
     workspace: &Workspace,
     workspace_name: &str,
 ) -> Result<(), OxenError> {
-    if workspace.name == Some(workspace_name.to_string())
-        || *workspace_name == workspace.id
-    {
+    if workspace.name == Some(workspace_name.to_string()) || *workspace_name == workspace.id {
         return Err(OxenError::basic_str(format!(
             "A workspace with the name {} already exists",
             workspace_name

--- a/src/lib/src/repositories/workspaces.rs
+++ b/src/lib/src/repositories/workspaces.rs
@@ -130,7 +130,7 @@ pub fn create_with_name(
     // Check for existing non-editable workspaces on the same commit
     for workspace in workspaces {
         if !is_editable {
-            check_non_editable_workspace(&workspace, &commit)?;
+            check_non_editable_workspace(&workspace, commit)?;
         }
         if let Some(workspace_name) = workspace_name.clone() {
             check_existing_workspace_name(&workspace, &workspace_name)?;
@@ -195,7 +195,7 @@ fn check_existing_workspace_name(
     workspace_name: &str,
 ) -> Result<(), OxenError> {
     if workspace.name == Some(workspace_name.to_string())
-        || workspace_name.to_string() == workspace.id
+        || *workspace_name == workspace.id
     {
         return Err(OxenError::basic_str(format!(
             "A workspace with the name {} already exists",

--- a/src/lib/src/repositories/workspaces.rs
+++ b/src/lib/src/repositories/workspaces.rs
@@ -67,7 +67,7 @@ pub fn get_by_dir(
 
     Ok(Workspace {
         id: config.workspace_id.unwrap_or(workspace_id.to_owned()),
-        name: Some(config.workspace_name),
+        name: config.workspace_name,
         base_repo: repo.clone(),
         workspace_repo: LocalRepository::new(workspace_dir)?,
         commit,
@@ -109,7 +109,6 @@ pub fn create_with_name(
     is_editable: bool,
 ) -> Result<Workspace, OxenError> {
     let workspace_id = workspace_id.as_ref();
-    let workspace_name = workspace_name.unwrap_or_else(|| workspace_id.to_string());
     let workspace_id_hash = util::hasher::hash_str_sha256(workspace_id);
     let workspace_dir = Workspace::workspace_dir(base_repo, &workspace_id_hash);
     let oxen_dir = workspace_dir.join(OXEN_HIDDEN_DIR);
@@ -133,7 +132,9 @@ pub fn create_with_name(
         if !is_editable {
             check_non_editable_workspace(&workspace, &commit)?;
         }
-        check_existing_workspace_name(&workspace, &workspace_name)?;
+        if let Some(workspace_name) = workspace_name.clone() {
+            check_existing_workspace_name(&workspace, &workspace_name)?;
+        }
     }
 
     log::debug!("index::workspaces::create Initializing oxen repo! 🐂");
@@ -144,7 +145,7 @@ pub fn create_with_name(
     let workspace_config = WorkspaceConfig {
         workspace_commit_id: commit.id.clone(),
         is_editable,
-        workspace_name: workspace_name.to_string(),
+        workspace_name: workspace_name.clone(),
         workspace_id: Some(workspace_id.to_string()),
     };
 
@@ -171,7 +172,7 @@ pub fn create_with_name(
 
     Ok(Workspace {
         id: workspace_id.to_owned(),
-        name: Some(workspace_name),
+        name: workspace_name,
         base_repo: base_repo.clone(),
         workspace_repo,
         commit: commit.clone(),

--- a/src/lib/src/view/workspaces.rs
+++ b/src/lib/src/view/workspaces.rs
@@ -47,6 +47,14 @@ pub struct WorkspaceResponse {
     pub commit: WorkspaceCommit,
 }
 
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct WorkspaceResponseWithStatus {
+    pub id: String,
+    pub name: Option<String>,
+    pub commit: WorkspaceCommit,
+    pub status: String,
+}
+
 #[derive(Deserialize, Serialize, Debug)]
 pub struct WorkspaceResponseView {
     #[serde(flatten)]

--- a/src/server/src/controllers/workspaces.rs
+++ b/src/server/src/controllers/workspaces.rs
@@ -33,13 +33,25 @@ pub async fn get_or_create(
     };
 
     let Some(branch) = repositories::branches::get_by_name(&repo, &data.branch_name)? else {
-        return Ok(HttpResponse::BadRequest().json(StatusMessage::error(format!("Branch not found: {}", data.branch_name))));
+        return Ok(
+            HttpResponse::BadRequest().json(StatusMessage::error(format!(
+                "Branch not found: {}",
+                data.branch_name
+            ))),
+        );
     };
 
     // Return workspace if it already exists
     let workspace_id = data.workspace_id.clone();
+    let workspace_name = data.name.clone();
+    let workspace_identifier;
+    if let Some(workspace_name) = workspace_name {
+        workspace_identifier = workspace_name;
+    } else {
+        workspace_identifier = workspace_id.clone();
+    }
     log::debug!("get_or_create workspace_id {:?}", workspace_id);
-    if let Ok(workspace) = repositories::workspaces::get(&repo, &workspace_id) {
+    if let Ok(workspace) = repositories::workspaces::get(&repo, &workspace_identifier) {
         return Ok(HttpResponse::Ok().json(WorkspaceResponseView {
             status: StatusMessage::resource_created(),
             workspace: WorkspaceResponse {
@@ -109,7 +121,12 @@ pub async fn create(
     };
 
     let Some(branch) = repositories::branches::get_by_name(&repo, &data.branch_name)? else {
-        return Ok(HttpResponse::BadRequest().json(StatusMessage::error(format!("Branch not found: {}", data.branch_name))));
+        return Ok(
+            HttpResponse::BadRequest().json(StatusMessage::error(format!(
+                "Branch not found: {}",
+                data.branch_name
+            ))),
+        );
     };
 
     let workspace_id = &data.workspace_id;

--- a/src/server/src/controllers/workspaces.rs
+++ b/src/server/src/controllers/workspaces.rs
@@ -95,7 +95,7 @@ pub async fn get(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpEr
     Ok(HttpResponse::Ok().json(WorkspaceResponseView {
         status: StatusMessage::resource_created(),
         workspace: WorkspaceResponse {
-            id: workspace_id,
+            id: workspace.id,
             name: workspace.name,
             commit: workspace.commit.into(),
         },

--- a/src/server/src/controllers/workspaces.rs
+++ b/src/server/src/controllers/workspaces.rs
@@ -93,7 +93,7 @@ pub async fn get(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpEr
     let workspace = repositories::workspaces::get(&repo, &workspace_id)?;
 
     Ok(HttpResponse::Ok().json(WorkspaceResponseView {
-        status: StatusMessage::resource_created(),
+        status: StatusMessage::resource_found(),
         workspace: WorkspaceResponse {
             id: workspace.id,
             name: workspace.name,

--- a/src/server/src/controllers/workspaces.rs
+++ b/src/server/src/controllers/workspaces.rs
@@ -53,7 +53,7 @@ pub async fn get_or_create(
     log::debug!("get_or_create workspace_id {:?}", workspace_id);
     if let Ok(workspace) = repositories::workspaces::get(&repo, &workspace_identifier) {
         return Ok(HttpResponse::Ok().json(WorkspaceResponseView {
-            status: StatusMessage::resource_created(),
+            status: StatusMessage::resource_found(),
             workspace: WorkspaceResponse {
                 id: workspace_id,
                 name: workspace.name.clone(),

--- a/src/server/src/controllers/workspaces/files.rs
+++ b/src/server/src/controllers/workspaces/files.rs
@@ -83,11 +83,11 @@ pub async fn delete(req: HttpRequest) -> Result<HttpResponse, OxenHttpError> {
     let app_data = app_data(&req)?;
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
-    let user_id = path_param(&req, "workspace_id")?;
+    let workspace_id = path_param(&req, "workspace_id")?;
     let repo = get_repo(&app_data.path, namespace, repo_name)?;
     let path = PathBuf::from(path_param(&req, "path")?);
 
-    let workspace = repositories::workspaces::get(&repo, user_id)?;
+    let workspace = repositories::workspaces::get(&repo, workspace_id)?;
 
     // This may not be in the commit if it's added, so have to parse tabular-ness from the path.
     if util::fs::is_tabular(&path) {


### PR DESCRIPTION
Implement the named workspace mechanism, where named workspaces function similarly to branches. Unlike unnamed workspaces, they remain open after commits, allowing users to reference them in workflows without needing to manually reopen them after each commit.

Workspace names must be unique within a repository and cannot conflict with workspace IDs. This ensures that no two workspaces share the same name or ID in any field.

Workspaces can now be referenced by either name or ID in CLI commands and API endpoints. The workspace_id field can accept either the unique ID or the name of the corresponding workspace, providing greater flexibility in workflows.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced workspace commands now support specifying a workspace by either ID or name for adding, committing, creating, and deleting operations.
  - The CLI now provides clearer, color-coded feedback on workspace creation and status, helping users understand outcomes at a glance.
  - Introduced a new function to retrieve workspaces by name, improving workspace management capabilities.
  - Added support for returning workspace responses with associated status information.
  - New CI workflow job added for RSpec testing on macOS.

- **Bug Fixes**
  - Improved error handling for missing workspace identifiers, ensuring clearer feedback for users.
  - Enhanced error handling for cases where entries or metadata may not exist.

- **Chores**
  - Updated release workflows improve authentication handling and job sequencing during deployment.
  - Updated Rust toolchain version to the latest patch.
  - Updated Dockerfile to use a newer Rust base image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->