### PR TITLE
add command to download a file from a workspace

### DIFF
--- a/src/cli/src/cmd/workspace.rs
+++ b/src/cli/src/cmd/workspace.rs
@@ -19,6 +19,9 @@ pub use df::WorkspaceDfCmd;
 pub mod delete;
 pub use delete::WorkspaceDeleteCmd;
 
+pub mod download;
+pub use download::WorkspaceDownloadCmd;
+
 pub mod list;
 pub use list::WorkspaceListCmd;
 
@@ -91,6 +94,7 @@ impl WorkspaceCmd {
             Box::new(WorkspaceDeleteCmd),
             Box::new(WorkspaceListCmd),
             Box::new(WorkspaceStatusCmd),
+            Box::new(WorkspaceDownloadCmd),
         ];
         let mut runners: HashMap<String, Box<dyn RunCmd>> = HashMap::new();
         for cmd in commands {

--- a/src/cli/src/cmd/workspace/download.rs
+++ b/src/cli/src/cmd/workspace/download.rs
@@ -1,0 +1,93 @@
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use clap::{Arg, ArgMatches, Command};
+
+use liboxen::{api, error::OxenError, model::LocalRepository};
+
+use crate::cmd::RunCmd;
+pub const NAME: &str = "download";
+pub struct WorkspaceDownloadCmd;
+
+#[async_trait]
+impl RunCmd for WorkspaceDownloadCmd {
+    fn name(&self) -> &str {
+        NAME
+    }
+
+    fn args(&self) -> Command {
+        Command::new(NAME)
+            .about("Download files from a workspace")
+            .arg(
+                Arg::new("workspace-id")
+                    .long("workspace-id")
+                    .short('w')
+                    .required_unless_present("workspace-name")
+                    .help("The workspace ID of the workspace")
+                    .conflicts_with("workspace-name"),
+            )
+            .arg(
+                Arg::new("workspace-name")
+                    .long("workspace-name")
+                    .short('n')
+                    .required_unless_present("workspace-id")
+                    .help("The name of the workspace")
+                    .conflicts_with("workspace-id"),
+            )
+            .arg(
+                Arg::new("file")
+                    .long("file")
+                    .short('f')
+                    .required(true)
+                    .help("The path of the file to download from the workspace"),
+            )
+            .arg(
+                Arg::new("output")
+                    .long("output")
+                    .short('o')
+                    .help("The output path where the file should be saved"),
+            )
+            .arg_required_else_help(true)
+    }
+
+    async fn run(&self, args: &ArgMatches) -> Result<(), OxenError> {
+        // Parse Args
+        let file_path = args.get_one::<String>("file").expect("Must supply file");
+
+        let workspace_name = args.get_one::<String>("workspace-name");
+        let workspace_id = args.get_one::<String>("workspace-id");
+        let output_path = args
+            .get_one::<String>("output")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(file_path));
+
+        let workspace_identifier = match workspace_id {
+            Some(id) => id,
+            None => {
+                // If no ID is provided, try to get the workspace by name
+                if let Some(name) = workspace_name {
+                    name
+                } else {
+                    return Err(OxenError::basic_str(
+                        "Either workspace-id or workspace-name must be provided.",
+                    ));
+                }
+            }
+        };
+
+        let repository = LocalRepository::from_current_dir()?;
+        let remote_repo = api::client::repositories::get_default_remote(&repository).await?;
+
+        // TODO: We wrote a notebook here, and cannot download the contents: https://www.oxen.ai/ox/Notebooks/workspaces/a92e6de8-5223-41b5-99ec-de238f1560b9/file/eval-qwen.py
+        //       Workflow improvement: auto commit when the notebook spins down, and be able to navigate to workspaces better from the UI.
+        api::client::workspaces::files::download(
+            &remote_repo,
+            workspace_identifier,
+            file_path,
+            Some(&output_path),
+        )
+        .await?;
+
+        Ok(())
+    }
+}

--- a/src/lib/src/api/client/workspaces/files.rs
+++ b/src/lib/src/api/client/workspaces/files.rs
@@ -235,6 +235,26 @@ pub async fn rm(
     Ok(())
 }
 
+pub async fn download(
+    remote_repo: &RemoteRepository,
+    workspace_id: &str,
+    path: &str,
+    output_path: Option<&Path>,
+) -> Result<(), OxenError> {
+    log::debug!("Downloading file from {workspace_id}/{path} to {output_path:?}");
+    let uri = format!("/workspaces/{workspace_id}/files/{path}");
+    let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
+    log::debug!("Downloading file from {url}");
+    let client = client::new_for_url(&url)?;
+    let response = client.get(&url).send().await?;
+    // Save the raw file contents from the response
+    let file_contents = response.bytes().await?;
+    let output_path = output_path.unwrap_or_else(|| Path::new(path));
+    util::fs::write(output_path, file_contents)?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new CLI subcommand to download files from a workspace, allowing users to specify the workspace by ID or name, select a file path, and optionally set an output location for the downloaded file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->