### PR TITLE
Fix workspace status call

### DIFF
--- a/src/lib/src/api/client/workspaces.rs
+++ b/src/lib/src/api/client/workspaces.rs
@@ -418,7 +418,7 @@ mod tests {
                     constants::DEFAULT_PAGE_SIZE,
                 )
                 .await?;
-                assert_eq!(remote_status.modified_files.entries.len(), 0);
+                assert_eq!(remote_status.modified_files.entries.len(), 1);
 
                 Ok(repo_dir)
             })

--- a/src/lib/src/api/client/workspaces.rs
+++ b/src/lib/src/api/client/workspaces.rs
@@ -123,7 +123,6 @@ pub async fn create_with_path(
         resource_path: Some(path.to_str().unwrap().to_string()),
         entity_type: Some("user".to_string()),
         name: workspace_name,
-        force: Some(true),
     };
 
     let client = client::new_for_url(&url)?;

--- a/src/lib/src/api/client/workspaces.rs
+++ b/src/lib/src/api/client/workspaces.rs
@@ -409,7 +409,7 @@ mod tests {
                 println!("{:?}", result);
                 assert!(result.is_err());
 
-                // Now status should be empty
+                // Status should have one modified file
                 let remote_status = api::client::workspaces::changes::list(
                     &remote_repo,
                     &workspace_id,

--- a/src/lib/src/api/client/workspaces/data_frames/rows.rs
+++ b/src/lib/src/api/client/workspaces/data_frames/rows.rs
@@ -367,8 +367,8 @@ mod tests {
                 page_size,
             )
             .await?;
-            assert_eq!(entries.added_files.entries.len(), 1);
-            assert_eq!(entries.added_files.total_entries, 1);
+            assert_eq!(entries.modified_files.entries.len(), 1);
+            assert_eq!(entries.modified_files.total_entries, 1);
 
             Ok(remote_repo)
         })
@@ -648,7 +648,7 @@ mod tests {
                     constants::DEFAULT_PAGE_SIZE,
                 )
                 .await?;
-                assert_eq!(status.added_files.entries.len(), 1);
+                assert_eq!(status.modified_files.entries.len(), 1);
 
                 // Delete it
                 let mut delete_opts = DFOpts::empty();
@@ -665,7 +665,7 @@ mod tests {
                     constants::DEFAULT_PAGE_SIZE,
                 )
                 .await?;
-                assert_eq!(status.added_files.entries.len(), 0);
+                assert_eq!(status.modified_files.entries.len(), 0);
 
                 Ok(repo_dir)
             })

--- a/src/lib/src/view/remote_staged_status.rs
+++ b/src/lib/src/view/remote_staged_status.rs
@@ -1,13 +1,11 @@
-use std::{
-    collections::HashMap,
-    path::PathBuf,
-};
+use std::{collections::HashMap, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
 
 use crate::{
     model::{
-        Commit, LocalRepository, MetadataEntry, ModEntry, StagedData, StagedEntry, StagedEntryStatus, SummarizedStagedDirStats
+        Commit, LocalRepository, MetadataEntry, ModEntry, StagedData, StagedEntry,
+        StagedEntryStatus, SummarizedStagedDirStats,
     },
     util,
 };
@@ -109,10 +107,11 @@ impl RemoteStagedStatus {
         repo: &LocalRepository,
         entries: &HashMap<PathBuf, StagedEntry>,
     ) -> Vec<MetadataEntry> {
-        let filtered_entries: HashMap<PathBuf, StagedEntry> = entries.iter()
+        let filtered_entries: HashMap<PathBuf, StagedEntry> = entries
+            .iter()
             .filter(|(_, entry)| entry.status == StagedEntryStatus::Added)
             .map(|(path, entry)| (path.clone(), entry.clone()))
-            .collect();        
+            .collect();
         RemoteStagedStatus::iter_to_meta_entry(repo, filtered_entries.keys())
     }
 
@@ -120,7 +119,8 @@ impl RemoteStagedStatus {
         repo: &LocalRepository,
         entries: &HashMap<PathBuf, StagedEntry>,
     ) -> Vec<MetadataEntry> {
-        let filtered_entries: HashMap<PathBuf, StagedEntry> = entries.iter()
+        let filtered_entries: HashMap<PathBuf, StagedEntry> = entries
+            .iter()
             .filter(|(_, entry)| entry.status == StagedEntryStatus::Modified)
             .map(|(path, entry)| (path.clone(), entry.clone()))
             .collect();

--- a/src/lib/src/view/remote_staged_status.rs
+++ b/src/lib/src/view/remote_staged_status.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     path::PathBuf,
 };
 
@@ -7,8 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     model::{
-        Commit, LocalRepository, MetadataEntry, ModEntry, StagedData, StagedEntry,
-        SummarizedStagedDirStats,
+        Commit, LocalRepository, MetadataEntry, ModEntry, StagedData, StagedEntry, StagedEntryStatus, SummarizedStagedDirStats
     },
     util,
 };
@@ -92,7 +91,7 @@ impl RemoteStagedStatus {
         let added_entries: Vec<MetadataEntry> =
             RemoteStagedStatus::added_to_meta_entry(repo, &staged.staged_files);
         let modified_entries: Vec<MetadataEntry> =
-            RemoteStagedStatus::modified_to_meta_entry(repo, &staged.modified_files);
+            RemoteStagedStatus::modified_to_meta_entry(repo, &staged.staged_files);
 
         let added_paginated =
             RemoteStagedStatus::paginate_entries(added_entries, page_num, page_size);
@@ -110,14 +109,22 @@ impl RemoteStagedStatus {
         repo: &LocalRepository,
         entries: &HashMap<PathBuf, StagedEntry>,
     ) -> Vec<MetadataEntry> {
-        RemoteStagedStatus::iter_to_meta_entry(repo, entries.keys())
+        let filtered_entries: HashMap<PathBuf, StagedEntry> = entries.iter()
+            .filter(|(_, entry)| entry.status == StagedEntryStatus::Added)
+            .map(|(path, entry)| (path.clone(), entry.clone()))
+            .collect();        
+        RemoteStagedStatus::iter_to_meta_entry(repo, filtered_entries.keys())
     }
 
     fn modified_to_meta_entry(
         repo: &LocalRepository,
-        entries: &HashSet<PathBuf>,
+        entries: &HashMap<PathBuf, StagedEntry>,
     ) -> Vec<MetadataEntry> {
-        RemoteStagedStatus::iter_to_meta_entry(repo, entries.iter())
+        let filtered_entries: HashMap<PathBuf, StagedEntry> = entries.iter()
+            .filter(|(_, entry)| entry.status == StagedEntryStatus::Modified)
+            .map(|(path, entry)| (path.clone(), entry.clone()))
+            .collect();
+        RemoteStagedStatus::iter_to_meta_entry(repo, filtered_entries.keys())
     }
 
     fn iter_to_meta_entry<'a, I: Iterator<Item = &'a PathBuf>>(

--- a/src/lib/src/view/workspaces.rs
+++ b/src/lib/src/view/workspaces.rs
@@ -12,7 +12,6 @@ pub struct NewWorkspace {
     pub resource_path: Option<String>,
     pub entity_type: Option<String>,
     pub name: Option<String>,
-    pub force: Option<bool>,
 }
 
 // HACK to get this to work with our hub where we don't keep parent_ids 🤦‍♂️


### PR DESCRIPTION
We weren't displaying modified files in the workspace status call, this fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the handling of staged file changes by introducing a structured approach for categorizing new versus modified files, enhancing accuracy in status reporting.
	- Removed the `force` field from the `NewWorkspace` struct, altering the workspace creation process to rely on default behavior without the option to force creation.
- **Tests**
	- Updated test assertions to reflect changes in tracking modified files instead of added files within the workspace's data frame operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->