### PR TITLE
Fix bug where oxen fetch wouldn't check for sync

### DIFF
--- a/src/lib/src/core/v_latest/fetch.rs
+++ b/src/lib/src/core/v_latest/fetch.rs
@@ -90,7 +90,12 @@ pub async fn fetch_remote_branch(
     } else {
         let hash = MerkleHash::from_str(&remote_branch.commit_id)?;
         let commit_node = repositories::tree::get_node_by_id(repo, &hash)?.unwrap();
-        HashSet::from([commit_node.commit()?.to_commit()])
+
+        if core::commit_sync_status::commit_is_synced(repo, &hash) {
+            HashSet::new()
+        } else {
+            HashSet::from([commit_node.commit()?.to_commit()])
+        }
     };
     log::debug!("Fetch got {} commits", commits.len());
 


### PR DESCRIPTION
In fetch_remote_branch, if fetch_opts.all wasn't set, the previous code wouldn't check whether the commits were synced to determine missing commits, but merely for their existance locally. That led to unnecessary downloads and the possibility of partially downloaded files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the update process to bypass reprocessing of items that are already current, reducing redundant work and improving responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->