### PR TITLE
add /mergability endpoint that checks at a file level if workspace staged changes can be committed

### DIFF
--- a/src/lib/src/api/client/commits.rs
+++ b/src/lib/src/api/client/commits.rs
@@ -1237,8 +1237,8 @@ mod tests {
 
             // Log comes out in reverse order, so we want the 5th commit as the base,
             // and will end up with the 1st,2nd,3rd,4th commits (4 commits total inclusive)
-            let base_commit = &commit_history[1];
-            let head_commit = &commit_history[4];
+            let head_commit = &commit_history[1];
+            let base_commit = &commit_history[4];
 
             println!("base_commit: {}\nhead_commit: {}", base_commit, head_commit);
 

--- a/src/lib/src/api/client/compare.rs
+++ b/src/lib/src/api/client/compare.rs
@@ -245,8 +245,8 @@ mod tests {
             // Push the commits to the remote
             repositories::push(&local_repo).await?;
 
-            let base_commit_id = MerkleHash::from_str(&commit_ids[1])?;
-            let head_commit_id = MerkleHash::from_str(&commit_ids[3])?;
+            let base_commit_id = MerkleHash::from_str(&commit_ids[3])?;
+            let head_commit_id = MerkleHash::from_str(&commit_ids[1])?;
             let commits =
                 api::client::compare::commits(&remote_repo, &base_commit_id, &head_commit_id)
                     .await?;

--- a/src/lib/src/api/client/tree.rs
+++ b/src/lib/src/api/client/tree.rs
@@ -385,9 +385,15 @@ pub async fn download_trees_between(
     log::debug!("unpacked trees {}", base_head);
 
     // Return the commits we downloaded
-    let base_commit = repositories::commits::get_by_id(local_repo, base_id)?.unwrap();
-    let head_commit = repositories::commits::get_by_id(local_repo, head_id)?.unwrap();
+    let Some(head_commit) = repositories::commits::get_by_id(local_repo, head_id)? else {
+        return Err(OxenError::revision_not_found(head_id.to_string().into()));
+    };
+    let Some(base_commit) = repositories::commits::get_by_id(local_repo, base_id)? else {
+        return Err(OxenError::revision_not_found(base_id.to_string().into()));
+    };
     let commits = repositories::commits::list_between(local_repo, &base_commit, &head_commit)?;
+    log::debug!("download_trees_between commits: {:?}", commits.len());
+    log::debug!("download_trees_between commits: {:?}", commits);
 
     Ok(commits)
 }

--- a/src/lib/src/api/client/workspaces/commits.rs
+++ b/src/lib/src/api/client/workspaces/commits.rs
@@ -2,15 +2,35 @@ use crate::api;
 use crate::api::client;
 use crate::error::OxenError;
 use crate::model::{Branch, Commit, NewCommitBody, RemoteRepository};
+use crate::view::merge::{Mergeable, MergeableResponse};
 use crate::view::CommitResponse;
+
+pub async fn mergeability(
+    remote_repo: &RemoteRepository,
+    branch_name: &str,
+    workspace_id: &str,
+) -> Result<Mergeable, OxenError> {
+    let uri = format!("/workspaces/{workspace_id}/mergeability/{branch_name}");
+    let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
+    let client = client::new_for_url(&url)?;
+    let res = client.get(&url).send().await?;
+    let body = client::parse_json_body(&url, res).await?;
+    let response: Result<MergeableResponse, serde_json::Error> = serde_json::from_str(&body);
+    match response {
+        Ok(val) => Ok(val.mergeable),
+        Err(err) => Err(OxenError::basic_str(format!(
+            "api::workspaces::commits::mergeability error parsing response from {url}\n\nErr {err:?} \n\n{body}"
+        ))),
+    }
+}
 
 pub async fn commit(
     remote_repo: &RemoteRepository,
     branch_name: &str,
-    identifier: &str,
+    workspace_id: &str,
     commit: &NewCommitBody,
 ) -> Result<Commit, OxenError> {
-    let uri = format!("/workspaces/{identifier}/commit/{branch_name}");
+    let uri = format!("/workspaces/{workspace_id}/commit/{branch_name}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
     log::debug!("commit_staged {}\n{:?}", url, commit);
 
@@ -31,9 +51,9 @@ pub async fn commit(
             api::client::commits::post_push_complete(remote_repo, &branch, &commit.id).await?;
             api::client::repositories::post_push(remote_repo, &branch, &commit.id).await?;
             Ok(commit)
-        },
+        }
         Err(err) => Err(OxenError::basic_str(format!(
-            "api::staging::commit_staged error parsing response from {url}\n\nErr {err:?} \n\n{body}"
+            "api::workspaces::commits error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
 }
@@ -43,13 +63,13 @@ mod tests {
 
     use std::path::Path;
 
-    use crate::api;
     use crate::config::UserConfig;
     use crate::constants::DEFAULT_BRANCH_NAME;
     use crate::error::OxenError;
     use crate::model::NewCommitBody;
     use crate::opts::DFOpts;
     use crate::test;
+    use crate::{api, util};
 
     #[tokio::test]
     async fn test_commit_staged_multiple_files() -> Result<(), OxenError> {
@@ -91,6 +111,209 @@ mod tests {
             let remote_commit = api::client::commits::get_by_id(&remote_repo, &commit.id).await?;
             assert!(remote_commit.is_some());
             assert_eq!(commit.id, remote_commit.unwrap().id);
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_mergeability_no_conflicts() -> Result<(), OxenError> {
+        test::run_remote_repo_test_bounding_box_csv_pushed(|_local_repo, remote_repo| async move {
+            let workspace_id = UserConfig::identifier()?;
+            let directory_name = "data";
+            let paths = vec![test::test_img_file()];
+            api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, &workspace_id)
+                .await?;
+            let result = api::client::workspaces::files::add_many(
+                &remote_repo,
+                &workspace_id,
+                directory_name,
+                paths,
+            )
+            .await;
+            assert!(result.is_ok());
+
+            let mergeable = api::client::workspaces::commits::mergeability(
+                &remote_repo,
+                DEFAULT_BRANCH_NAME,
+                &workspace_id,
+            )
+            .await?;
+            assert!(mergeable.is_mergeable);
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_mergeability_with_no_conflicts_different_files() -> Result<(), OxenError> {
+        test::run_remote_repo_test_bounding_box_csv_pushed(|local_repo, remote_repo| async move {
+            let workspace_1_id = "workspace_1";
+            let directory_name = Path::new("annotations").join("train");
+            api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, &workspace_1_id)
+                .await?;
+
+            // Create a second workspace with the same branch off of the same commit
+            let workspace_2_id = "workspace_2";
+            api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, &workspace_2_id)
+                .await?;
+
+            // add an image file to workspace 1
+            let paths = vec![test::test_img_file()];
+            let result = api::client::workspaces::files::add_many(
+                &remote_repo,
+                &workspace_1_id,
+                directory_name.to_str().unwrap(),
+                paths,
+            )
+            .await;
+            assert!(result.is_ok());
+            let body = NewCommitBody {
+                message: "Add image".to_string(),
+                author: "Test User".to_string(),
+                email: "test@oxen.ai".to_string(),
+            };
+            // Commit to get the branch ahead
+            api::client::workspaces::commit(
+                &remote_repo,
+                DEFAULT_BRANCH_NAME,
+                workspace_1_id,
+                &body,
+            )
+            .await?;
+
+            // And write new data to the annotations/train/bounding_box.csv file
+            let bbox_path = local_repo
+                .path
+                .join("annotations")
+                .join("train")
+                .join("bounding_box.csv");
+            let data = "file,label\ntest/test.jpg,dog";
+            util::fs::write_to_path(&bbox_path, data)?;
+            let paths = vec![bbox_path];
+            let result = api::client::workspaces::files::add_many(
+                &remote_repo,
+                &workspace_2_id,
+                directory_name.to_str().unwrap(),
+                paths,
+            )
+            .await;
+            assert!(result.is_ok());
+
+            let mergeable = api::client::workspaces::commits::mergeability(
+                &remote_repo,
+                DEFAULT_BRANCH_NAME,
+                workspace_2_id,
+            )
+            .await?;
+            println!("mergeable: {:?}", mergeable);
+            assert!(mergeable.is_mergeable);
+
+            let body = NewCommitBody {
+                message: "Update bounding box".to_string(),
+                author: "Test User".to_string(),
+                email: "test@oxen.ai".to_string(),
+            };
+
+            let commit_result = api::client::workspaces::commit(
+                &remote_repo,
+                DEFAULT_BRANCH_NAME,
+                workspace_2_id,
+                &body,
+            )
+            .await;
+            assert!(commit_result.is_ok());
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_mergeability_with_conflicts() -> Result<(), OxenError> {
+        test::run_remote_repo_test_bounding_box_csv_pushed(|local_repo, remote_repo| async move {
+            let workspace_1_id = "workspace_1";
+            let directory_name = Path::new("annotations").join("train");
+            api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, &workspace_1_id)
+                .await?;
+
+            // Create a second workspace with the same branch off of the same commit
+            let workspace_2_id = "workspace_2";
+            api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, &workspace_2_id)
+                .await?;
+
+            // And write new data to the annotations/train/bounding_box.csv file
+            let bbox_path = local_repo
+                .path
+                .join("annotations")
+                .join("train")
+                .join("bounding_box.csv");
+            let data = "file,label,min_x,min_y,width,height\ntest/test.jpg,dog,13.5,32.0,385,330";
+            util::fs::write_to_path(&bbox_path, data)?;
+            let paths = vec![bbox_path];
+            let result = api::client::workspaces::files::add_many(
+                &remote_repo,
+                &workspace_1_id,
+                directory_name.to_str().unwrap(),
+                paths,
+            )
+            .await;
+            assert!(result.is_ok());
+            let body = NewCommitBody {
+                message: "Update bounding box".to_string(),
+                author: "Test User".to_string(),
+                email: "test@oxen.ai".to_string(),
+            };
+            // Commit to get the branch ahead
+            api::client::workspaces::commit(
+                &remote_repo,
+                DEFAULT_BRANCH_NAME,
+                workspace_1_id,
+                &body,
+            )
+            .await?;
+
+            // And write new data to the annotations/train/bounding_box.csv file
+            let bbox_path = local_repo
+                .path
+                .join("annotations")
+                .join("train")
+                .join("bounding_box.csv");
+            let data = "file,label\ntest/test.jpg,dog";
+            util::fs::write_to_path(&bbox_path, data)?;
+            let paths = vec![bbox_path];
+            let result = api::client::workspaces::files::add_many(
+                &remote_repo,
+                &workspace_2_id,
+                directory_name.to_str().unwrap(),
+                paths,
+            )
+            .await;
+            assert!(result.is_ok());
+            let body = NewCommitBody {
+                message: "Update bounding box".to_string(),
+                author: "Test User".to_string(),
+                email: "test@oxen.ai".to_string(),
+            };
+
+            let mergeable = api::client::workspaces::commits::mergeability(
+                &remote_repo,
+                DEFAULT_BRANCH_NAME,
+                workspace_2_id,
+            )
+            .await?;
+            assert!(!mergeable.is_mergeable);
+
+            let commit_result = api::client::workspaces::commit(
+                &remote_repo,
+                DEFAULT_BRANCH_NAME,
+                workspace_2_id,
+                &body,
+            )
+            .await;
+            assert!(commit_result.is_err());
 
             Ok(remote_repo)
         })

--- a/src/lib/src/api/client/workspaces/commits.rs
+++ b/src/lib/src/api/client/workspaces/commits.rs
@@ -141,6 +141,8 @@ mod tests {
             )
             .await?;
             assert!(mergeable.is_mergeable);
+            assert_eq!(mergeable.conflicts.len(), 0);
+            assert_eq!(mergeable.commits.len(), 1);
 
             Ok(remote_repo)
         })
@@ -210,6 +212,8 @@ mod tests {
             .await?;
             println!("mergeable: {:?}", mergeable);
             assert!(mergeable.is_mergeable);
+            assert_eq!(mergeable.conflicts.len(), 0);
+            assert_eq!(mergeable.commits.len(), 2);
 
             let body = NewCommitBody {
                 message: "Update bounding box".to_string(),
@@ -305,6 +309,8 @@ mod tests {
             )
             .await?;
             assert!(!mergeable.is_mergeable);
+            assert_eq!(mergeable.conflicts.len(), 1);
+            assert_eq!(mergeable.commits.len(), 2);
 
             let commit_result = api::client::workspaces::commit(
                 &remote_repo,

--- a/src/lib/src/api/client/workspaces/commits.rs
+++ b/src/lib/src/api/client/workspaces/commits.rs
@@ -10,7 +10,7 @@ pub async fn mergeability(
     branch_name: &str,
     workspace_id: &str,
 ) -> Result<Mergeable, OxenError> {
-    let uri = format!("/workspaces/{workspace_id}/mergeability/{branch_name}");
+    let uri = format!("/workspaces/{workspace_id}/merge/{branch_name}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
     let client = client::new_for_url(&url)?;
     let res = client.get(&url).send().await?;
@@ -19,7 +19,7 @@ pub async fn mergeability(
     match response {
         Ok(val) => Ok(val.mergeable),
         Err(err) => Err(OxenError::basic_str(format!(
-            "api::workspaces::commits::mergeability error parsing response from {url}\n\nErr {err:?} \n\n{body}"
+            "api::workspaces::commits::merge error parsing response from {url}\n\nErr {err:?} \n\n{body}"
         ))),
     }
 }

--- a/src/lib/src/api/client/workspaces/files.rs
+++ b/src/lib/src/api/client/workspaces/files.rs
@@ -152,10 +152,12 @@ pub async fn post_file(
 
 pub async fn add_many(
     remote_repo: &RemoteRepository,
-    workspace_id: &str,
-    directory_name: &str,
+    workspace_id: impl AsRef<str>,
+    directory_name: impl AsRef<str>,
     paths: Vec<PathBuf>,
 ) -> Result<Vec<PathBuf>, OxenError> {
+    let workspace_id = workspace_id.as_ref();
+    let directory_name = directory_name.as_ref();
     // Check if the total size of the files is too large (over 100mb for now)
     let limit = 100_000_000;
     let total_size: u64 = paths.iter().map(|p| p.metadata().unwrap().len()).sum();

--- a/src/lib/src/core/df/tabular.rs
+++ b/src/lib/src/core/df/tabular.rs
@@ -1836,21 +1836,21 @@ mod tests {
         let json = tabular::any_val_to_json(val);
         assert_eq!(json, json!(42));
 
-        let val = AnyValue::Float32(3.14);
+        let val = AnyValue::Float32(3.41);
         let json = tabular::any_val_to_json(val);
         if let serde_json::Value::Number(num) = json {
             let float_val = num.as_f64().unwrap();
             assert!(
-                (float_val - 3.14).abs() < 0.0001,
-                "Float32 value should be approximately 3.14"
+                (float_val - 3.41).abs() < 0.0001,
+                "Float32 value should be approximately 3.41"
             );
         } else {
             panic!("Expected a JSON number");
         }
 
-        let val = AnyValue::Float64(3.14);
+        let val = AnyValue::Float64(3.41);
         let json = tabular::any_val_to_json(val);
-        assert_eq!(json, json!(3.14));
+        assert_eq!(json, json!(3.41));
 
         let val = AnyValue::String("hello");
         let json = tabular::any_val_to_json(val);

--- a/src/lib/src/core/v_latest/fetch.rs
+++ b/src/lib/src/core/v_latest/fetch.rs
@@ -141,9 +141,12 @@ async fn sync_from_head(
     pull_progress: &Arc<PullProgress>,
 ) -> Result<(), OxenError> {
     let repo_hidden_dir = util::fs::oxen_hidden_dir(&repo.path);
+    log::debug!("sync_from_head head_commit: {}", head_commit);
+    log::debug!("sync_from_head branch: {}", branch);
 
     // If HEAD commit is not on the remote server, that means we are ahead of the remote branch
     if api::client::tree::has_node(remote_repo, MerkleHash::from_str(&head_commit.id)?).await? {
+        log::debug!("sync_from_head has head commit: {}", head_commit);
         pull_progress.set_message(format!(
             "Downloading commits from {} to {}",
             head_commit.id, branch.commit_id
@@ -158,8 +161,8 @@ async fn sync_from_head(
         .await?;
         api::client::commits::download_base_head_dir_hashes(
             remote_repo,
-            &branch.commit_id,
             &head_commit.id,
+            &branch.commit_id,
             &repo_hidden_dir,
         )
         .await?;

--- a/src/lib/src/core/v_latest/merge.rs
+++ b/src/lib/src/core/v_latest/merge.rs
@@ -107,7 +107,7 @@ pub fn list_commits_between_branches(
         head_commit,
         lca
     );
-    list_between(repo, &head_commit, &lca)
+    list_between(repo, &lca, &head_commit)
 }
 
 pub fn list_commits_between_commits(
@@ -116,7 +116,7 @@ pub fn list_commits_between_commits(
     head_commit: &Commit,
 ) -> Result<Vec<Commit>, OxenError> {
     log::debug!(
-        "list_commits_between_commits() base: {:?} head: {:?}",
+        "list_commits_between_commits()\nbase: {}\nhead: {}",
         base_commit,
         head_commit
     );
@@ -613,7 +613,7 @@ fn merge_commits(
 ) -> Result<Option<Commit>, OxenError> {
     // User output
     println!(
-        "merge_commits {} -> {}",
+        "Merge commits {} -> {}",
         merge_commits.base.id, merge_commits.merge.id
     );
 

--- a/src/lib/src/core/v_latest/push.rs
+++ b/src/lib/src/core/v_latest/push.rs
@@ -167,7 +167,7 @@ async fn push_to_existing_branch(
 
     // If we do have the commit locally, we are ahead
     // We need to find all the commits that need to be pushed
-    let mut commits = repositories::commits::list_between(repo, commit, &latest_remote_commit)?;
+    let mut commits = repositories::commits::list_between(repo, &latest_remote_commit, commit)?;
     commits.reverse();
 
     push_commits(repo, remote_repo, &commits).await?;

--- a/src/lib/src/core/v_latest/workspaces.rs
+++ b/src/lib/src/core/v_latest/workspaces.rs
@@ -1,14 +1,7 @@
-use crate::constants::STAGED_DIR;
-use crate::core;
-use crate::core::db;
-use crate::core::refs::RefWriter;
+use crate::constants;
 use crate::error::OxenError;
-use crate::model::{Commit, LocalRepository, NewCommitBody, Workspace};
+use crate::model::LocalRepository;
 use crate::util;
-use crate::{constants, repositories};
-
-use indicatif::ProgressBar;
-use rocksdb::{DBWithThreadMode, SingleThreaded};
 use std::path::Path;
 
 pub mod commit;
@@ -46,53 +39,4 @@ pub fn init_workspace_repo(
     }
 
     LocalRepository::new(workspace_dir)
-}
-
-pub fn commit(
-    workspace: &Workspace,
-    new_commit: &NewCommitBody,
-    branch_name: impl AsRef<str>,
-) -> Result<Commit, OxenError> {
-    let branch_name = branch_name.as_ref();
-
-    let staged_db_path = util::fs::oxen_hidden_dir(&workspace.workspace_repo.path).join(STAGED_DIR);
-    log::debug!(
-        "0.19.0::workspaces::commit staged db path: {:?}",
-        staged_db_path
-    );
-    let opts = db::key_val::opts::default();
-
-    // Ensure connection to staged_db is dropped before clearing it
-    let commit = {
-        let staged_db: DBWithThreadMode<SingleThreaded> =
-            DBWithThreadMode::open(&opts, dunce::simplified(&staged_db_path))?;
-
-        let commit_progress_bar = ProgressBar::new_spinner();
-
-        // Read all the staged entries
-        let (dir_entries, _) = core::v_latest::status::read_staged_entries(
-            &workspace.workspace_repo,
-            &staged_db,
-            &commit_progress_bar,
-        )?;
-
-        if dir_entries.is_empty() {
-            return Err(OxenError::basic_str("No changes to commit"));
-        }
-
-        repositories::commits::commit_writer::commit_dir_entries(
-            &workspace.base_repo,
-            dir_entries,
-            new_commit,
-            branch_name,
-            &commit_progress_bar,
-        )?
-    };
-
-    // Update the branch
-    let ref_writer = RefWriter::new(&workspace.base_repo)?;
-    let commit_id = commit.id.to_owned();
-    ref_writer.set_branch_commit_id(branch_name, &commit_id)?;
-
-    Ok(commit)
 }

--- a/src/lib/src/core/v_latest/workspaces/commit.rs
+++ b/src/lib/src/core/v_latest/workspaces/commit.rs
@@ -124,17 +124,22 @@ pub fn mergeability(
         ));
     };
 
-    let Some(base) = repositories::commits::get_by_id(&workspace.base_repo, &branch.commit_id)?
+    let base = &workspace.commit;
+    let Some(head) = repositories::commits::get_by_id(&workspace.base_repo, &branch.commit_id)?
     else {
         return Err(OxenError::revision_not_found(
             branch.commit_id.clone().into(),
         ));
     };
-    let head = &workspace.commit;
+
+    log::debug!("workspaces::mergeability base: {:?}", base);
+    log::debug!("workspaces::mergeability head: {:?}", head);
 
     // Get commits between the base and head
     let commits =
-        repositories::merge::list_commits_between_commits(&workspace.base_repo, &base, head)?;
+        repositories::merge::list_commits_between_commits(&workspace.base_repo, base, &head)?;
+
+    log::debug!("workspaces::mergeability commits: {:?}", commits);
 
     // Get conflicts between the base and head
     let staged_db_path = util::fs::oxen_hidden_dir(&workspace.workspace_repo.path).join(STAGED_DIR);

--- a/src/lib/src/model/merkle_tree/node/merkle_tree_node.rs
+++ b/src/lib/src/model/merkle_tree/node/merkle_tree_node.rs
@@ -80,6 +80,17 @@ impl MerkleTreeNode {
         count
     }
 
+    /// Get the latest commit id for file or dir
+    pub fn latest_commit_id(&self) -> Result<&MerkleHash, OxenError> {
+        match &self.node {
+            EMerkleTreeNode::File(file_node) => Ok(file_node.last_commit_id()),
+            EMerkleTreeNode::Directory(dir_node) => Ok(dir_node.last_commit_id()),
+            _ => Err(OxenError::basic_str(
+                "MerkleTreeNode::latest_commit_id called on invalid node type",
+            )),
+        }
+    }
+
     /// Create a default DirNode with none of the metadata fields set
     pub fn default_dir() -> MerkleTreeNode {
         MerkleTreeNode {

--- a/src/lib/src/repositories/commits.rs
+++ b/src/lib/src/repositories/commits.rs
@@ -193,6 +193,7 @@ pub fn list_from(repo: &LocalRepository, revision: &str) -> Result<Vec<Commit>, 
         _ => core::v_latest::commits::list_from(repo, revision),
     }
 }
+
 pub fn list_from_with_depth(
     repo: &LocalRepository,
     revision: &str,
@@ -208,12 +209,12 @@ pub fn list_from_with_depth(
 /// List the history between two commits
 pub fn list_between(
     repo: &LocalRepository,
-    start: &Commit,
-    end: &Commit,
+    base: &Commit,
+    head: &Commit,
 ) -> Result<Vec<Commit>, OxenError> {
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
-        _ => core::v_latest::commits::list_between(repo, start, end),
+        _ => core::v_latest::commits::list_between(repo, base, head),
     }
 }
 
@@ -785,7 +786,7 @@ mod tests {
             repositories::add(&repo, new_file)?;
             repositories::commit(&repo, "commit 4")?;
 
-            let history = repositories::commits::list_between(&repo, &head_commit, &base_commit)?;
+            let history = repositories::commits::list_between(&repo, &base_commit, &head_commit)?;
             assert_eq!(history.len(), 3);
 
             assert_eq!(history.first().unwrap().message, head_commit.message);

--- a/src/lib/src/util/fs.rs
+++ b/src/lib/src/util/fs.rs
@@ -351,6 +351,14 @@ pub fn read_from_path(path: impl AsRef<Path>) -> Result<String, OxenError> {
 pub fn write_to_path(path: impl AsRef<Path>, value: impl AsRef<str>) -> Result<(), OxenError> {
     let path = path.as_ref();
     let value = value.as_ref();
+
+    // Make sure the parent directory exists
+    if let Some(parent) = path.parent() {
+        if !parent.exists() {
+            create_dir_all(parent)?;
+        }
+    }
+
     match File::create(path) {
         Ok(mut file) => match file.write(value.as_bytes()) {
             Ok(_) => Ok(()),

--- a/src/server/src/controllers/commits.rs
+++ b/src/server/src/controllers/commits.rs
@@ -116,6 +116,7 @@ pub async fn history(
                 let commits =
                     repositories::commits::list_from_paginated(&repo, revision_id, pagination)?;
                 log::debug!("commit_history got {} commits", commits.commits.len());
+                // log::debug!("commit_history commits: {:?}", commits.commits);
                 Ok(HttpResponse::Ok().json(commits))
             } else {
                 Err(OxenHttpError::NotFound)

--- a/src/server/src/controllers/tree.rs
+++ b/src/server/src/controllers/tree.rs
@@ -207,6 +207,11 @@ pub async fn download_tree_nodes(
     );
 
     let (base_commit_id, maybe_head_commit_id) = maybe_parse_base_head(base_head_str)?;
+    log::debug!("download_tree_nodes base_commit_id: {}", base_commit_id);
+    log::debug!(
+        "download_tree_nodes maybe_head_commit_id: {:?}",
+        maybe_head_commit_id
+    );
 
     let base_commit = repositories::commits::get_by_id(&repository, &base_commit_id)?
         .ok_or(OxenError::resource_not_found(&base_commit_id))?;
@@ -245,7 +250,7 @@ fn get_commit_list(
     let commits = if let Some(head_commit_id) = maybe_head_commit_id {
         let head_commit = repositories::commits::get_by_id(repository, &head_commit_id)?
             .ok_or(OxenError::resource_not_found(&head_commit_id))?;
-        repositories::commits::list_between(repository, &head_commit, base_commit)?
+        repositories::commits::list_between(repository, base_commit, &head_commit)?
     } else {
         // If the subtree is specified, we only want to get the latest commit
         if maybe_subtrees.is_some() {
@@ -375,7 +380,7 @@ pub async fn download_commits(req: HttpRequest) -> actix_web::Result<HttpRespons
     let commits = if let Some(head_commit_id) = maybe_head_commit_id {
         let head_commit = repositories::commits::get_by_id(&repository, &head_commit_id)?
             .ok_or(OxenError::resource_not_found(&head_commit_id))?;
-        repositories::commits::list_between(&repository, &head_commit, &base_commit)?
+        repositories::commits::list_between(&repository, &base_commit, &head_commit)?
     } else {
         repositories::commits::list_from(&repository, &base_commit_id)?
     };

--- a/src/server/src/services/workspaces.rs
+++ b/src/server/src/services/workspaces.rs
@@ -39,6 +39,10 @@ pub fn workspace() -> Scope {
                     "/commit/{branch:.*}",
                     web::post().to(controllers::workspaces::commit),
                 )
+                .route(
+                    "/mergeability/{branch:.*}",
+                    web::get().to(controllers::workspaces::mergeability),
+                )
                 .service(data_frames::data_frames()),
         )
 }

--- a/src/server/src/services/workspaces.rs
+++ b/src/server/src/services/workspaces.rs
@@ -35,12 +35,17 @@ pub fn workspace() -> Scope {
                     "/files/{path:.*}",
                     web::delete().to(controllers::workspaces::files::delete),
                 )
+                // TODO: Depreciate /commit as we are calling it /merge instead to be consistent with the /merge branch endpoint
                 .route(
                     "/commit/{branch:.*}",
                     web::post().to(controllers::workspaces::commit),
                 )
                 .route(
-                    "/mergeability/{branch:.*}",
+                    "/merge/{branch:.*}",
+                    web::post().to(controllers::workspaces::commit),
+                )
+                .route(
+                    "/merge/{branch:.*}",
                     web::get().to(controllers::workspaces::mergeability),
                 )
                 .service(data_frames::data_frames()),


### PR DESCRIPTION
This allows us to commit workspaces that have file level differences. Instead of just checking the commit ids, we see if there are any conflicts at the file level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a new workspace mergeability check accessible via API endpoints and service routes.
  - Enhanced commit operations by unifying workspace referencing for improved consistency.
  - Expanded file addition capabilities to support a broader range of input types.
  - Added functionality to retrieve the latest commit ID for both file and directory nodes.

- **Tests**
  - Added validations for mergeability and conflict scenarios.
  - Updated numerical assertions in floating-point tests.

- **Chores/Refactor**
  - Improved file creation by automatically ensuring necessary directories exist.
  - Removed legacy commit logic to streamline workspace management.
  - Enhanced logging for better traceability in various functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->