### PR TITLE
fix `oxen add` on files where the metadata does not exist

### DIFF
--- a/src/cli/src/cmd/notebook.rs
+++ b/src/cli/src/cmd/notebook.rs
@@ -241,9 +241,7 @@ impl NotebookCmd {
             repository.namespace, repository.name, notebook.id
         );
         println!("✅ Notebook {} successfully started", notebook.id);
-        if "edit" == opts.mode {
-            println!("\nVisit the notebook at:\n\n  {}\n\nTo stop the notebook run:\n\n  oxen notebook stop -n {}\n", url, notebook.id)
-        }
+        println!("\nVisit the notebook at:\n\n  {}\n\nTo stop the notebook run:\n\n  oxen notebook stop -n {}\n", url, notebook.id);
         Ok(())
     }
 

--- a/src/cli/src/cmd/notebook.rs
+++ b/src/cli/src/cmd/notebook.rs
@@ -237,7 +237,7 @@ impl NotebookCmd {
         let notebook = api::client::notebooks::create(repository, opts).await?;
         api::client::notebooks::run(repository, &notebook).await?;
         let url = format!(
-            "https://hub.oxen.ai/{}/{}/notebooks/{}",
+            "https://oxen.ai/{}/{}/notebooks/{}",
             repository.namespace, repository.name, notebook.id
         );
         println!("✅ Notebook {} successfully started", notebook.id);

--- a/src/cli/src/cmd/status.rs
+++ b/src/cli/src/cmd/status.rs
@@ -91,6 +91,7 @@ impl RunCmd for StatusCmd {
             is_remote,
             ignore: parse_ignore_files(args.get_one::<String>("ignore")),
         };
+        log::debug!("status opts: {:?}", opts);
 
         let repo_status = repositories::status::status_from_opts(&repository, &opts)?;
 

--- a/src/lib/src/core/v_latest/add.rs
+++ b/src/lib/src/core/v_latest/add.rs
@@ -273,9 +273,12 @@ pub fn process_add_dir(
                 }
 
                 let file_name = &path.file_name().unwrap_or_default().to_string_lossy();
-                let file_status =
+                let Ok(file_status) =
                     core::v_latest::add::determine_file_status(&dir_node, file_name, &path)
-                        .unwrap();
+                else {
+                    log::debug!("Could not determine file status for {:?}", path);
+                    return;
+                };
                 version_store
                     .store_version_from_path(&file_status.hash.to_string(), &path)
                     .unwrap();

--- a/src/lib/src/model/staged_data.rs
+++ b/src/lib/src/model/staged_data.rs
@@ -264,9 +264,10 @@ impl StagedData {
                 } else {
                     dir_row.push("\n".normal());
                 }
-            }
-            if !dir_row.is_empty() {
-                dirs.push(dir_row);
+
+                if !dir_row.is_empty() {
+                    dirs.push(dir_row.clone());
+                }
             }
         }
 
@@ -274,6 +275,7 @@ impl StagedData {
             return;
         }
 
+        log::debug!("num dirs staged: {}", dirs.len());
         outputs.push("Directories to be committed\n".normal());
         self.__collapse_outputs(&dirs, |dir| dir.to_vec(), outputs, opts);
         outputs.push("\n".normal());
@@ -530,6 +532,11 @@ impl StagedData {
     ) where
         F: Fn(&T) -> Vec<ColoredString>,
     {
+        log::debug!(
+            "__collapse_outputs inputs.len(): {} opts: {:?}",
+            inputs.len(),
+            opts
+        );
         if inputs.is_empty() {
             return;
         }

--- a/src/lib/src/util/fs.rs
+++ b/src/lib/src/util/fs.rs
@@ -866,7 +866,7 @@ pub fn metadata(path: impl AsRef<Path>) -> Result<std::fs::Metadata, OxenError> 
     match std::fs::metadata(path) {
         Ok(file) => Ok(file),
         Err(err) => {
-            log::error!("metadata {:?} {}", path, err);
+            log::debug!("metadata {:?} {}", path, err);
             Err(OxenError::file_metadata_error(path, err))
         }
     }


### PR DESCRIPTION
Fixes OXB-89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when determining file status during directory processing, preventing unexpected crashes and allowing processing to continue smoothly if a file status cannot be determined.

- **Style**
  - Adjusted logging levels for certain file system errors to reduce noise in error logs.

- **Chores**
  - Added additional debug logging throughout the application to aid in troubleshooting and provide more detailed status information during operations.
  - Enhanced notebook command messages to always display the notebook URL and stop instructions regardless of mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->