### PR TITLE
Feat/windows cli tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,8 +202,14 @@ jobs:
           cmd /c "START /B .\target\debug\oxen-server.exe start"
           cargo test -- --test-threads=1
 
-  rspec_tests:
-    name: RSpec CLI Tests
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: oxen-binary-windows
+          path: target/debug/oxen*
+
+  rpsec_tests_macos:
+    name: MacOS RSpec CLI Tests
     needs: [test_macos]
     runs-on: macos-latest
 
@@ -218,6 +224,7 @@ jobs:
           brew update
           brew install pkg-config || brew upgrade pkg-config
           brew install ffmpeg imagemagick ruby
+
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -246,6 +253,42 @@ jobs:
       - name: Run RSpec tests
         env:
           PATH: ${{ env.PATH }}:${{ github.workspace }}/target/debug
+        working-directory: ./cli-test
+        run: |
+          bundle exec rspec spec/test_cases/**/tests.rb
+
+  rspec_test_windows:
+    name: Windows RSpec CLI Tests
+    needs: [test_windows]
+    runs-on: windows-latest
+
+    env:
+      OXEN_API_KEY: ${{ secrets.DEV_OXEN_API_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: oxen-binary-windows
+          path: target/debug
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0'
+          bundler-cache: true
+
+      - name: Install Ruby dependencies
+        working-directory: ./cli-test
+        run: |
+          bundle config path vendor/bundle
+          bundle install
+
+      - name: Run RSpec tests
+        env:
+          PATH: ${{ env.PATH }};${{ github.workspace }}/target/debug
         working-directory: ./cli-test
         run: |
           bundle exec rspec spec/test_cases/**/tests.rb

--- a/cli-test/spec/test_cases/add_schema/tests.rb
+++ b/cli-test/spec/test_cases/add_schema/tests.rb
@@ -1,4 +1,7 @@
 require 'spec_helper'
+require 'json'
+require 'shellwords'
+require 'open3'
 
 RSpec.describe 'schemas add - test relative paths', type: :aruba do
   before(:each) do
@@ -6,55 +9,79 @@ RSpec.describe 'schemas add - test relative paths', type: :aruba do
   end
 
   after(:each) do
-    run_command_and_stop('rm -rf test-schema-paths')
+    FileUtils.rm_rf('test-schema-paths')
+
   end
 
   it 'tests oxen schemas add with relative paths from subdirectories' do
-    directory_path = 'tmp/aruba/test-schema-paths'
-
+  
     # Setup base repo
-    run_command_and_stop('mkdir test-schema-paths')
-    cd 'test-schema-paths'
-    run_command_and_stop('oxen init')
+    directory_path = File.join('tmp', 'aruba', 'test-relative-dirs')
+    FileUtils.mkdir_p(directory_path)
+
+    # Capitalize path
+    directory_path = File.join('tmp', 'Aruba', 'test-relative-dirs')
+    Dir.chdir(directory_path)
+
+    run_system_command('oxen init')
 
     # Create nested directory structure
-    run_command_and_stop('mkdir -p data/frames')
+    data_path = File.join('data', 'frames')
+    FileUtils.mkdir_p(data_path)
 
-    csv_path = File.join(directory_path, 'root.csv')
+    csv_path = File.join('root.csv')
     File.open(csv_path, 'w') do |file|
       file.puts 'id,image,description'
       file.puts '1,/path/to/img1.jpg,test image 1'
       file.puts '2,/path/to/img2.jpg,test image 2'
     end
 
-    run_command_and_stop('oxen add root.csv')
-    run_command_and_stop('oxen commit -m "adding root csv"')
+    run_system_command('oxen add root.csv') 
+    run_system_command('oxen commit -m "adding root csv"') 
 
 
     # Create a CSV file in the nested directory
-    csv_path = File.join(directory_path, 'data/frames/test.csv')
+    csv_path = File.join(data_path, 'test.csv')
     File.open(csv_path, 'w') do |file|
       file.puts 'id,image,description'
       file.puts '1,/path/to/img1.jpg,test image 1'
       file.puts '2,/path/to/img2.jpg,test image 2'
     end
 
-    cd 'data/frames'
+    Dir.chdir(data_path)
+
 
     # Add and commit the CSV file
-    run_command_and_stop('oxen add test.csv')
-    run_command_and_stop('oxen commit -m "adding test csv"')
+    run_system_command('oxen add test.csv') 
+    run_system_command('oxen commit -m "adding test csv"') 
 
-    run_command_and_stop('oxen schemas add test.csv -c image -m \'{"_oxen": {"render": {"func": "image"}}}\'')
-    run_command_and_stop('oxen schemas add ../../root.csv -c image -m \'{"_oxen": {"render": {"func": "image"}}}\'')
+    # Build command to avoid json-parsing issues
+    metadata = {
+      "_oxen" => {
+        "render" => {
+          "func" => "image"
+        }
+      }
+    }
 
-    # Verify schema changes
-    cd '..'
-    run_command_and_stop('oxen status')
+    json_string = metadata.to_json
+    root_path = File.join('..', '..', 'root.csv')
 
-    # Check for schema changes in status
-    expect(last_command_started).to have_output(/new schema: data\/frames\/test\.csv/)
-    expect(last_command_started).to have_output(/new schema: root\.csv/)
-    expect(last_command_started).to have_output(/Schemas to be committed/)
+    system('oxen', 'schemas', 'add', 'test.csv', '-c', 'image', '-m', json_string) or fail
+    system('oxen', 'schemas', 'add', root_path, '-c', 'image', '-m', json_string) or fail
+ 
+    # Verify schema changes 
+    status_output = Open3.capture2('oxen status')
+    puts status_output
+    output_lines = status_output[0].split("\n")
+    schema_line = output_lines[10]
+
+    expect(schema_line).to eq("Schemas to be committed") 
+
+
+    # Return to cli-test 
+    parent_path = File.join('..', '..', '..', '..')
+    Dir.chdir(parent_path)
+
   end
 end

--- a/src/cli/src/cmd/schemas/add.rs
+++ b/src/cli/src/cmd/schemas/add.rs
@@ -7,6 +7,7 @@ use liboxen::model::LocalRepository;
 use liboxen::repositories;
 
 use crate::cmd::RunCmd;
+use crate::util;
 pub const NAME: &str = "add";
 
 pub struct SchemasAddCmd;
@@ -51,13 +52,7 @@ impl RunCmd for SchemasAddCmd {
                     OxenError::basic_str(format!("Failed to get current directory: {}", e))
                 })?;
                 let path = current_dir.join(p);
-                path.canonicalize().map_err(|e| {
-                    OxenError::basic_str(format!(
-                        "Failed to resolve path '{}': {}",
-                        path.display(),
-                        e
-                    ))
-                })
+                util::fs::canonicalize(&path).or_else(|_| Ok(path))
             })
             .transpose()?;
 


### PR DESCRIPTION
Makes the RSpec tests system independent, and implements a module in .github/workflows/ci.yml to run them on windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Enhanced CI workflows by rolling out separate testing jobs for Windows and macOS with improved artifact management.
- **Tests**
	- Streamlined several test cases by replacing shell commands with native file utilities and a unified command execution approach for greater clarity and maintainability.
- **Bug Fixes**
	- Refined error handling in the schema addition command to allow smoother processing when file path resolution encounters issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->