### PR TITLE
return option on workspace::get_by_name call if no workspace exists

### DIFF
--- a/src/lib/src/repositories/workspaces.rs
+++ b/src/lib/src/repositories/workspaces.rs
@@ -43,10 +43,13 @@ pub fn get(
     if config_path.exists() {
         get_by_dir(repo, workspace_dir)
     } else {
-        let workspace = get_by_name(repo, workspace_id)?;
-        let workspace_id = util::hasher::hash_str_sha256(&workspace.id);
-        let workspace_dir = Workspace::workspace_dir(repo, &workspace_id);
-        get_by_dir(repo, workspace_dir)
+        if let Some(workspace) = get_by_name(repo, workspace_id)? {
+            let workspace_id = util::hasher::hash_str_sha256(&workspace.id);
+            let workspace_dir = Workspace::workspace_dir(repo, &workspace_id);
+            get_by_dir(repo, workspace_dir)
+        } else {
+            Ok(None)
+        }
     }
 }
 
@@ -87,18 +90,15 @@ pub fn get_by_dir(
 pub fn get_by_name(
     repo: &LocalRepository,
     workspace_name: impl AsRef<str>,
-) -> Result<Workspace, OxenError> {
+) -> Result<Option<Workspace>, OxenError> {
     let workspace_name = workspace_name.as_ref();
     let workspaces = list(repo)?;
     for workspace in workspaces {
         if workspace.name == Some(workspace_name.to_string()) {
-            return Ok(workspace);
+            return Ok(Some(workspace));
         }
     }
-    Err(OxenError::basic_str(format!(
-        "Workspace {} not found",
-        workspace_name
-    )))
+    return Ok(None);
 }
 
 /// Creates a new workspace and saves it to the filesystem

--- a/src/lib/src/repositories/workspaces.rs
+++ b/src/lib/src/repositories/workspaces.rs
@@ -42,14 +42,12 @@ pub fn get(
 
     if config_path.exists() {
         get_by_dir(repo, workspace_dir)
+    } else if let Some(workspace) = get_by_name(repo, workspace_id)? {
+        let workspace_id = util::hasher::hash_str_sha256(&workspace.id);
+        let workspace_dir = Workspace::workspace_dir(repo, &workspace_id);
+        get_by_dir(repo, workspace_dir)
     } else {
-        if let Some(workspace) = get_by_name(repo, workspace_id)? {
-            let workspace_id = util::hasher::hash_str_sha256(&workspace.id);
-            let workspace_dir = Workspace::workspace_dir(repo, &workspace_id);
-            get_by_dir(repo, workspace_dir)
-        } else {
-            Ok(None)
-        }
+        Ok(None)
     }
 }
 
@@ -98,7 +96,7 @@ pub fn get_by_name(
             return Ok(Some(workspace));
         }
     }
-    return Ok(None);
+    Ok(None)
 }
 
 /// Creates a new workspace and saves it to the filesystem


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved workspace retrieval by handling missing workspaces gracefully. Instead of returning an error when a workspace isn’t found, the system now provides a non-intrusive empty result, ensuring a smoother and more robust user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->