### PR TITLE
add ability to download/export a data frame from a workspace

### DIFF
--- a/src/cli/src/cmd/workspace/download.rs
+++ b/src/cli/src/cmd/workspace/download.rs
@@ -78,8 +78,6 @@ impl RunCmd for WorkspaceDownloadCmd {
         let repository = LocalRepository::from_current_dir()?;
         let remote_repo = api::client::repositories::get_default_remote(&repository).await?;
 
-        // TODO: We wrote a notebook here, and cannot download the contents: https://www.oxen.ai/ox/Notebooks/workspaces/a92e6de8-5223-41b5-99ec-de238f1560b9/file/eval-qwen.py
-        //       Workflow improvement: auto commit when the notebook spins down, and be able to navigate to workspaces better from the UI.
         api::client::workspaces::files::download(
             &remote_repo,
             workspace_identifier,

--- a/src/lib/src/api/client/workspaces/files.rs
+++ b/src/lib/src/api/client/workspaces/files.rs
@@ -337,8 +337,13 @@ pub async fn download(
     path: &str,
     output_path: Option<&Path>,
 ) -> Result<(), OxenError> {
+    let uri = if util::fs::has_tabular_extension(path) {
+        format!("/workspaces/{workspace_id}/data_frames/download/{path}")
+    } else {
+        format!("/workspaces/{workspace_id}/files/{path}")
+    };
+
     log::debug!("Downloading file from {workspace_id}/{path} to {output_path:?}");
-    let uri = format!("/workspaces/{workspace_id}/files/{path}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
     log::debug!("Downloading file from {url}");
     let client = client::new_for_url(&url)?;

--- a/src/lib/src/util/fs.rs
+++ b/src/lib/src/util/fs.rs
@@ -884,7 +884,10 @@ pub fn file_create(path: impl AsRef<Path>) -> Result<std::fs::File, OxenError> {
     }
 }
 
-pub fn is_tabular_from_extension(data_path: &Path, file_path: &Path) -> bool {
+/// Looks at both the extension and the first bytes of the file to determine if it is tabular
+pub fn is_tabular_from_extension(data_path: impl AsRef<Path>, file_path: impl AsRef<Path>) -> bool {
+    let data_path = data_path.as_ref();
+    let file_path = file_path.as_ref();
     if has_ext(file_path, "json") {
         // check if the first character in the file is '['
         // if so it is just a json array we can treat as tabular
@@ -895,6 +898,12 @@ pub fn is_tabular_from_extension(data_path: &Path, file_path: &Path) -> bool {
         }
     }
 
+    has_tabular_extension(file_path)
+}
+
+/// Looks at the extension of the file to determine if it is tabular
+pub fn has_tabular_extension(file_path: impl AsRef<Path>) -> bool {
+    let file_path = file_path.as_ref();
     let exts: HashSet<String> = vec!["csv", "tsv", "parquet", "arrow", "ndjson", "jsonl"]
         .into_iter()
         .map(String::from)


### PR DESCRIPTION
The file may not exist on the server if it is a data frame in a workspace, so we have a separate endpoint to download data frames.

This was the behavior before:

<img width="1467" alt="Screenshot 2025-05-14 at 10 37 19 AM" src="https://github.com/user-attachments/assets/f3d2af19-2c1d-430d-be3e-deaa55eb9e85" />

Now we check the file extension, if it is a data frame, download it from the data frame endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved detection of tabular file types, including enhanced support for JSON files containing arrays.
  - Downloads for tabular files now use a specialized endpoint, improving handling of data frame formats.

- **Refactor**
  - Updated file type checking functions for greater flexibility and clarity.

- **Chores**
  - Removed obsolete comments related to notebook download workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->