### PR TITLE
Fix/checkout should not overwrite modified

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3426,6 +3426,7 @@ dependencies = [
  "walkdir",
  "words-count",
  "xxhash-rust",
+ "zip",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ lazy_static = "1.4.0"
 lofty = "0.21.0"
 log = "0.4.20"
 lru = "0.12.0"
-# magick_rust = "0.18.0"
+mockito = "1.1.0"
 mp4 = "0.14.0"
 mime = "0.3.17"
 minus = { version = "5.4.0", features = ["static_output", "search"] }
@@ -142,7 +142,6 @@ uuid = { version = "1.4.1", features = ["serde", "v4"] }
 walkdir = "2.5.0"
 words-count = "0.1.6"
 xxhash-rust = { version = "0.8.7", features = ["xxh3"] }
-mockito = "1.1.0"
 zip = "2.2.0"
 
 

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -73,6 +73,7 @@ log = "0.4.17"
 lru = "0.12.0"
 # magick_rust = "0.18.0"
 minus = { version = "5.3.1", features = ["static_output", "search"] }
+mockito = "1.1.0"
 mp4 = "0.14.0"
 nom = "7.1.1"
 num_cpus = "1.13.1"
@@ -128,7 +129,7 @@ uuid = { version = "1.3.3", features = ["serde", "v4"] }
 walkdir = "2.5.0"
 words-count = "0.1.5"
 xxhash-rust = { version = "0.8.5", features = ["xxh3"] }
-mockito = "1.1.0"
+zip = "2.2.0"
 
 [lib]
 name = "liboxen"

--- a/src/lib/src/api/client/tree.rs
+++ b/src/lib/src/api/client/tree.rs
@@ -608,13 +608,8 @@ mod tests {
             let remote_repo_clone = remote_repo.clone();
             let download_repo_path = local_repo.path.join("download_repo_test_1");
             let download_local_repo = repositories::init(&download_repo_path)?;
-            let fetch_opts = FetchOpts {
-                subtree_paths: None,
-                depth: None,
-                all: false,
-                remote: remote_repo_clone.url().to_string(),
-                branch: "main".to_string(),
-            };
+            let mut fetch_opts = FetchOpts::new();
+            fetch_opts.remote = remote_repo_clone.url().to_string();
             api::client::tree::download_trees_from(
                 &download_local_repo,
                 &remote_repo_clone,
@@ -650,6 +645,7 @@ mod tests {
                 all: false,
                 remote: remote_repo_clone.url().to_string(),
                 branch: "main".to_string(),
+                should_update_branch_head: true,
             };
             api::client::tree::download_trees_from(
                 &download_local_repo_2,

--- a/src/lib/src/core/df/tabular.rs
+++ b/src/lib/src/core/df/tabular.rs
@@ -847,7 +847,7 @@ fn sniff_db_csv_delimiter(path: impl AsRef<Path>, opts: &DFOpts) -> Result<u8, O
 pub fn read_df(path: impl AsRef<Path>, opts: DFOpts) -> Result<DataFrame, OxenError> {
     let path = path.as_ref();
     if !path.exists() {
-        return Err(OxenError::entry_does_not_exist(path));
+        return Err(OxenError::path_does_not_exist(path));
     }
 
     let extension = path.extension().and_then(OsStr::to_str);

--- a/src/lib/src/core/merge/node_merge_conflict_writer.rs
+++ b/src/lib/src/core/merge/node_merge_conflict_writer.rs
@@ -40,6 +40,7 @@ pub fn write_conflicts_to_disk(
 
     for conflict in conflicts.iter() {
         let (_, base_path) = &conflict.base_entry;
+        log::debug!("writing conflict to db: {:?}", base_path);
         let key = base_path.to_str().unwrap();
         let key_bytes = key.as_bytes();
         let val_json = serde_json::to_string(&conflict)?;

--- a/src/lib/src/core/v_latest/merge.rs
+++ b/src/lib/src/core/v_latest/merge.rs
@@ -415,23 +415,11 @@ fn fast_forward_merge(
         &mut cannot_overwrite_entries,
     )?;
     // If there are no conflicts, restore the entries
-    log::debug!(
-        "r_ff_merge_commit cannot_overwrite_entries {:?}",
-        cannot_overwrite_entries.len()
-    );
     if cannot_overwrite_entries.is_empty() {
-        log::debug!(
-            "r_ff_merge_commit restoring {} entries!",
-            entries_to_restore.len()
-        );
         for entry in entries_to_restore.iter() {
             restore::restore_file(repo, &entry.file_node, &entry.path)?;
         }
     } else {
-        log::debug!(
-            "r_ff_merge_commit cannot_overwrite_entries {:?}",
-            cannot_overwrite_entries
-        );
         // If there are conflicts, return an error without restoring anything
         return Err(OxenError::cannot_overwrite_files(&cannot_overwrite_entries));
     }
@@ -448,23 +436,11 @@ fn fast_forward_merge(
     )?;
 
     // If there are no conflicts, remove the entries
-    log::debug!(
-        "r_ff_merge_commit cannot_remove_entries {:?}",
-        cannot_remove_entries.len()
-    );
     if cannot_remove_entries.is_empty() {
-        log::debug!(
-            "r_ff_merge_commit removing {} entries!",
-            entries_to_remove.len()
-        );
         for entry in entries_to_remove.iter() {
             util::fs::remove_file(&entry.path)?;
         }
     } else {
-        log::debug!(
-            "r_ff_merge_commit cannot_remove_entries {:?}",
-            cannot_remove_entries
-        );
         // If there are conflicts, return an error without removing anything
         return Err(OxenError::cannot_overwrite_files(&cannot_remove_entries));
     }
@@ -937,20 +913,11 @@ pub fn find_merge_conflicts(
     log::debug!("three_way_merge conflicts.len() {}", conflicts.len());
 
     // If there are no conflicts, restore the entries
-    log::debug!(
-        "three_way_merge cannot_overwrite_entries {:?}",
-        cannot_overwrite_entries.len()
-    );
     if cannot_overwrite_entries.is_empty() {
-        log::debug!("three_way_merge restoring entries!");
         for entry in entries_to_restore.iter() {
             restore::restore_file(repo, &entry.file_node, &entry.path)?;
         }
     } else {
-        log::debug!(
-            "three_way_merge cannot_overwrite_entries {:?}",
-            cannot_overwrite_entries
-        );
         // If there are conflicts, return an error without restoring anything
         return Err(OxenError::cannot_overwrite_files(&cannot_overwrite_entries));
     }

--- a/src/lib/src/error.rs
+++ b/src/lib/src/error.rs
@@ -9,6 +9,7 @@ use std::fmt;
 use std::io;
 use std::num::ParseIntError;
 use std::path::Path;
+use std::path::PathBuf;
 use std::path::StripPrefixError;
 
 use crate::model::Branch;
@@ -445,6 +446,19 @@ impl OxenError {
             path.as_ref()
         );
         OxenError::basic_str(err)
+    }
+
+    pub fn cannot_overwrite_files(paths: &[PathBuf]) -> OxenError {
+        let paths_str = paths
+            .iter()
+            .map(|p| p.to_string_lossy().to_string())
+            .collect::<Vec<String>>()
+            .join("\n  ");
+
+        OxenError::basic_str(format!(
+            "\nError: your local changes to the following files would be overwritten. Please commit the following changes before continuing:\n\n  {}\n",
+            paths_str
+        ))
     }
 
     pub fn entry_does_not_exist_in_commit(

--- a/src/lib/src/opts/fetch_opts.rs
+++ b/src/lib/src/opts/fetch_opts.rs
@@ -15,6 +15,8 @@ pub struct FetchOpts {
     // If true, recursively clones the whole repository history
     // by default, only the head commit is cloned to save time and disk space
     pub all: bool,
+    // Defaults to true, but on pull we want to only update the branch head if there are no conflicts
+    pub should_update_branch_head: bool,
 }
 
 impl Default for FetchOpts {
@@ -32,6 +34,7 @@ impl FetchOpts {
             subtree_paths: None,
             depth: None,
             all: false,
+            should_update_branch_head: true,
         }
     }
 

--- a/src/lib/src/repositories/checkout.rs
+++ b/src/lib/src/repositories/checkout.rs
@@ -45,6 +45,7 @@ pub async fn checkout(
         let previous_head_commit = repositories::commits::head_commit_maybe(repo)?;
         repositories::branches::checkout_commit_from_commit(repo, &commit, &previous_head_commit)
             .await?;
+        repositories::branches::update(repo, value, &commit.id)?;
         repositories::branches::set_head(repo, value)?;
         Ok(None)
     }

--- a/src/lib/src/repositories/diffs.rs
+++ b/src/lib/src/repositories/diffs.rs
@@ -137,7 +137,7 @@ pub fn diff(
         let committed_file = util::fs::version_path_from_node(&repository, &hash, &path_1);
         // log::debug!("committed file: {:?}", committed_file);
         let result =
-            repositories::diffs::diff_files(path_1, committed_file, keys, targets, vec![])?;
+            repositories::diffs::diff_files(committed_file, path_1, keys, targets, vec![])?;
 
         return Ok(result);
     };

--- a/src/lib/src/repositories/pull.rs
+++ b/src/lib/src/repositories/pull.rs
@@ -52,6 +52,7 @@ mod tests {
     use crate::opts::CloneOpts;
     use crate::opts::DFOpts;
     use crate::opts::FetchOpts;
+    use crate::opts::RmOpts;
     use crate::repositories;
     use crate::test;
     use crate::util;
@@ -827,7 +828,8 @@ mod tests {
                 assert!(result.is_err());
 
                 // Pull
-                repositories::pull(&user_b_repo).await?;
+                let result = repositories::pull(&user_b_repo).await;
+                assert!(result.is_err());
 
                 // Make sure it's not a full clone
                 assert_eq!(user_b_repo.depth(), Some(2));
@@ -913,7 +915,8 @@ mod tests {
                 assert!(result.is_err());
 
                 // Pull
-                repositories::pull(&user_b_repo).await?;
+                let result = repositories::pull(&user_b_repo).await;
+                assert!(result.is_err());
 
                 // Make sure it's not a full clone
                 assert_eq!(user_b_repo.depth(), Some(1));
@@ -995,7 +998,8 @@ mod tests {
                     assert!(result.is_err());
 
                     // Pull
-                    repositories::pull(&user_b_repo).await?;
+                    let result = repositories::pull(&user_b_repo).await;
+                    assert!(result.is_err());
 
                     // Check for merge conflict
                     let status = repositories::status(&user_b_repo)?;
@@ -1067,7 +1071,7 @@ mod tests {
                     // Pull changes without pushing first - fine since no conflict
                     repositories::pull(&user_b_repo).await?;
 
-                    // Get new  head commit of the pulled repo
+                    // Get new head commit of the pulled repo
                     repositories::commits::head_commit(&user_b_repo)?;
 
                     // Make sure we now have all three files
@@ -1161,13 +1165,22 @@ mod tests {
                     )?;
 
                     // Pull changes
+                    let result = repositories::pull(&user_b_repo).await;
+
+                    // There should be a conflict with file_2
+                    assert!(result.is_err());
+
+                    // Remove the file that is causing the conflict
+                    util::fs::remove_file(user_b_repo.path.join(local_file_2))?;
+
+                    // Pull again should succeed
                     repositories::pull(&user_b_repo).await?;
 
                     // Files from the other commit successfully pulled
                     assert!(user_b_repo.path.join(file_1).exists());
                     assert!(user_b_repo.path.join(file_2).exists());
 
-                    // Bad local data successfully overwritten on pull (should we flag conflict here?)
+                    // File 2 should be same as the remote file
                     let local_file_2_contents =
                         std::fs::read_to_string(user_b_repo.path.join(local_file_2))?;
                     assert_eq!(local_file_2_contents, "File 2");
@@ -1573,7 +1586,7 @@ mod tests {
                 let new_file_path = user_a_repo.path.join(new_file);
                 test::write_txt_file_to_path(&new_file_path, "hello from user a file")?;
 
-                // Pull again
+                // Pull changes
                 let result = repositories::pull(&user_a_repo).await;
 
                 // Assert that it failed
@@ -1582,6 +1595,12 @@ mod tests {
                 // Make sure that the local changes are not overwritten
                 let content = util::fs::read_from_path(&new_file_path)?;
                 assert_eq!(content, "hello from user a file");
+
+                // Pull again
+                let result = repositories::pull(&user_a_repo).await;
+
+                // Assert that it failed
+                assert!(result.is_err());
 
                 Ok(user_a_repo_dir_copy)
             })
@@ -1597,7 +1616,8 @@ mod tests {
     you do not want to overwrite when pulling from the remote
     */
     #[tokio::test]
-    async fn test_pull_does_not_overwrite_modified_files() -> Result<(), OxenError> {
+    async fn test_pull_does_not_overwrite_modified_files_after_remote_modification(
+    ) -> Result<(), OxenError> {
         // Push the Remote Repo
         test::run_select_data_sync_remote("README.md", |_, remote_repo| async move {
             let remote_repo_copy = remote_repo.clone();
@@ -1634,6 +1654,220 @@ mod tests {
                 let modified_file = "README.md";
                 let modified_file_path = user_a_repo.path.join(modified_file);
                 test::write_txt_file_to_path(&modified_file_path, "# User A README")?;
+
+                // Pull again
+                let result = repositories::pull(&user_a_repo).await;
+
+                // Assert that it failed
+                assert!(result.is_err());
+
+                // Make sure that the local changes are not overwritten
+                let content = util::fs::read_from_path(&modified_file_path)?;
+                assert_eq!(content, "# User A README");
+
+                Ok(user_a_repo_dir_copy)
+            })
+            .await?;
+
+            Ok(remote_repo_copy)
+        })
+        .await
+    }
+
+    /*
+    This one tests modifying the file on the local before it is modified on the remote
+    Regardless, the local file should not be overwritten
+    */
+    #[tokio::test]
+    async fn test_pull_does_not_overwrite_modified_files_before_remote_modification(
+    ) -> Result<(), OxenError> {
+        // Push the Remote Repo
+        test::run_select_data_sync_remote("README.md", |_, remote_repo| async move {
+            let remote_repo_copy = remote_repo.clone();
+            test::run_empty_dir_test_async(|user_a_repo_dir| async move {
+                let user_a_repo_dir_copy = user_a_repo_dir.join("repo_a");
+                let user_a_repo =
+                    repositories::clone_url(&remote_repo.remote.url, &user_a_repo_dir_copy).await?;
+
+                // Make some changes locally
+                let modified_file = "README.md";
+                let modified_file_path = user_a_repo.path.join(modified_file);
+                test::write_txt_file_to_path(&modified_file_path, "# User A README")?;
+
+                // Make a couple commits on the remote
+                test::run_empty_dir_test_async(|user_b_repo_dir| async move {
+                    let user_b_repo_dir_copy = user_b_repo_dir.join("repo_b");
+
+                    let user_b_repo =
+                        repositories::clone_url(&remote_repo.remote.url, &user_b_repo_dir_copy)
+                            .await?;
+
+                    // Edit the README to cause a conflict
+                    let readme_path = user_b_repo.path.join("README.md");
+                    test::write_txt_file_to_path(
+                        &readme_path,
+                        "Hello from another user b README :(",
+                    )?;
+                    repositories::add(&user_b_repo, &readme_path)?;
+                    repositories::commit(&user_b_repo, "Updating the README on the remote")?;
+
+                    // Push the remote
+                    repositories::push(&user_b_repo).await?;
+
+                    Ok(user_b_repo_dir_copy)
+                })
+                .await?;
+
+                // Pull again
+                let result = repositories::pull(&user_a_repo).await;
+
+                // Assert that it failed
+                assert!(result.is_err());
+
+                // Make sure that the local changes are not overwritten
+                let content = util::fs::read_from_path(&modified_file_path)?;
+                assert_eq!(content, "# User A README");
+
+                // Pull again
+                let result = repositories::pull(&user_a_repo).await;
+
+                // Assert that it failed
+                assert!(result.is_err());
+
+                // Make sure that the local changes are not overwritten
+                let content = util::fs::read_from_path(&modified_file_path)?;
+                assert_eq!(content, "# User A README");
+
+                Ok(user_a_repo_dir_copy)
+            })
+            .await?;
+
+            Ok(remote_repo_copy)
+        })
+        .await
+    }
+
+    /*
+    Modify a different file on the remote, and modify the readme locally, and make sure that the local readme is not overwritten
+    */
+    #[tokio::test]
+    async fn test_pull_does_not_overwrite_modified_files_after_modifying_different_file(
+    ) -> Result<(), OxenError> {
+        // Push the Remote Repo
+        test::run_select_data_sync_remote("README.md", |_, remote_repo| async move {
+            let remote_repo_copy = remote_repo.clone();
+            test::run_empty_dir_test_async(|user_a_repo_dir| async move {
+                let user_a_repo_dir_copy = user_a_repo_dir.join("repo_a");
+                let user_a_repo =
+                    repositories::clone_url(&remote_repo.remote.url, &user_a_repo_dir_copy).await?;
+
+                // Make a couple commits on the remote
+                test::run_empty_dir_test_async(|user_b_repo_dir| async move {
+                    let user_b_repo_dir_copy = user_b_repo_dir.join("repo_b");
+
+                    let user_b_repo =
+                        repositories::clone_url(&remote_repo.remote.url, &user_b_repo_dir_copy)
+                            .await?;
+
+                    // Edit a new file on the remote
+                    let new_file = "new_file.txt";
+                    let new_file_path = user_b_repo.path.join(new_file);
+                    test::write_txt_file_to_path(
+                        &new_file_path,
+                        "Hello from another user b new file",
+                    )?;
+                    repositories::add(&user_b_repo, &new_file_path)?;
+                    repositories::commit(&user_b_repo, "Updating the new file on the remote")?;
+
+                    // Push the remote
+                    repositories::push(&user_b_repo).await?;
+
+                    Ok(user_b_repo_dir_copy)
+                })
+                .await?;
+
+                // Make some changes locally
+                let modified_file = "README.md";
+                let modified_file_path = user_a_repo.path.join(modified_file);
+                test::write_txt_file_to_path(&modified_file_path, "# User A README")?;
+
+                // Pull should succeed because we did not modify README on remote
+                let result = repositories::pull(&user_a_repo).await;
+                assert!(result.is_err());
+
+                // Make sure that the local changes are not overwritten
+                let content = util::fs::read_from_path(&modified_file_path)?;
+                assert_eq!(content, "# User A README");
+
+                // Pull again
+                let result = repositories::pull(&user_a_repo).await;
+                assert!(result.is_err());
+
+                // Make sure that the local changes are still not overwritten
+                let content = util::fs::read_from_path(&modified_file_path)?;
+                assert_eq!(content, "# User A README");
+
+                Ok(user_a_repo_dir_copy)
+            })
+            .await?;
+
+            Ok(remote_repo_copy)
+        })
+        .await
+    }
+
+    /*
+    Remove the README.md on the remote, and modify the readme locally, and make sure that the local readme is not overwritten
+    */
+    #[tokio::test]
+    async fn test_pull_does_not_overwrite_modified_files_after_removing_file(
+    ) -> Result<(), OxenError> {
+        // Push the Remote Repo
+        test::run_select_data_sync_remote("README.md", |_, remote_repo| async move {
+            let remote_repo_copy = remote_repo.clone();
+            test::run_empty_dir_test_async(|user_a_repo_dir| async move {
+                let user_a_repo_dir_copy = user_a_repo_dir.join("repo_a");
+                let user_a_repo =
+                    repositories::clone_url(&remote_repo.remote.url, &user_a_repo_dir_copy).await?;
+
+                // Make a couple commits on the remote
+                test::run_empty_dir_test_async(|user_b_repo_dir| async move {
+                    let user_b_repo_dir_copy = user_b_repo_dir.join("repo_b");
+
+                    let user_b_repo =
+                        repositories::clone_url(&remote_repo.remote.url, &user_b_repo_dir_copy)
+                            .await?;
+
+                    // Remove the README.md on the remote
+                    let rm_opts = RmOpts {
+                        path: PathBuf::from("README.md"),
+                        staged: false,
+                        recursive: false,
+                    };
+                    repositories::rm(&user_b_repo, &rm_opts)?;
+                    repositories::commit(&user_b_repo, "Removing the README.md on the remote")?;
+
+                    // Push the remote
+                    repositories::push(&user_b_repo).await?;
+
+                    Ok(user_b_repo_dir_copy)
+                })
+                .await?;
+
+                // Make some changes locally
+                let modified_file = "README.md";
+                let modified_file_path = user_a_repo.path.join(modified_file);
+                test::write_txt_file_to_path(&modified_file_path, "# User A README")?;
+
+                // Pull again
+                let result = repositories::pull(&user_a_repo).await;
+
+                // Assert that it failed
+                assert!(result.is_err());
+
+                // Make sure that the local changes are not overwritten
+                let content = util::fs::read_from_path(&modified_file_path)?;
+                assert_eq!(content, "# User A README");
 
                 // Pull again
                 let result = repositories::pull(&user_a_repo).await;

--- a/src/lib/src/repositories/push.rs
+++ b/src/lib/src/repositories/push.rs
@@ -844,12 +844,15 @@ mod tests {
                     log::debug!("first_push_result: {:?}", first_push_result);
                     assert!(first_push_result.is_err());
 
-                    // Pull should succeed
-                    repositories::pull(&user_b_repo).await?;
+                    // Pull should error because there are conflicts
+                    let result = repositories::pull(&user_b_repo).await;
+                    assert!(result.is_err());
 
                     // There should be conflicts
                     let status = repositories::status(&user_b_repo)?;
                     assert!(status.has_merge_conflicts());
+                    println!("passed has_merge_conflicts");
+                    status.print();
 
                     // User B resolves conflicts
                     let b_mod_file_path = user_b_repo.path.join(mod_file);
@@ -857,8 +860,11 @@ mod tests {
                         b_mod_file_path,
                         "No for real. I be the README now.",
                     )?;
+                    println!("passed write_txt_file_to_path");
                     repositories::add(&user_b_repo, &b_mod_file_path)?;
+                    println!("passed add");
                     repositories::commit(&user_b_repo, "User B resolving conflicts.")?;
+                    println!("passed commit");
 
                     // Push should now succeed
                     let third_push_result = repositories::push(&user_b_repo).await;

--- a/src/lib/src/util/fs.rs
+++ b/src/lib/src/util/fs.rs
@@ -155,7 +155,7 @@ pub fn version_file_size(repo: &LocalRepository, entry: &CommitEntry) -> Result<
     //     Ok(meta.len())
     // } else {
     if !version_path.exists() {
-        return Err(OxenError::entry_does_not_exist(version_path));
+        return Err(OxenError::path_does_not_exist(version_path));
     }
     let meta = util::fs::metadata(&version_path)?;
     Ok(meta.len())

--- a/src/server/src/controllers/branches.rs
+++ b/src/server/src/controllers/branches.rs
@@ -148,6 +148,7 @@ pub async fn update(
         branch,
     }))
 }
+
 pub async fn maybe_create_merge(
     req: HttpRequest,
     body: String,


### PR DESCRIPTION

```
echo "Hello" > README.md
oxen add README.md
oxen commit README.md

// update README on remote on main

echo "Hello World" > README.md
oxen pull origin main

// Should error out and say you need to commit changes before pulling
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package dependencies and build configurations.
  
- **Bug Fixes**
  - Enhanced pull, merge, and checkout operations to better protect local modifications and provide clearer error feedback.
  - Improved file restoration logic to prevent accidental overwrites during updates.
  
- **New Features**
  - Introduced remote branch merging capabilities for streamlined branch management.
  - Added refined control over branch updates for more predictable synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->