### PR TITLE
Workspace multiple file upload

### DIFF
--- a/src/lib/src/api/client/dir.rs
+++ b/src/lib/src/api/client/dir.rs
@@ -430,7 +430,7 @@ mod tests {
             util::fs::file_create(&full_path)?;
             util::fs::write(&full_path, b"test content")?;
 
-            let _result = api::client::workspaces::files::post_file(
+            let _result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,
@@ -442,7 +442,7 @@ mod tests {
             let full_path = local_repo.path.join(file_path);
             util::fs::write(&full_path, "name,age\nAlice,30\nBob,25\n")?;
 
-            let _result = api::client::workspaces::files::post_file(
+            let _result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,

--- a/src/lib/src/api/client/file.rs
+++ b/src/lib/src/api/client/file.rs
@@ -144,7 +144,7 @@ mod tests {
             util::fs::file_create(&full_path)?;
             util::fs::write(&full_path, b"test content")?;
 
-            let _result = api::client::workspaces::files::post_file(
+            let _result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,

--- a/src/lib/src/api/client/metadata.rs
+++ b/src/lib/src/api/client/metadata.rs
@@ -189,7 +189,7 @@ mod tests {
             util::fs::file_create(&full_path)?;
             util::fs::write(&full_path, b"test content")?;
 
-            let _result = api::client::workspaces::files::post_file(
+            let _result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,
@@ -216,7 +216,7 @@ mod tests {
             let full_path = local_repo.path.join(file_path.clone());
             util::fs::write(&full_path, "name,age\nAlice,30\nBob,25\n")?;
 
-            let _result = api::client::workspaces::files::post_file(
+            let _result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,

--- a/src/lib/src/api/client/workspaces.rs
+++ b/src/lib/src/api/client/workspaces.rs
@@ -474,7 +474,7 @@ mod tests {
 
             // Advance head on main branch, leave behind-main behind
             let path = test::test_img_file();
-            let result = api::client::workspaces::files::post_file(
+            let result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &identifier,
                 main_path,
@@ -496,7 +496,7 @@ mod tests {
 
             // Add a file to behind-main
             let image_path = test::test_1k_parquet();
-            let result = api::client::workspaces::files::post_file(
+            let result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &identifier,
                 main_path,
@@ -519,7 +519,7 @@ mod tests {
 
             // Add file at images/folder to behind-main, committed to main
             let image_path = test::test_100_parquet();
-            let result = api::client::workspaces::files::post_file(
+            let result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &identifier,
                 main_path,
@@ -557,9 +557,13 @@ mod tests {
             api::client::workspaces::create(&remote_repo, DEFAULT_BRANCH_NAME, workspace_id)
                 .await?;
             let path = test::test_img_file();
-            let result =
-                api::client::workspaces::files::post_file(&remote_repo, &&workspace_id, "", path)
-                    .await;
+            let result = api::client::workspaces::files::upload_single_file(
+                &remote_repo,
+                &&workspace_id,
+                "",
+                path,
+            )
+            .await;
             assert!(result.is_ok());
 
             let body = NewCommitBody {
@@ -591,9 +595,13 @@ mod tests {
             )
             .await?;
             let path = test::test_img_file();
-            let result =
-                api::client::workspaces::files::post_file(&remote_repo, &workspace_name, "", path)
-                    .await;
+            let result = api::client::workspaces::files::upload_single_file(
+                &remote_repo,
+                &workspace_name,
+                "",
+                path,
+            )
+            .await;
             assert!(result.is_ok());
 
             let body = NewCommitBody {

--- a/src/lib/src/api/client/workspaces/files.rs
+++ b/src/lib/src/api/client/workspaces/files.rs
@@ -12,46 +12,76 @@ use std::path::{Path, PathBuf};
 
 use crate::core::oxenignore;
 use crate::model::LocalRepository;
-use crate::opts::AddOpts;
 use crate::util;
 
-pub async fn add(
+pub async fn add_from_local_repo(
     local_repo: &LocalRepository,
     remote_repo: &RemoteRepository,
     workspace_id: impl AsRef<str>,
-    path: impl AsRef<Path>,
-    opts: &AddOpts,
+    directory: impl AsRef<str>,
+    paths: Vec<PathBuf>,
 ) -> Result<(), OxenError> {
     let workspace_id = workspace_id.as_ref();
-    let path = path.as_ref();
+    let directory = directory.as_ref();
 
-    // * make sure file is not in .oxenignore
-    let ignore = oxenignore::create(local_repo);
-    if let Some(ignore) = ignore {
-        if ignore.matched(path, path.is_dir()).is_ignore() {
-            return Ok(());
-        }
+    // If no paths provided, return early
+    if paths.is_empty() {
+        return Ok(());
     }
 
-    let (remote_directory, resolved_path) = resolve_remote_add_file_path(local_repo, path, opts)?;
-    let directory_name = remote_directory.to_string_lossy().to_string();
+    let ignore = oxenignore::create(local_repo);
 
-    log::debug!(
-        "repositories::workspaces::add Resolved path: {:?}",
-        resolved_path
-    );
-    log::debug!(
-        "repositories::workspaces::add Remote directory: {:?}",
-        remote_directory
-    );
-    log::debug!(
-        "repositories::workspaces::add Directory name: {:?}",
-        directory_name
-    );
+    for path in &paths {
+        let path = path.as_path();
 
-    let result = post_file(remote_repo, workspace_id, &directory_name, resolved_path).await?;
+        // * make sure file is not in .oxenignore
+        if let Some(ignore) = &ignore {
+            if ignore.matched(path, path.is_dir()).is_ignore() {
+                continue;
+            }
+        }
 
-    println!("{}", result.to_string_lossy());
+        let (remote_directory, resolved_path) =
+            resolve_remote_add_file_path(local_repo, path, directory)?;
+        let directory_name = remote_directory.to_string_lossy().to_string();
+
+        log::debug!(
+            "repositories::workspaces::add Resolved path: {:?}",
+            resolved_path
+        );
+        log::debug!(
+            "repositories::workspaces::add Remote directory: {:?}",
+            remote_directory
+        );
+        log::debug!(
+            "repositories::workspaces::add Directory name: {:?}",
+            directory_name
+        );
+
+        let result = upload_single_file(remote_repo, workspace_id, directory, path).await?;
+
+        println!("{}", result.to_string_lossy());
+    }
+
+    Ok(())
+}
+
+pub async fn add(
+    remote_repo: &RemoteRepository,
+    workspace_id: impl AsRef<str>,
+    directory: impl AsRef<str>,
+    paths: Vec<PathBuf>,
+) -> Result<(), OxenError> {
+    let workspace_id = workspace_id.as_ref();
+    let directory = directory.as_ref();
+
+    // If no paths provided, return early
+    if paths.is_empty() {
+        return Ok(());
+    }
+
+    // TODO: add a progress bar
+    upload_multiple_files(remote_repo, workspace_id, directory, paths).await?;
 
     Ok(())
 }
@@ -60,7 +90,7 @@ pub async fn add(
 fn resolve_remote_add_file_path(
     repo: &LocalRepository,
     path: impl AsRef<Path>,
-    opts: &AddOpts,
+    directory: impl AsRef<str>,
 ) -> Result<(PathBuf, PathBuf), OxenError> {
     let path = path.as_ref();
     match util::fs::canonicalize(path) {
@@ -72,11 +102,10 @@ fn resolve_remote_add_file_path(
                     .parent()
                     .ok_or_else(|| OxenError::file_has_no_parent(&path))?;
                 Ok((remote_directory.to_path_buf(), path))
-            } else if opts.directory.is_some() {
-                // We have to get the remote directory from the opts
-                Ok((opts.directory.clone().unwrap(), path))
             } else {
-                return Err(OxenError::workspace_add_file_not_in_repo(path));
+                // Use the provided directory
+                let dir_path = PathBuf::from(directory.as_ref());
+                Ok((dir_path, path))
             }
         }
         Err(err) => {
@@ -86,7 +115,7 @@ fn resolve_remote_add_file_path(
     }
 }
 
-pub async fn post_file(
+pub async fn upload_single_file(
     remote_repo: &RemoteRepository,
     workspace_id: impl AsRef<str>,
     directory: impl AsRef<Path>,
@@ -115,11 +144,128 @@ pub async fn post_file(
         }
     } else {
         // Single multipart request
-        multipart_file_upload(remote_repo, workspace_id, directory, path).await
+        p_upload_single_file(remote_repo, workspace_id, directory, path).await
     }
 }
 
-async fn multipart_file_upload(
+async fn upload_multiple_files(
+    remote_repo: &RemoteRepository,
+    workspace_id: impl AsRef<str>,
+    directory: impl AsRef<Path>,
+    paths: Vec<PathBuf>,
+) -> Result<(), OxenError> {
+    if paths.is_empty() {
+        return Ok(());
+    }
+
+    let workspace_id = workspace_id.as_ref();
+    let directory = directory.as_ref();
+
+    // Separate files by size, storing the file size with each path
+    let mut large_files = Vec::new();
+    let mut small_files = Vec::new();
+    let mut small_files_size = 0;
+
+    // Group files by size
+    for path in paths {
+        if !path.exists() {
+            log::warn!("File does not exist: {:?}", path);
+            continue;
+        }
+
+        match path.metadata() {
+            Ok(metadata) => {
+                let file_size = metadata.len();
+                if file_size > AVG_CHUNK_SIZE {
+                    // Large file goes directly to parallel upload
+                    large_files.push((path, file_size));
+                } else {
+                    // Small file goes to batch
+                    small_files.push((path, file_size));
+                    small_files_size += file_size;
+                }
+            }
+            Err(err) => {
+                log::warn!("Failed to get metadata for file {:?}: {}", path, err);
+                continue;
+            }
+        }
+    }
+
+    // Process large files individually with parallel upload
+    for (path, size) in large_files {
+        log::info!("Uploading large file: {:?} ({} bytes)", path, size);
+        match api::client::versions::parallel_large_file_upload(
+            remote_repo,
+            &path,
+            Some(directory),
+            Some(workspace_id.to_string()),
+        )
+        .await
+        {
+            Ok(_) => log::debug!("Successfully uploaded large file: {:?}", path),
+            Err(err) => log::error!("Failed to upload large file {:?}: {}", path, err),
+        }
+    }
+
+    // Upload small files in batches
+    sequential_batched_small_file_upload(
+        remote_repo,
+        workspace_id,
+        directory,
+        small_files,
+        small_files_size,
+    )
+    .await?;
+
+    Ok(())
+}
+
+async fn sequential_batched_small_file_upload(
+    remote_repo: &RemoteRepository,
+    workspace_id: impl AsRef<str>,
+    directory: impl AsRef<Path>,
+    small_files: Vec<(PathBuf, u64)>,
+    small_files_size: u64,
+) -> Result<(), OxenError> {
+    // Batch small files in chunks of ~AVG_CHUNK_SIZE
+    log::info!(
+        "Uploading {} small files (total {} bytes)",
+        small_files.len(),
+        small_files_size
+    );
+
+    let workspace_id = workspace_id.as_ref();
+    let directory_str = directory.as_ref().to_string_lossy();
+
+    let mut current_batch = Vec::new();
+    let mut current_batch_size = 0;
+
+    for (idx, (path, file_size)) in small_files.iter().enumerate() {
+        // Add the file to the current batch
+        current_batch.push(path.clone());
+        current_batch_size += file_size;
+
+        // If the current batch is larger than our target size or we're at the end of the list, upload it
+        if current_batch_size > AVG_CHUNK_SIZE || idx == small_files.len() - 1 {
+            log::debug!(
+                "Uploading batch of {} files ({} bytes)",
+                current_batch.len(),
+                current_batch_size
+            );
+            match multipart_upload(remote_repo, workspace_id, &directory_str, current_batch).await {
+                Ok(_) => log::debug!("Successfully uploaded batch of files"),
+                Err(err) => log::error!("Failed to upload batch of files: {}", err),
+            }
+            current_batch = Vec::new();
+            current_batch_size = 0;
+        }
+    }
+
+    Ok(())
+}
+
+async fn p_upload_single_file(
     remote_repo: &RemoteRepository,
     workspace_id: impl AsRef<str>,
     directory: impl AsRef<Path>,
@@ -164,6 +310,41 @@ async fn multipart_file_upload(
             Err(OxenError::basic_str(err))
         }
     }
+}
+
+async fn multipart_upload(
+    remote_repo: &RemoteRepository,
+    workspace_id: impl AsRef<str>,
+    directory_name: impl AsRef<str>,
+    paths: Vec<PathBuf>,
+) -> Result<Vec<PathBuf>, OxenError> {
+    let workspace_id = workspace_id.as_ref();
+    let directory_name = directory_name.as_ref();
+
+    log::debug!("Uploading {} files to {}", paths.len(), directory_name);
+
+    let uri = format!("/workspaces/{workspace_id}/files/{directory_name}");
+    let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
+
+    let mut form = reqwest::multipart::Form::new();
+    for path in paths {
+        let file_name = path
+            .file_name()
+            .unwrap()
+            .to_os_string()
+            .into_string()
+            .ok()
+            .unwrap();
+        let file = std::fs::read(&path).unwrap();
+        let file_part = reqwest::multipart::Part::bytes(file).file_name(file_name);
+        form = form.part("file[]", file_part);
+    }
+
+    let client = client::new_for_url(&url)?;
+    let response = client.post(&url).multipart(form).send().await?;
+    let body = client::parse_json_body(&url, response).await?;
+    let response: FilePathsResponse = serde_json::from_str(&body)?;
+    Ok(response.paths)
 }
 
 pub async fn add_many(
@@ -268,6 +449,7 @@ mod tests {
     use crate::{repositories, test};
 
     use std::path::Path;
+    use uuid;
 
     #[tokio::test]
     async fn test_stage_single_file() -> Result<(), OxenError> {
@@ -288,7 +470,7 @@ mod tests {
             assert_eq!(workspace.id, workspace_id);
 
             let path = test::test_img_file();
-            let result = api::client::workspaces::files::post_file(
+            let result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,
@@ -335,7 +517,7 @@ mod tests {
             assert_eq!(workspace.id, workspace_id);
 
             let path = test::test_30k_parquet();
-            let result = api::client::workspaces::files::post_file(
+            let result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,
@@ -425,7 +607,7 @@ mod tests {
 
             let file_to_post = test::test_1k_parquet();
             let directory_name = "";
-            let result = api::client::workspaces::files::post_file(
+            let result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,
@@ -465,7 +647,7 @@ mod tests {
             assert_eq!(workspace.id, workspace_id);
             let file_to_post = test::test_csv_file_with_name("emojis.csv");
             let directory_name = "moare_data";
-            let result = api::client::workspaces::files::post_file(
+            let result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,
@@ -506,7 +688,7 @@ mod tests {
             assert_eq!(workspace.id, workspace_id);
             let file_to_post = test::test_invalid_parquet_file();
             let directory_name = "broken_data";
-            let result = api::client::workspaces::files::post_file(
+            let result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,
@@ -556,7 +738,7 @@ mod tests {
 
             let file_to_post = test::test_1k_parquet();
             let directory_name = "";
-            let result = api::client::workspaces::files::post_file(
+            let result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,
@@ -596,7 +778,7 @@ mod tests {
             assert_eq!(workspace.id, workspace_id);
             let file_to_post = test::test_csv_file_with_name("emojis.csv");
             let directory_name = "moare_data";
-            let result = api::client::workspaces::files::post_file(
+            let result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,
@@ -637,7 +819,7 @@ mod tests {
             assert_eq!(workspace.id, workspace_id);
             let file_to_post = test::test_invalid_parquet_file();
             let directory_name = "broken_data";
-            let result = api::client::workspaces::files::post_file(
+            let result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,
@@ -695,7 +877,7 @@ mod tests {
 
             let file_to_post = test::test_img_file();
             let directory_name = "data";
-            let result = api::client::workspaces::files::post_file(
+            let result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,
@@ -774,7 +956,7 @@ mod tests {
 
             // Post a parquet file
             let path = test::test_1k_parquet();
-            let result = api::client::workspaces::files::post_file(
+            let result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,
@@ -785,7 +967,7 @@ mod tests {
 
             // Post an image file
             let path = test::test_img_file();
-            let result = api::client::workspaces::files::post_file(
+            let result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,
@@ -881,7 +1063,7 @@ mod tests {
 
             let directory_name = "images";
             let path = test::test_img_file();
-            let result = api::client::workspaces::files::post_file(
+            let result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,
@@ -935,7 +1117,7 @@ mod tests {
             assert_eq!(workspace.id, workspace_id);
 
             let path = test::test_img_file();
-            let result = api::client::workspaces::files::post_file(
+            let result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,
@@ -957,6 +1139,61 @@ mod tests {
             .await?;
             assert_eq!(entries.added_files.entries.len(), 1);
             assert_eq!(entries.added_files.total_entries, 1);
+
+            Ok(remote_repo)
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_add_from_local_repo_multiple_files() -> Result<(), OxenError> {
+        test::run_remote_repo_test_bounding_box_csv_pushed(|local_repo, remote_repo| async move {
+            let branch_name = "add-multiple-files";
+            let branch = api::client::branches::create_from_branch(
+                &remote_repo,
+                branch_name,
+                DEFAULT_BRANCH_NAME,
+            )
+            .await?;
+            assert_eq!(branch.name, branch_name);
+
+            let workspace_id = format!("test-workspace-{}", uuid::Uuid::new_v4());
+            let workspace =
+                api::client::workspaces::create(&remote_repo, &branch_name, &workspace_id).await?;
+            assert_eq!(workspace.id, workspace_id);
+
+            // Prepare paths and directory
+            let paths = vec![
+                test::test_img_file(),
+                test::test_img_file_with_name("cole_anthony.jpeg"),
+            ];
+            let directory = "test_data";
+
+            // Call the add function with multiple files
+            let result = api::client::workspaces::files::add_from_local_repo(
+                &local_repo,
+                &remote_repo,
+                &workspace_id,
+                directory,
+                paths,
+            )
+            .await;
+            assert!(result.is_ok());
+
+            // Verify that both files were added
+            let page_num = constants::DEFAULT_PAGE_NUM;
+            let page_size = constants::DEFAULT_PAGE_SIZE;
+            let path = Path::new(directory);
+            let entries = api::client::workspaces::changes::list(
+                &remote_repo,
+                &workspace_id,
+                path,
+                page_num,
+                page_size,
+            )
+            .await?;
+            assert_eq!(entries.added_files.entries.len(), 2);
+            assert_eq!(entries.added_files.total_entries, 2);
 
             Ok(remote_repo)
         })

--- a/src/lib/src/repositories/rm.rs
+++ b/src/lib/src/repositories/rm.rs
@@ -237,7 +237,7 @@ mod tests {
             assert_eq!(workspace.id, workspace_id);
             let file_to_post = test::test_csv_file_with_name("emojis.csv");
             let directory_name = "phi-4";
-            let result = api::client::workspaces::files::post_file(
+            let result = api::client::workspaces::files::upload_single_file(
                 &remote_repo,
                 &workspace_id,
                 directory_name,

--- a/src/lib/src/repositories/workspaces.rs
+++ b/src/lib/src/repositories/workspaces.rs
@@ -748,10 +748,20 @@ mod tests {
             // Modify files in each workspace
             util::fs::write_to_path(&file1, "Updated file 1")?;
             util::fs::write_to_path(&file2, "Updated file 2")?;
-            api::client::workspaces::files::post_file(&remote_repo, &workspace1.id, "dir1", file1)
-                .await?;
-            api::client::workspaces::files::post_file(&remote_repo, &workspace2.id, "dir2", file2)
-                .await?;
+            api::client::workspaces::files::upload_single_file(
+                &remote_repo,
+                &workspace1.id,
+                "dir1",
+                file1,
+            )
+            .await?;
+            api::client::workspaces::files::upload_single_file(
+                &remote_repo,
+                &workspace2.id,
+                "dir2",
+                file2,
+            )
+            .await?;
 
             // Create commit bodies
             let commit_body1 = NewCommitBody {
@@ -836,7 +846,7 @@ mod tests {
                     // Add a unique file
                     let file_path = repo.path.join(format!("file-{}.txt", i));
                     util::fs::write_to_path(&file_path, format!("content {}", i))?;
-                    api::client::workspaces::files::post_file(
+                    api::client::workspaces::files::upload_single_file(
                         &remote_repo,
                         &workspace.id,
                         "",

--- a/src/lib/src/util/fs.rs
+++ b/src/lib/src/util/fs.rs
@@ -791,7 +791,6 @@ pub fn copy_mkdir(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<(), Ox
 
 /// Recursively check if a file exists within a directory
 pub fn file_exists_in_directory(directory: impl AsRef<Path>, file: impl AsRef<Path>) -> bool {
-    // TODO: Can't this just check if the directory is a substring of the file?
     let mut file = file.as_ref();
     while file.parent().is_some() {
         if directory.as_ref() == file.parent().unwrap() {

--- a/src/lib/src/util/fs.rs
+++ b/src/lib/src/util/fs.rs
@@ -791,6 +791,7 @@ pub fn copy_mkdir(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<(), Ox
 
 /// Recursively check if a file exists within a directory
 pub fn file_exists_in_directory(directory: impl AsRef<Path>, file: impl AsRef<Path>) -> bool {
+    // TODO: Can't this just check if the directory is a substring of the file?
     let mut file = file.as_ref();
     while file.parent().is_some() {
         if directory.as_ref() == file.parent().unwrap() {
@@ -1733,6 +1734,20 @@ mod tests {
 
         let relative = util::fs::path_relative_to_dir(file, dir)?;
         assert_eq!(relative, Path::new("other").join("dir"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn path_relative_to_unrelated_dir() -> Result<(), OxenError> {
+        let file = Path::new("data").join("test").join("other").join("dir");
+        let dir = Path::new("some").join("repo");
+
+        let relative = util::fs::path_relative_to_dir(file, dir)?;
+        assert_eq!(
+            relative,
+            Path::new("data").join("test").join("other").join("dir")
+        );
 
         Ok(())
     }


### PR DESCRIPTION
This is an intermediate step towards what we want this to look like to unblock some of our load testing. More updates including locking around staged DB and parallel small file uploads in next PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved support for adding multiple files to a workspace at once, with optimized batching and parallel uploads for large files.

- **Bug Fixes**
  - Paths matching ignore rules are now correctly filtered out when adding files to a workspace.

- **Refactor**
  - File upload operations in tests and implementation now use a unified method for single-file uploads.
  - Enhanced logic for handling multiple file uploads, improving efficiency and reliability.

- **Tests**
  - Added new tests for uploading multiple files and for verifying path handling in unrelated directories.
  - Updated existing tests to use the new file upload method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->