### PR TITLE
Check modified time before file hash in checkout

### DIFF
--- a/src/lib/src/core/v_latest/branches.rs
+++ b/src/lib/src/core/v_latest/branches.rs
@@ -412,9 +412,9 @@ fn r_restore_missing_or_modified_files(
                 progress.increment_restored();
             } else {
                 // File exists, check if it needs to be updated
-                let current_hash = util::hasher::hash_file_contents(&full_path)?;
-                if current_hash != file_node.hash().to_string() {
+                if util::fs::is_modified_from_node(&full_path, file_node)? {
                     let mut from_node: Option<FileNode> = None;
+
                     if let Some(from_tree) = from_tree {
                         if let Some(node_from_tree) = from_tree.get_by_path(&rel_path)? {
                             if let EMerkleTreeNode::File(file_node) = &node_from_tree.node {


### PR DESCRIPTION
Implemented a new utility function to compare a file in the working directory against its node in the merkle tree. It first checks the file's modified time, and if that differs from the node, only then is the file hashed for comparison. This avoids the unnecessary re-hashing of markedly unmodified files in the checkout code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved file restoration logic by encapsulating file modification checks into a utility function, resulting in cleaner and more maintainable code.
- **New Features**
  - Added a utility to detect if a file has been modified compared to its stored metadata and hash, enhancing accuracy during file restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->