### PR TITLE
Optimize checkout logic with seen files hashset

### DIFF
--- a/src/lib/src/core/v_latest/branches.rs
+++ b/src/lib/src/core/v_latest/branches.rs
@@ -1,14 +1,15 @@
 use indicatif::{ProgressBar, ProgressStyle};
 
 use crate::core::v_latest::index::restore::{self, FileToRestore};
+use crate::core::v_latest::index::CommitMerkleTree;
 use crate::core::v_latest::{fetch, index};
 use crate::error::OxenError;
 use crate::model::merkle_tree::node::{EMerkleTreeNode, FileNode, MerkleTreeNode};
-use crate::model::{Commit, CommitEntry, LocalRepository};
+use crate::model::{Commit, CommitEntry, LocalRepository, MerkleHash};
 use crate::repositories;
 use crate::util;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -151,6 +152,7 @@ pub async fn checkout_subtrees(
         let parent_path = subtree_path.parent().unwrap_or(Path::new(""));
         let mut files_to_restore: Vec<FileToRestore> = vec![];
         let mut cannot_overwrite_entries: Vec<PathBuf> = vec![];
+        let mut seen_files: HashSet<MerkleHash> = HashSet::new();
         r_restore_missing_or_modified_files(
             repo,
             &target_root,
@@ -159,6 +161,7 @@ pub async fn checkout_subtrees(
             &mut files_to_restore,
             &mut cannot_overwrite_entries,
             &mut progress,
+            &mut seen_files,
         )?;
 
         if !cannot_overwrite_entries.is_empty() {
@@ -214,19 +217,20 @@ pub async fn set_working_repo_to_commit(
         ));
     };
 
-    let from_node = if let Some(from_commit) = maybe_from_commit {
-        if from_commit.id == to_commit.id {
-            return Ok(());
-        }
+    let mut files_to_restore: Vec<FileToRestore> = vec![];
+    let mut cannot_overwrite_entries: Vec<PathBuf> = vec![];
+    let mut seen_files: HashSet<MerkleHash> = HashSet::new();
 
-        // Only cleanup removed files if we are checking out from an existing tree
-        let Some(from_node) = repositories::tree::get_root_with_children(repo, from_commit)? else {
-            return Err(OxenError::basic_str("Cannot get root node for base commit"));
-        };
-        cleanup_removed_files(repo, &target_node, &from_node, &mut progress)?;
-        Some(from_node)
-    } else {
-        None
+    let from_node = match maybe_from_commit {
+        Some(from_commit) => {
+            if from_commit.id == to_commit.id {
+                return Ok(());
+            }
+
+            repositories::tree::get_root_with_children(repo, from_commit)
+                .map_err(|_| OxenError::basic_str("Cannot get root node for base commit"))?
+        }
+        None => None,
     };
 
     // You may be thinking, why do we not do this in one pass?
@@ -235,8 +239,6 @@ pub async fn set_working_repo_to_commit(
 
     // If we did it in one pass, we would not know if we should remove the file
     // or restore it.
-    let mut files_to_restore: Vec<FileToRestore> = vec![];
-    let mut cannot_overwrite_entries: Vec<PathBuf> = vec![];
     r_restore_missing_or_modified_files(
         repo,
         &target_node,
@@ -245,7 +247,20 @@ pub async fn set_working_repo_to_commit(
         &mut files_to_restore,
         &mut cannot_overwrite_entries,
         &mut progress,
+        &mut seen_files,
     )?;
+
+    // Cleanup files if checking out from another commit
+    if maybe_from_commit.is_some() {
+        cleanup_removed_files(
+            repo,
+            &target_node,
+            &from_node.unwrap(),
+            &mut progress,
+            to_commit,
+            &mut seen_files,
+        )?;
+    }
 
     // If there are conflicts, return an error without restoring anything
     if !cannot_overwrite_entries.is_empty() {
@@ -270,22 +285,26 @@ fn cleanup_removed_files(
     target_node: &MerkleTreeNode,
     from_node: &MerkleTreeNode,
     progress: &mut CheckoutProgressBar,
+    to_commit: &Commit,
+    seen: &mut HashSet<MerkleHash>,
 ) -> Result<(), OxenError> {
     // Compare the nodes in the from tree to the nodes in the target tree
     // If the file node is in the from tree, but not in the target tree, remove it
     let from_root_dir_node = repositories::tree::get_root_dir(from_node)?;
     log::debug!("cleanup_removed_files from_commit {}", from_root_dir_node);
 
+    let dir_hashes = CommitMerkleTree::dir_hashes(repo, to_commit)?;
     let mut paths_to_remove: Vec<PathBuf> = vec![];
     let mut cannot_overwrite_entries: Vec<PathBuf> = vec![];
     r_remove_if_not_in_target(
         repo,
         from_root_dir_node,
-        from_node,
         target_node,
         Path::new(""),
         &mut paths_to_remove,
         &mut cannot_overwrite_entries,
+        &dir_hashes,
+        seen,
     )?;
 
     if !cannot_overwrite_entries.is_empty() {
@@ -310,20 +329,20 @@ fn cleanup_removed_files(
 fn r_remove_if_not_in_target(
     repo: &LocalRepository,
     head_node: &MerkleTreeNode,
-    from_tree_root: &MerkleTreeNode,
     target_tree_root: &MerkleTreeNode,
     current_path: &Path,
     paths_to_remove: &mut Vec<PathBuf>,
     cannot_overwrite_entries: &mut Vec<PathBuf>,
+    dir_hashes: &HashMap<PathBuf, MerkleHash>,
+    seen_files: &mut HashSet<MerkleHash>,
 ) -> Result<(), OxenError> {
     match &head_node.node {
         EMerkleTreeNode::File(file_node) => {
             let file_path = current_path.join(file_node.name());
-            let target_node = target_tree_root.get_by_path(&file_path)?;
 
-            if target_node.is_none() {
+            if !seen_files.contains(&head_node.hash) {
                 let full_path = repo.path.join(&file_path);
-                if full_path.exists() {
+                if full_path.exists() && target_tree_root.get_by_path(&file_path)?.is_none() {
                     // Verify that the file is not in a modified state
                     if util::fs::is_modified_from_node(&full_path, file_node)? {
                         cannot_overwrite_entries.push(file_path.clone());
@@ -334,39 +353,58 @@ fn r_remove_if_not_in_target(
                 }
             }
         }
-        EMerkleTreeNode::Directory(dir_node) => {
-            // TODO: can we also check if the directory is in the target tree,
-            // and potentially remove the whole directory?
-            let dir_path = current_path.join(dir_node.name());
 
-            // Check if the directory is the same in the from and target trees
-            // If it is, we don't need to do anything
-            if let Some(target_node) = target_tree_root.get_by_path(&dir_path)? {
+        EMerkleTreeNode::Directory(dir_node) => {
+            let dir_path = current_path.join(dir_node.name());
+            let children = if let Some(target_hash) = dir_hashes.get(&dir_path) {
+                let target_node = CommitMerkleTree::read_node(repo, target_hash, false)?.unwrap();
+
+                // Check if the same directory is in target trees
                 if target_node.node.hash() == dir_node.hash() {
                     return Ok(());
                 }
-            }
 
-            let from_dir = from_tree_root
-                .get_by_path(&dir_path)?
-                .ok_or(OxenError::basic_str(format!(
-                    "Could not find directory in from tree: {:?}",
-                    dir_path
-                )))?;
-            let from_children = repositories::tree::list_files_and_folders(&from_dir)?;
-            for child in from_children {
-                // If the hashes match, we don't need to check if we need to remove any children
-                // because the subdirectory will be the same content-wise
+                // Get vnodes for the from dir node
+                let dir_vnodes = &head_node.children;
+
+                // Get vnode hashes for the target dir node
+                let mut target_hashes = HashSet::new();
+                for child in &target_tree_root.get_vnodes_for_dir(&dir_path)? {
+                    if let EMerkleTreeNode::VNode(_) = &child.node {
+                        target_hashes.insert(child.hash);
+                    }
+                }
+
+                // Filter out vnodes that are present in the target tree
+                let mut unique_nodes = Vec::new();
+                for vnode in dir_vnodes {
+                    if !target_hashes.contains(&vnode.hash) {
+                        unique_nodes.extend(vnode.children.iter().cloned());
+                    }
+                }
+
+                unique_nodes
+            } else {
+                // Dir not found in target tree; need to check every file/folder
+                repositories::tree::list_files_and_folders(head_node)?
+            };
+
+            for child in &children {
                 r_remove_if_not_in_target(
                     repo,
-                    &child,
-                    from_tree_root,
+                    child,
                     target_tree_root,
                     &dir_path,
                     paths_to_remove,
                     cannot_overwrite_entries,
+                    dir_hashes,
+                    seen_files,
                 )?;
             }
+            log::debug!(
+                "r_remove_if_not_in_target checked {:?} paths",
+                children.len()
+            );
 
             // Remove directory if it's empty
             let full_dir_path = repo.path.join(&dir_path);
@@ -387,6 +425,7 @@ fn r_restore_missing_or_modified_files(
     files_to_restore: &mut Vec<FileToRestore>,
     cannot_overwrite_entries: &mut Vec<PathBuf>,
     progress: &mut CheckoutProgressBar,
+    seen_files: &mut HashSet<MerkleHash>,
 ) -> Result<(), OxenError> {
     // Recursively iterate through the tree, checking each file against the working repo
     // If the file is not in the working repo, restore it from the commit
@@ -397,6 +436,7 @@ fn r_restore_missing_or_modified_files(
         EMerkleTreeNode::File(file_node) => {
             let rel_path = path.join(file_node.name());
             let full_path = repo.path.join(&rel_path);
+
             if !full_path.exists() {
                 // File doesn't exist, restore it
                 log::debug!("Restoring missing file: {:?}", rel_path);
@@ -435,7 +475,10 @@ fn r_restore_missing_or_modified_files(
                     progress.increment_modified();
                 }
             }
+
+            seen_files.insert(node.hash);
         }
+        // MATCH VNODES
         EMerkleTreeNode::Directory(dir_node) => {
             // Early exit if the directory is the same in the from and target trees
             if let Some(from_tree) = from_tree {
@@ -459,6 +502,7 @@ fn r_restore_missing_or_modified_files(
                     files_to_restore,
                     cannot_overwrite_entries,
                     progress,
+                    seen_files,
                 )?;
             }
         }
@@ -473,6 +517,7 @@ fn r_restore_missing_or_modified_files(
                 files_to_restore,
                 cannot_overwrite_entries,
                 progress,
+                seen_files,
             )?;
         }
         _ => {

--- a/src/lib/src/core/v_latest/index/commit_merkle_tree.rs
+++ b/src/lib/src/core/v_latest/index/commit_merkle_tree.rs
@@ -215,6 +215,47 @@ impl CommitMerkleTree {
         }
     }
 
+    // Load in dir with only its vnodes
+    /* pub fn dir_with_vnodes(
+        repo: &LocalRepository,
+        commit: &Commit,
+        path: impl AsRef<Path>,
+    ) -> Result<Option<MerkleTreeNode>, OxenError> {
+        let node_path = path.as_ref();
+        log::debug!("dir_with_vnodes read path {:?} in commit {:?}", node_path, commit);
+        let dir_hashes = CommitMerkleTree::dir_hashes(repo, commit)?;
+        let node_hash: Option<MerkleHash> = dir_hashes.get(node_path).cloned();
+        if let Some(node_hash) = node_hash {
+            log::debug!("Look up dir 🗂️ {:?}", node_path);
+            // Read the node and its vnodes
+            // Can't use read_depth, because read_children_until_depth doesn't count vnodes
+            let mut node = MerkleTreeNode::from_hash(repo, hash)?;
+            let mut node_db = MerkleNodeDB::open_read_only(repo, hash)?;
+
+            let children: Vec<(MerkleHash, MerkleTreeNode)> = node_db.map()?;
+
+            for (_key, child) in children {
+                   // Here we have to not panic on error, because if we clone a subtree we might not have all of the children nodes of a particular dir
+                        // given that we are only loading the nodes that are needed.
+                        if let Ok(mut node_db) = MerkleNodeDB::open_read_only(repo, &child.hash) {
+                            CommitMerkleTree::read_children_until_depth(
+                                repo,
+                                &mut node_db,
+                                &mut child,
+                                requested_depth,
+                                traversed_depth,
+                            )?;
+                        }
+                node.children.push(child);
+
+            }
+
+        } else {
+            Ok(None)
+        }
+    }
+    */
+
     pub fn read_node(
         repo: &LocalRepository,
         hash: &MerkleHash,


### PR DESCRIPTION
Speeds up r_remove_if_not_in_target in the checkout logic by implementing a hashset of seen files from the target tree. Previously, that function would have to lookup every file it was checking for removal in the Merkle tree. To avoid this, we now do r_restore_missing_or_modified_files first, and store every file it comes across in a hashset, so that the check for its presence in the from tree is immediate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file checkout operations to prevent redundant file processing and ensure correct file removal and restoration.
  - Enhanced directory handling during file removal to avoid unnecessary recursion and improve accuracy.

- **Refactor**
  - Updated internal logic for commit handling and file tracking to streamline operations and error handling.

- **Chores**
  - Added (commented out) a new method for loading directory nodes with vnode children for potential future use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->