### PR TITLE
Move Windows Rspec tests inside unit test module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,6 @@ jobs:
         env:
           PATH: ${{ env.PATH }};${{ github.workspace }}/target/debug
         run: |
-          mkdir .\data\test\runs
           echo "Adding user"
           .\target\debug\oxen-server.exe add-user --email ox@oxen.ai --name Ox --output user_config.toml
           echo "Copying user config"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,11 +202,30 @@ jobs:
           cmd /c "START /B .\target\debug\oxen-server.exe start"
           cargo test -- --test-threads=1
 
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          name: oxen-binary-windows
-          path: target/debug/oxen*
+          ruby-version: '3.0'
+          bundler-cache: true
+  
+      - name: Run Rspec Tests
+        env:
+          PATH: ${{ env.PATH }};${{ github.workspace }}/target/debug
+        run: |
+          mkdir .\data\test\runs
+          echo "Adding user"
+          .\target\debug\oxen-server.exe add-user --email ox@oxen.ai --name Ox --output user_config.toml
+          echo "Copying user config"
+          cp user_config.toml data\test\config\user_config.toml
+          echo "Starting server"
+          pwd
+          ls .\target\debug\
+          cmd /c "START /B .\target\debug\oxen-server.exe start"
+          echo "🐂 Running tests"
+          cd cli-test
+          bundle config path vendor/bundle
+          bundle install
+          bundle exec rspec spec/test_cases/**/tests.rb
 
   rpsec_tests_macos:
     name: MacOS RSpec CLI Tests
@@ -267,45 +286,4 @@ jobs:
         working-directory: ./cli-test
         run: |
           bundle exec rspec spec/test_cases/**/tests.rb
-
-  rspec_test_windows:
-    name: Windows RSpec CLI Tests
-    needs: [test_windows]
-    runs-on: windows-latest
-
-    env:
-      OXEN_API_KEY: ${{ secrets.DEV_OXEN_API_KEY }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: oxen-binary-windows
-          path: target/debug
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.0'
-          bundler-cache: true
-
-      - name: Run oxen-server
-        env:
-          PATH: ${{ env.PATH }};${{ github.workspace }}/target/debug
-        run: |
-          mkdir .\data\test\runs
-          echo "Adding user"
-          .\target\debug\oxen-server.exe add-user --email ox@oxen.ai --name Ox --output user_config.toml
-          echo "Copying user config"
-          cp user_config.toml data\test\config\user_config.toml
-          echo "Starting server"
-          pwd
-          ls .\target\debug\
-          cmd /c "START /B .\target\debug\oxen-server.exe start"
-          echo "🐂 Running tests"
-          cd cli-test
-          bundle config path vendor/bundle
-          bundle install
-          bundle exec rspec spec/test_cases/**/tests.rb
+    


### PR DESCRIPTION
Deleted the Windows Rspec CLI test module in the workflows YML and moved the relevant code into the unit testing module. This solves the issue where the oxen server would not instantiate within the Windows module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Streamlined the Windows testing workflow by consolidating redundant test jobs to improve efficiency.
	- Enhanced the setup process for the Windows environment to ensure more reliable test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->