### PR TITLE
set concurrency on fetch_all to be 1

### DIFF
--- a/src/lib/src/repositories/fetch.rs
+++ b/src/lib/src/repositories/fetch.rs
@@ -4,7 +4,6 @@
 //!
 
 use crate::api;
-use crate::constants::DEFAULT_NUM_WORKERS;
 use crate::core;
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;

--- a/src/lib/src/repositories/fetch.rs
+++ b/src/lib/src/repositories/fetch.rs
@@ -68,8 +68,9 @@ pub async fn fetch_all(
         let remote_repo = remote_repo.clone();
         async move { fetch_remote_branch(&repo, &remote_repo, &opts).await }
     }))
-    // Limit to DEFAULT_NUM_WORKERS concurrent fetches
-    .buffer_unordered(DEFAULT_NUM_WORKERS)
+    // We were having concurrency issues unpacking the merkle tree tarballs
+    // setting to 1 for now, then we can revisit
+    .buffer_unordered(1)
     .collect::<Vec<_>>();
 
     let branches: Result<Vec<Branch>, OxenError> = stream.await.into_iter().collect();


### PR DESCRIPTION
We were non-deterministically getting this error:

```
Error running test. Err: IO(Custom { kind: AlreadyExists, error: TarError { desc: "failed to create `/Users/josh/src/oxen/Oxen/data/test/runs/dir/data/test/runs/ec62a224-8299-441b-95c1-99de64a05a14/new_repo/.oxen/tree/nodes/e96/e57f7dceef70c623bc593297da9c8`", io: Custom { kind: AlreadyExists, error: VerboseError { source: Os { code: 17, kind: AlreadyExists, message: "File exists" }, message: "could not create directory `/Users/josh/src/oxen/Oxen/data/test/runs/dir/data/test/runs/ec62a224-8299-441b-95c1-99de64a05a14/new_repo/.oxen/tree/nodes/e96`" } } } })

thread 'repositories::fetch::tests::test_fetch_branches' panicked at src/lib/src/test.rs:214:5
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of remote branch fetching by processing fetch operations one at a time, addressing issues related to concurrent operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->