### PR TITLE
Remote repo improvements

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.86.0"

--- a/src/cli/src/cmd/clone.rs
+++ b/src/cli/src/cmd/clone.rs
@@ -74,7 +74,7 @@ impl RunCmd for CloneCmd {
 
         let dst = std::env::current_dir().expect("Could not get current working directory");
         // Get the name of the repo from the url
-        let name = url.split('/').last().unwrap();
+        let name = url.split('/').next_back().unwrap();
         let dst = dst.join(name);
 
         let opts = CloneOpts {

--- a/src/lib/src/api/client.rs
+++ b/src/lib/src/api/client.rs
@@ -22,6 +22,7 @@ pub mod file;
 pub mod merger;
 pub mod metadata;
 pub mod repositories;
+pub mod revisions;
 pub mod schemas;
 pub mod stats;
 pub mod tree;

--- a/src/lib/src/api/client/branches.rs
+++ b/src/lib/src/api/client/branches.rs
@@ -65,7 +65,7 @@ pub async fn create_from_commit(
     let new_name = new_name.as_ref();
 
     let url = api::endpoint::url_from_repo(repository, "/branches")?;
-    log::debug!("branches::create_from_branch {}", url);
+    log::debug!("branches::create_from_commit {}", url);
 
     let params = serde_json::to_string(&BranchNewFromCommitId {
         new_name: new_name.to_string(),
@@ -88,7 +88,7 @@ pub async fn create_from_commit_id(
     let commit_id = commit_id.as_ref();
 
     let url = api::endpoint::url_from_repo(repository, "/branches")?;
-    log::debug!("branches::create_from_branch {}", url);
+    log::debug!("branches::create_from_commit_id {}", url);
 
     let params = serde_json::to_string(&BranchNewFromCommitId {
         new_name: new_name.to_string(),

--- a/src/lib/src/api/client/branches.rs
+++ b/src/lib/src/api/client/branches.rs
@@ -79,6 +79,29 @@ pub async fn create_from_commit(
     Ok(response.branch)
 }
 
+pub async fn create_from_commit_id(
+    repository: &RemoteRepository,
+    new_name: impl AsRef<str>,
+    commit_id: impl AsRef<str>,
+) -> Result<Branch, OxenError> {
+    let new_name = new_name.as_ref();
+    let commit_id = commit_id.as_ref();
+
+    let url = api::endpoint::url_from_repo(repository, "/branches")?;
+    log::debug!("branches::create_from_branch {}", url);
+
+    let params = serde_json::to_string(&BranchNewFromCommitId {
+        new_name: new_name.to_string(),
+        commit_id: commit_id.to_string(),
+    })?;
+
+    let client = client::new_for_url(&url)?;
+    let res = client.post(&url).body(params).send().await?;
+    let body = client::parse_json_body(&url, res).await?;
+    let response: BranchResponse = serde_json::from_str(&body)?;
+    Ok(response.branch)
+}
+
 /// List all branches on the remote
 pub async fn list(repository: &RemoteRepository) -> Result<Vec<Branch>, OxenError> {
     let url = api::endpoint::url_from_repo(repository, "/branches")?;

--- a/src/lib/src/api/client/commits.rs
+++ b/src/lib/src/api/client/commits.rs
@@ -47,22 +47,19 @@ pub async fn get_by_id(
     log::debug!("remote::commits::get_by_id {}", url);
 
     let client = client::new_for_url(&url)?;
-    if let Ok(res) = client.get(&url).send().await {
-        if res.status() == 404 {
-            return Ok(None);
-        }
+    let res = client.get(&url).send().await?;
+    if res.status() == 404 {
+        return Ok(None);
+    }
 
-        let body = client::parse_json_body(&url, res).await?;
-        log::debug!("api::client::commits::get_by_id Got response {}", body);
-        let response: Result<CommitResponse, serde_json::Error> = serde_json::from_str(&body);
-        match response {
-            Ok(j_res) => Ok(Some(j_res.commit)),
-            Err(err) => Err(OxenError::basic_str(format!(
-                "get_commit_by_id() Could not deserialize response [{err}]\n{body}"
-            ))),
-        }
-    } else {
-        Err(OxenError::basic_str("get_commit_by_id() Request failed"))
+    let body = client::parse_json_body(&url, res).await?;
+    log::debug!("api::client::commits::get_by_id Got response {}", body);
+    let response: Result<CommitResponse, serde_json::Error> = serde_json::from_str(&body);
+    match response {
+        Ok(j_res) => Ok(Some(j_res.commit)),
+        Err(err) => Err(OxenError::basic_str(format!(
+            "get_commit_by_id() Could not deserialize response [{err}]\n{body}"
+        ))),
     }
 }
 

--- a/src/lib/src/api/client/entries.rs
+++ b/src/lib/src/api/client/entries.rs
@@ -43,7 +43,7 @@ pub async fn list_entries_with_type(
 ) -> Result<Vec<MetadataEntry>, OxenError> {
     let path = path.as_ref().to_string_lossy();
     let revision = revision.as_ref();
-    let uri = if path == "" || path == "/" {
+    let uri = if path.is_empty() || path == "/" {
         format!("/{}/{}", data_type, revision)
     } else {
         format!("/{}/{}/{}", data_type, revision, path)

--- a/src/lib/src/api/client/merger.rs
+++ b/src/lib/src/api/client/merger.rs
@@ -5,7 +5,7 @@ use crate::api;
 use crate::api::client;
 use crate::error::OxenError;
 use crate::model::RemoteRepository;
-use crate::view::merge::{MergeSuccessResponse, Mergeable, MergeableResponse};
+use crate::view::merge::{MergeResult, MergeSuccessResponse, Mergeable, MergeableResponse};
 
 /// Can check the mergability of base into head
 /// base or head are strings that can be branch names or commit ids
@@ -30,7 +30,7 @@ pub async fn merge(
     remote_repo: &RemoteRepository,
     base: &str,
     head: &str,
-) -> Result<(), OxenError> {
+) -> Result<MergeResult, OxenError> {
     let uri = format!("/merge/{base}..{head}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
     log::debug!("api::client::merger::merge url: {url}");
@@ -38,8 +38,8 @@ pub async fn merge(
     let client = client::new_for_url(&url)?;
     let res = client.post(&url).send().await?;
     let body = client::parse_json_body(&url, res).await?;
-    let _response: MergeSuccessResponse = serde_json::from_str(&body)?;
-    Ok(())
+    let response: MergeSuccessResponse = serde_json::from_str(&body)?;
+    Ok(response.commits)
 }
 
 #[cfg(test)]

--- a/src/lib/src/api/client/revisions.rs
+++ b/src/lib/src/api/client/revisions.rs
@@ -1,0 +1,70 @@
+use crate::api;
+use crate::api::client;
+use crate::error::OxenError;
+use crate::model::{ParsedResource, RemoteRepository};
+use crate::view::ParseResourceResponse;
+
+pub async fn get(
+    repository: &RemoteRepository,
+    revision: impl AsRef<str>,
+) -> Result<Option<ParsedResource>, OxenError> {
+    let revision = revision.as_ref();
+    let uri = format!("/revisions/{revision}");
+    let url = api::endpoint::url_from_repo(repository, &uri)?;
+    log::debug!("api::client::revisions::get {}", url);
+
+    let client = client::new_for_url(&url)?;
+    let res = client.get(&url).send().await?;
+    if res.status() == 404 {
+        return Ok(None);
+    }
+
+    let body = client::parse_json_body(&url, res).await?;
+    log::debug!("api::client::revisions::get Got response {}", body);
+    let response: Result<ParseResourceResponse, serde_json::Error> = serde_json::from_str(&body);
+    match response {
+        Ok(j_res) => Ok(Some(j_res.resource)),
+        Err(err) => Err(OxenError::basic_str(format!(
+            "api::client::revisions::get() Could not deserialize response [{err}]\n{body}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::api;
+    use crate::error::OxenError;
+
+    use crate::repositories;
+    use crate::test;
+
+    #[tokio::test]
+    async fn test_get_revision_from_commit() -> Result<(), OxenError> {
+        test::run_one_commit_sync_repo_test(|local_repo, remote_repo| async move {
+            let commit = repositories::commits::head_commit(&local_repo)?;
+
+            let revision = api::client::revisions::get(&remote_repo, &commit.id).await?;
+
+            assert!(revision.is_some());
+            assert!(revision.unwrap().commit.unwrap().id == commit.id);
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_get_revision_from_branch() -> Result<(), OxenError> {
+        test::run_one_commit_sync_repo_test(|local_repo, remote_repo| async move {
+            let branch = repositories::branches::current_branch(&local_repo)?.unwrap();
+
+            let revision = api::client::revisions::get(&remote_repo, &branch.name).await?;
+
+            assert!(revision.is_some());
+            assert!(revision.unwrap().commit.unwrap().id == branch.commit_id);
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+}

--- a/src/lib/src/api/client/workspaces.rs
+++ b/src/lib/src/api/client/workspaces.rs
@@ -123,7 +123,7 @@ pub async fn create_with_path(
         resource_path: Some(path.to_str().unwrap().to_string()),
         entity_type: Some("user".to_string()),
         name: workspace_name,
-        force: true,
+        force: Some(true),
     };
 
     let client = client::new_for_url(&url)?;

--- a/src/lib/src/core/v_latest/commits.rs
+++ b/src/lib/src/core/v_latest/commits.rs
@@ -240,7 +240,7 @@ fn list_recursive(
         return Ok(());
     }
 
-    log::debug!("list_recursive: commit: {}", head_commit);
+    // log::debug!("list_recursive: commit: {}", head_commit);
     results.push(head_commit.clone());
 
     if stop_at_base.is_some() && &head_commit == stop_at_base.unwrap() {

--- a/src/lib/src/core/v_latest/fetch.rs
+++ b/src/lib/src/core/v_latest/fetch.rs
@@ -652,7 +652,7 @@ async fn pull_large_entries(
         });
     }
 
-    while finished_queue.len() > 0 {
+    while !finished_queue.is_empty() {
         // log::debug!("Before waiting for {} workers to finish...", queue.len());
         sleep(Duration::from_secs(1)).await;
     }
@@ -742,7 +742,7 @@ async fn pull_small_entries(
             }
         });
     }
-    while finished_queue.len() > 0 {
+    while !finished_queue.is_empty() {
         // log::debug!("Waiting for {} workers to finish...", queue.len());
         sleep(Duration::from_millis(1)).await;
     }

--- a/src/lib/src/core/v_latest/push.rs
+++ b/src/lib/src/core/v_latest/push.rs
@@ -408,7 +408,7 @@ async fn chunk_and_send_large_entries(
         });
     }
 
-    while finished_queue.len() > 0 {
+    while !finished_queue.is_empty() {
         // log::debug!("Before waiting for {} workers to finish...", queue.len());
         sleep(Duration::from_secs(1)).await;
     }
@@ -770,7 +770,7 @@ async fn bundle_and_send_small_entries(
             }
         });
     }
-    while finished_queue.len() > 0 {
+    while !finished_queue.is_empty() {
         // log::debug!("Waiting for {} workers to finish...", queue.len());
         sleep(Duration::from_secs(1)).await;
     }

--- a/src/lib/src/core/v_latest/workspaces/commit.rs
+++ b/src/lib/src/core/v_latest/workspaces/commit.rs
@@ -65,10 +65,7 @@ pub fn commit(
 
         let conflicts = list_conflicts(workspace, &dir_entries, &branch)?;
         if !conflicts.is_empty() {
-            return Err(OxenError::WorkspaceBehind(Branch {
-                name: branch_name.to_string(),
-                commit_id: workspace.commit.id.to_string(),
-            }));
+            return Err(OxenError::workspace_behind(workspace));
         }
 
         let dir_entries = export_tabular_data_frames(workspace, dir_entries)?;

--- a/src/lib/src/error.rs
+++ b/src/lib/src/error.rs
@@ -12,8 +12,8 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::path::StripPrefixError;
 
-use crate::model::Branch;
 use crate::model::Schema;
+use crate::model::Workspace;
 use crate::model::{Commit, ParsedResource};
 use crate::model::{Remote, RepoNew};
 
@@ -68,7 +68,7 @@ pub enum OxenError {
     // Workspaces
     WorkspaceNotFound(Box<StringError>),
     QueryableWorkspaceNotFound(),
-    WorkspaceBehind(Branch),
+    WorkspaceBehind(Box<Workspace>),
 
     // Resources (paths, uris, etc.)
     ResourceNotFound(StringError),
@@ -266,8 +266,8 @@ impl OxenError {
         OxenError::WorkspaceNotFound(Box::new(value))
     }
 
-    pub fn workspace_behind(branch: Branch) -> Self {
-        OxenError::WorkspaceBehind(branch)
+    pub fn workspace_behind(workspace: &Workspace) -> Self {
+        OxenError::WorkspaceBehind(Box::new(workspace.clone()))
     }
 
     pub fn root_commit_does_not_match(commit: Commit) -> Self {

--- a/src/lib/src/model/diff/diff_entry.rs
+++ b/src/lib/src/model/diff/diff_entry.rs
@@ -297,10 +297,7 @@ impl DiffEntry {
         commit: &Commit,
     ) -> Option<MetadataEntry> {
         if let Some(dir) = dir {
-            match repositories::entries::get_meta_entry(repo, commit, dir) {
-                Ok(entry) => Some(entry),
-                Err(_) => None,
-            }
+            repositories::entries::get_meta_entry(repo, commit, dir).ok()
         } else {
             None
         }

--- a/src/lib/src/model/diff/tabular_diff_summary.rs
+++ b/src/lib/src/model/diff/tabular_diff_summary.rs
@@ -157,11 +157,8 @@ impl TabularDiffWrapper {
         match node {
             Some(node) => {
                 let version_path = util::fs::version_path_from_hash(repo, node.hash().to_string());
-                tabular::read_df_with_extension(
-                    version_path,
-                    node.extension(),
-                    &DFOpts::empty(),
-                ).ok()
+                tabular::read_df_with_extension(version_path, node.extension(), &DFOpts::empty())
+                    .ok()
             }
             None => None,
         }

--- a/src/lib/src/model/diff/tabular_diff_summary.rs
+++ b/src/lib/src/model/diff/tabular_diff_summary.rs
@@ -157,14 +157,11 @@ impl TabularDiffWrapper {
         match node {
             Some(node) => {
                 let version_path = util::fs::version_path_from_hash(repo, node.hash().to_string());
-                match tabular::read_df_with_extension(
+                tabular::read_df_with_extension(
                     version_path,
                     node.extension(),
                     &DFOpts::empty(),
-                ) {
-                    Ok(df) => Some(df),
-                    Err(_) => None,
-                }
+                ).ok()
             }
             None => None,
         }
@@ -177,10 +174,7 @@ impl TabularDiffWrapper {
         match entry {
             Some(entry) => {
                 let version_path = util::fs::version_path(repo, entry);
-                match tabular::read_df(version_path, DFOpts::empty()) {
-                    Ok(df) => Some(df),
-                    Err(_) => None,
-                }
+                tabular::read_df(version_path, DFOpts::empty()).ok()
             }
             None => None,
         }

--- a/src/lib/src/model/entry/metadata_entry.rs
+++ b/src/lib/src/model/entry/metadata_entry.rs
@@ -80,10 +80,7 @@ impl MetadataEntry {
         commit: &Commit,
     ) -> Option<MetadataEntry> {
         entry.as_ref()?;
-        match repositories::metadata::from_commit_entry(repo, &entry.unwrap(), commit) {
-            Ok(metadata) => Some(metadata),
-            Err(_) => None,
-        }
+        repositories::metadata::from_commit_entry(repo, &entry.unwrap(), commit).ok()
     }
 
     pub fn from_file_node(
@@ -92,10 +89,7 @@ impl MetadataEntry {
         commit: &Commit,
     ) -> Option<MetadataEntry> {
         node.as_ref()?;
-        match repositories::metadata::from_file_node(repo, &node.unwrap(), commit) {
-            Ok(metadata) => Some(metadata),
-            Err(_) => None,
-        }
+        repositories::metadata::from_file_node(repo, &node.unwrap(), commit).ok()
     }
 
     pub fn from_dir_node(
@@ -104,10 +98,7 @@ impl MetadataEntry {
         commit: &Commit,
     ) -> Option<MetadataEntry> {
         node.as_ref()?;
-        match repositories::metadata::from_dir_node(repo, &node.unwrap(), commit) {
-            Ok(metadata) => Some(metadata),
-            Err(_) => None,
-        }
+        repositories::metadata::from_dir_node(repo, &node.unwrap(), commit).ok()
     }
 }
 

--- a/src/lib/src/model/workspace.rs
+++ b/src/lib/src/model/workspace.rs
@@ -44,6 +44,18 @@ impl Workspace {
     }
 }
 
+impl std::fmt::Display for Workspace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Workspace(name={:?}, commit_id={})",
+            self.name, self.commit.id
+        )
+    }
+}
+
+impl std::error::Error for Workspace {}
+
 /// Conversion from the internal `Workspace` to a `WorkspaceView`
 impl From<Workspace> for WorkspaceView {
     fn from(workspace: Workspace) -> Self {

--- a/src/lib/src/repositories/workspaces.rs
+++ b/src/lib/src/repositories/workspaces.rs
@@ -40,6 +40,7 @@ pub fn get(
     let workspace_dir = Workspace::workspace_dir(repo, &workspace_id_hash);
     let config_path = workspace_dir.join(OXEN_HIDDEN_DIR).join(WORKSPACE_CONFIG);
 
+    log::debug!("workspace::get directory: {workspace_dir:?}");
     if config_path.exists() {
         get_by_dir(repo, workspace_dir)
     } else if let Some(workspace) = get_by_name(repo, workspace_id)? {

--- a/src/lib/src/util/logging.rs
+++ b/src/lib/src/util/logging.rs
@@ -18,7 +18,7 @@ pub fn init_logging() {
         .format(|buf, record| {
             // Split string on a character and take the last part
             fn take_last(s: &str, c: char) -> &str {
-                s.split(c).last().unwrap_or("")
+                s.split(c).next_back().unwrap_or("")
             }
 
             // Format the target to remove "liboxen::" prefix and replace "::" with "/"

--- a/src/lib/src/view/entries.rs
+++ b/src/lib/src/view/entries.rs
@@ -158,6 +158,21 @@ pub struct PaginatedDirEntries {
     pub total_entries: usize,
 }
 
+impl PaginatedDirEntries {
+    pub fn empty() -> PaginatedDirEntries {
+        PaginatedDirEntries {
+            dir: None,
+            entries: vec![],
+            resource: None,
+            metadata: None,
+            page_size: 0,
+            page_number: 0,
+            total_pages: 0,
+            total_entries: 0,
+        }
+    }
+}
+
 #[derive(Deserialize, Serialize, Debug)]
 pub struct PaginatedDirEntriesResponse {
     #[serde(flatten)]

--- a/src/lib/src/view/merge.rs
+++ b/src/lib/src/view/merge.rs
@@ -25,9 +25,15 @@ pub struct MergeableResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct MergeResult {
+    pub head: Commit,
+    pub base: Commit,
+    pub merge: Commit,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MergeSuccessResponse {
     #[serde(flatten)]
     pub status: StatusMessage,
-    pub head_commit: String,
-    pub base_commit: String,
+    pub commits: MergeResult,
 }

--- a/src/lib/src/view/revision.rs
+++ b/src/lib/src/view/revision.rs
@@ -6,6 +6,7 @@ use super::StatusMessage;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ParseResourceResponse {
+    #[serde(flatten)]
     pub status: StatusMessage,
     pub resource: ParsedResource,
 }

--- a/src/lib/src/view/workspaces.rs
+++ b/src/lib/src/view/workspaces.rs
@@ -12,7 +12,7 @@ pub struct NewWorkspace {
     pub resource_path: Option<String>,
     pub entity_type: Option<String>,
     pub name: Option<String>,
-    pub force: bool,
+    pub force: Option<bool>,
 }
 
 // HACK to get this to work with our hub where we don't keep parent_ids 🤦‍♂️

--- a/src/server/src/controllers/branches.rs
+++ b/src/server/src/controllers/branches.rs
@@ -59,15 +59,19 @@ pub async fn create(req: HttpRequest, body: String) -> Result<HttpResponse, Oxen
 
     let repo = get_repo(&app_data.path, namespace, repo_name)?;
 
+    log::debug!("Create branch: {body}");
+
     // Try to deserialize the body into a BranchNewFromBranchName
     let data: Result<BranchNewFromBranchName, serde_json::Error> = serde_json::from_str(&body);
     if let Ok(data) = data {
+        log::debug!("Create from branch!");
         return create_from_branch(&repo, &data);
     }
 
     // Try to deserialize the body into a BranchNewFromCommitId
     let data: Result<BranchNewFromCommitId, serde_json::Error> = serde_json::from_str(&body);
     if let Ok(data) = data {
+        log::debug!("Create from commit!");
         return create_from_commit(&repo, &data);
     }
 

--- a/src/server/src/controllers/file.rs
+++ b/src/server/src/controllers/file.rs
@@ -266,7 +266,7 @@ pub async fn import(
     } else {
         url_parsed
             .path_segments()
-            .and_then(|segments| segments.last())
+            .and_then(|mut segments| segments.next_back())
             .map(|s| s.to_string())
     }
     .ok_or_else(|| OxenHttpError::BadRequest("Invalid filename in URL".into()))?;

--- a/src/server/src/controllers/workspaces/changes.rs
+++ b/src/server/src/controllers/workspaces/changes.rs
@@ -12,6 +12,43 @@ use actix_web::{web, HttpRequest, HttpResponse};
 
 use std::path::PathBuf;
 
+pub async fn list_root(
+    req: HttpRequest,
+    query: web::Query<PageNumQuery>,
+) -> actix_web::Result<HttpResponse, OxenHttpError> {
+    let app_data = app_data(&req)?;
+    let namespace = path_param(&req, "namespace")?;
+    let repo_name = path_param(&req, "repo_name")?;
+    let workspace_id = path_param(&req, "workspace_id")?;
+    log::debug!("/changes looking up repo: {namespace}/{repo_name}");
+
+    let repo = get_repo(&app_data.path, namespace, repo_name)?;
+    let page_num = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
+    let page_size = query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);
+
+    log::debug!("/changes looking up workspace_id: {workspace_id}");
+    let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
+        log::debug!("/changes could not find workspace_id: {workspace_id}");
+        return Ok(HttpResponse::NotFound()
+            .json(StatusMessageDescription::workspace_not_found(workspace_id)));
+    };
+    let path = PathBuf::from(".");
+    let staged = repositories::workspaces::status::status_from_dir(&workspace, &path)?;
+
+    staged.print();
+
+    let response = RemoteStagedStatusResponse {
+        status: StatusMessage::resource_found(),
+        staged: RemoteStagedStatus::from_staged(
+            &workspace.workspace_repo,
+            &staged,
+            page_num,
+            page_size,
+        ),
+    };
+    Ok(HttpResponse::Ok().json(response))
+}
+
 pub async fn list(
     req: HttpRequest,
     query: web::Query<PageNumQuery>,
@@ -20,12 +57,16 @@ pub async fn list(
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
+    log::debug!("/changes looking up repo: {namespace}/{repo_name}");
+
     let repo = get_repo(&app_data.path, namespace, repo_name)?;
     let path = PathBuf::from(path_param(&req, "path")?);
     let page_num = query.page.unwrap_or(constants::DEFAULT_PAGE_NUM);
     let page_size = query.page_size.unwrap_or(constants::DEFAULT_PAGE_SIZE);
 
+    log::debug!("/changes looking up workspace_id: {workspace_id}");
     let Some(workspace) = repositories::workspaces::get(&repo, &workspace_id)? else {
+        log::debug!("/changes could not find workspace_id: {workspace_id}");
         return Ok(HttpResponse::NotFound()
             .json(StatusMessageDescription::workspace_not_found(workspace_id)));
     };

--- a/src/server/src/services/workspaces.rs
+++ b/src/server/src/services/workspaces.rs
@@ -16,6 +16,10 @@ pub fn workspace() -> Scope {
                 .route("", web::get().to(controllers::workspaces::get))
                 .route("", web::delete().to(controllers::workspaces::delete))
                 .route(
+                    "/changes",
+                    web::get().to(controllers::workspaces::changes::list_root),
+                )
+                .route(
                     "/changes/{path:.*}",
                     web::get().to(controllers::workspaces::changes::list),
                 )


### PR DESCRIPTION
Added a client for fetching commit/branch info from a revision string

```
api::client::revisions::get(&remote_repo, revision).await
```

Also made it so `merge` returns the new merge commit info

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enabled branch creation using specific commit IDs.
	- Merge operations now return detailed commit information.
	- Introduced a revision retrieval feature.
	- Launched a new workspace endpoint to view staged changes.
	- Added a method to create empty paginated directory entries.
	- Introduced a new asynchronous function to list workspace changes.

- **Improvements**
	- Enhanced error reporting for workspace conflicts.
	- Refined logging for clearer tracking of workspace and branch operations.
	- Improved organization of merge result data.
	- Streamlined error handling in various functions for better clarity.
	- Updated workspace creation to allow optional force parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->