### PR TITLE
Feat/rename column

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.85.0"

--- a/src/cli/src/cmd/df.rs
+++ b/src/cli/src/cmd/df.rs
@@ -220,6 +220,12 @@ impl RunCmd for DFCmd {
                 .action(clap::ArgAction::Set),
         )
         .arg(
+            Arg::new("rename-col")
+                .long("rename-col")
+                .help("Rename a column in the data frame. Format: 'old_name:new_name'")
+                .action(clap::ArgAction::Set),
+        )
+        .arg(
             Arg::new("delete-row")
                 .long("delete-row")
                 .help("Delete a row from a data frame. Currently only works with remote data frames with the value from _id column.")
@@ -286,6 +292,7 @@ impl DFCmd {
         liboxen::opts::DFOpts {
             add_col: args.get_one::<String>("add-col").map(String::from),
             add_row: args.get_one::<String>("add-row").map(String::from),
+            rename_col: args.get_one::<String>("rename-col").map(String::from),
             at: args
                 .get_one::<String>("at")
                 .map(|x| x.parse::<usize>().expect("at must be valid int")),

--- a/src/cli/src/cmd/node.rs
+++ b/src/cli/src/cmd/node.rs
@@ -43,6 +43,13 @@ impl RunCmd for NodeCmd {
                     .short('f')
                     .help("File path to inspect"),
             )
+            // add --revision flag
+            .arg(
+                Arg::new("revision")
+                    .long("revision")
+                    .short('r')
+                    .help("Which revision to start at"),
+            )
     }
 
     async fn run(&self, args: &clap::ArgMatches) -> Result<(), OxenError> {
@@ -51,7 +58,11 @@ impl RunCmd for NodeCmd {
 
         // if the --file flag is set, we need to get the node for the file
         if let Some(file) = args.get_one::<String>("file") {
-            let commit = repositories::commits::head_commit(&repository)?;
+            let commit = if let Some(revision) = args.get_one::<String>("revision") {
+                repositories::revisions::get(&repository, revision)?.unwrap()
+            } else {
+                repositories::commits::head_commit(&repository)?
+            };
             let node = repositories::entries::get_file(&repository, &commit, file)?;
             println!("{:?}", node);
             return Ok(());

--- a/src/lib/src/core/v_latest/index/commit_merkle_tree.rs
+++ b/src/lib/src/core/v_latest/index/commit_merkle_tree.rs
@@ -450,6 +450,7 @@ impl CommitMerkleTree {
         // Look up the directory hash
         let node_hash: Option<MerkleHash> = dir_hashes.get(parent_path).cloned();
         let Some(node_hash) = node_hash else {
+            log::debug!("read_file could not find parent dir: {:?}", parent_path);
             return Ok(None);
         };
 

--- a/src/lib/src/core/v_latest/workspaces/data_frames.rs
+++ b/src/lib/src/core/v_latest/workspaces/data_frames.rs
@@ -64,8 +64,8 @@ pub fn get_queryable_data_frame_workspace_from_file_node(
     log::debug!("Looking for workspace with commit id {:?}", commit_id);
 
     for workspace in workspaces {
-        log::debug!("is workspace editable: {:?}", workspace.is_editable);
-        log::debug!("workspace commit id: {:?}", workspace.commit.id);
+        // log::debug!("is workspace editable: {:?}", workspace.is_editable);
+        // log::debug!("workspace commit id: {:?}", workspace.commit.id);
         // Ensure the workspace is not editable and matches the commit ID of the resource
         if !workspace.is_editable && workspace.commit.id == commit_id.to_string() {
             // Construct the path to the DuckDB resource within the workspace

--- a/src/lib/src/model/data_frame/schema.rs
+++ b/src/lib/src/model/data_frame/schema.rs
@@ -197,8 +197,7 @@ impl Schema {
             .filter(|f| {
                 // Perform the actual filter condition check
                 f.changes
-                    .as_ref()
-                    .map_or(true, |changes| changes.status != "deleted")
+                    .as_ref().is_none_or(|changes| changes.status != "deleted")
             })
             .map(|f| f.name.clone()) // Assuming name is a String and needs to be cloned
             .collect()

--- a/src/lib/src/model/data_frame/schema.rs
+++ b/src/lib/src/model/data_frame/schema.rs
@@ -197,7 +197,8 @@ impl Schema {
             .filter(|f| {
                 // Perform the actual filter condition check
                 f.changes
-                    .as_ref().is_none_or(|changes| changes.status != "deleted")
+                    .as_ref()
+                    .is_none_or(|changes| changes.status != "deleted")
             })
             .map(|f| f.name.clone()) // Assuming name is a String and needs to be cloned
             .collect()

--- a/src/lib/src/opts/df_opts.rs
+++ b/src/lib/src/opts/df_opts.rs
@@ -31,6 +31,7 @@ pub struct IndexedItem {
 pub struct DFOpts {
     pub add_col: Option<String>,
     pub add_row: Option<String>,
+    pub rename_col: Option<String>,
     pub at: Option<usize>,
     pub columns: Option<String>,
     pub delete_row: Option<String>,
@@ -80,6 +81,7 @@ impl DFOpts {
         DFOpts {
             add_col: None,
             add_row: None,
+            rename_col: None,
             at: None,
             columns: None,
             delete_row: None,
@@ -159,6 +161,7 @@ impl DFOpts {
     pub fn has_transform(&self) -> bool {
         self.add_col.is_some()
             || self.add_row.is_some()
+            || self.rename_col.is_some()
             || self.item.is_some()
             || self.columns.is_some()
             || self.filter.is_some()

--- a/src/lib/src/repositories/workspaces.rs
+++ b/src/lib/src/repositories/workspaces.rs
@@ -259,10 +259,7 @@ pub fn list(repo: &LocalRepository) -> Result<Vec<Workspace>, OxenError> {
     let workspaces_hashes = util::fs::list_dirs_in_dir(&workspaces_dir)
         .map_err(|e| OxenError::basic_str(format!("Error listing workspace directories: {}", e)))?;
 
-    log::debug!(
-        "workspace::list got {} workspaces",
-        workspaces_hashes.len()
-    );
+    log::debug!("workspace::list got {} workspaces", workspaces_hashes.len());
 
     let mut workspaces = Vec::new();
     for workspace_hash in workspaces_hashes {

--- a/src/lib/src/repositories/workspaces.rs
+++ b/src/lib/src/repositories/workspaces.rs
@@ -260,8 +260,8 @@ pub fn list(repo: &LocalRepository) -> Result<Vec<Workspace>, OxenError> {
         .map_err(|e| OxenError::basic_str(format!("Error listing workspace directories: {}", e)))?;
 
     log::debug!(
-        "workspace::list got workspaces_hashes: {:?}",
-        workspaces_hashes
+        "workspace::list got {} workspaces",
+        workspaces_hashes.len()
     );
 
     let mut workspaces = Vec::new();

--- a/src/lib/src/view/entries.rs
+++ b/src/lib/src/view/entries.rs
@@ -111,8 +111,7 @@ impl EMetadataEntry {
             EMetadataEntry::MetadataEntry(entry) => {
                 entry.resource.clone().map(ParsedResourceView::from)
             }
-            EMetadataEntry::WorkspaceMetadataEntry(entry) => {
-                entry.resource.clone()}
+            EMetadataEntry::WorkspaceMetadataEntry(entry) => entry.resource.clone(),
         }
     }
 

--- a/src/lib/src/view/entries.rs
+++ b/src/lib/src/view/entries.rs
@@ -112,8 +112,7 @@ impl EMetadataEntry {
                 entry.resource.clone().map(ParsedResourceView::from)
             }
             EMetadataEntry::WorkspaceMetadataEntry(entry) => {
-                entry.resource.clone().map(ParsedResourceView::from)
-            }
+                entry.resource.clone()}
         }
     }
 


### PR DESCRIPTION
oxen df prompts.parquet --rename-col rust_prompt:prompt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a command-line option to rename DataFrame columns using an "old:new" format for seamless column renaming.
  - Introduced a revision argument that lets users specify a starting revision for certain operations.
  - Enhanced data processing workflows by integrating custom column renaming during transformations.
  - Added a new test for uploading files to a subdirectory within a remote repository.

- **Chores**
  - Updated the Rust toolchain version from 1.84.1 to 1.85.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->