### PR TITLE
fix download of large files

### DIFF
--- a/src/cli/src/cmd/push.rs
+++ b/src/cli/src/cmd/push.rs
@@ -75,8 +75,17 @@ impl RunCmd for PushCmd {
             check_remote_version_blocking(host.clone()).await?;
             check_remote_version(host).await?;
 
-            repositories::push::push_remote_branch(&repository, remote, branch).await?;
-            Ok(())
+            match repositories::push::push_remote_branch(&repository, remote, branch).await {
+                Ok(_) => Ok(()),
+                Err(OxenError::BranchNotFound(branch)) => {
+                    let msg = format!("{}\nMake sure you are on the correct branch and have committed your changes.", branch);
+                    Err(OxenError::basic_str(msg))
+                }
+                Err(e) => {
+                    println!("Error pushing: {}", e);
+                    Err(e)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes OXB-82

Downloading files in a directory would not download send the path properly to download the large files. We also had a weird inner loop that was doing extra work, not sure how it was working at all before.

```
oxen download ox/fine-tune-medical-qwen  --host localhost:3001 --scheme http models/qwen-med/SFT_14_2025-04-30_08-43-59_Qwen2.5-1.5B-Instruct/checkpoints/checkpoint_12
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error messages and user feedback when pushing to a remote branch that does not exist.
- **Style**
	- Enhanced debug logging for directory downloads to provide clearer and more detailed information.
- **Tests**
	- Added a new test to verify remote directory downloads with large files, ensuring correct handling and file integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->