### PR TITLE
Make cache dir configurable

### DIFF
--- a/src/lib/src/constants.rs
+++ b/src/lib/src/constants.rs
@@ -11,8 +11,6 @@ pub const OXEN_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const OXEN_HIDDEN_DIR: &str = ".oxen";
 /// Folder name for oxen home within `.cache`, `.config`., etc.
 pub const OXEN: &str = "oxen";
-/// ~/.cache/oxen holds tmp downloads
-pub const TMP_DIR: &str = ".cache";
 /// ~/.config/oxen holds config files
 pub const CONFIG_DIR: &str = ".config";
 /// .oxenignore is the name of the file that contains the ignore patterns

--- a/src/lib/src/error.rs
+++ b/src/lib/src/error.rs
@@ -303,6 +303,10 @@ impl OxenError {
         OxenError::basic_str("Home directory not found")
     }
 
+    pub fn cache_dir_not_found() -> OxenError {
+        OxenError::basic_str("Cache directory not found")
+    }
+
     pub fn must_be_on_valid_branch() -> OxenError {
         OxenError::basic_str("Repository is in a detached HEAD state, checkout a valid branch to continue.\n\n  oxen checkout <branch>\n")
     }

--- a/src/lib/src/util/fs.rs
+++ b/src/lib/src/util/fs.rs
@@ -45,9 +45,14 @@ pub fn oxen_hidden_dir(repo_path: impl AsRef<Path>) -> PathBuf {
 }
 
 pub fn oxen_tmp_dir() -> Result<PathBuf, OxenError> {
-    match dirs::home_dir() {
-        Some(home_dir) => Ok(home_dir.join(constants::TMP_DIR).join(constants::OXEN)),
-        None => Err(OxenError::home_dir_not_found()),
+    // Override the cache dir with the OXEN_TMP_DIR env var if it is set
+    if let Ok(tmp_dir) = std::env::var("OXEN_TMP_DIR") {
+        return Ok(PathBuf::from(tmp_dir));
+    }
+
+    match dirs::cache_dir() {
+        Some(cache_dir) => Ok(cache_dir.join(constants::OXEN)),
+        None => Err(OxenError::cache_dir_not_found()),
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The application now supports using the OXEN_TMP_DIR environment variable to specify a custom temporary directory.
  - Improved error messaging when the cache directory cannot be found.

- **Refactor**
  - Updated the logic for determining the temporary directory to prioritize the environment variable and system cache directory over the user's home directory.

- **Chores**
  - Removed an unused constant related to the temporary directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->