### PR TITLE
Diff fix: check for condition where neither node exists

### DIFF
--- a/src/lib/src/core/v_latest/diff.rs
+++ b/src/lib/src/core/v_latest/diff.rs
@@ -496,6 +496,12 @@ pub fn diff_entries(
     head_commit: &Commit,
     df_opts: DFOpts,
 ) -> Result<DiffEntry, OxenError> {
+    if base_entry.is_none() && head_entry.is_none() {
+        return Err(OxenError::basic_str(
+            "Could not calculate diff: neither base nor head entries exist.",
+        ));
+    }
+
     // Assume both entries exist
     let mut status = DiffEntryStatus::Modified;
 

--- a/src/lib/src/core/v_latest/index/commit_merkle_tree.rs
+++ b/src/lib/src/core/v_latest/index/commit_merkle_tree.rs
@@ -176,8 +176,9 @@ impl CommitMerkleTree {
             log::debug!("Look up dir 🗂️ {:?}", node_path);
             CommitMerkleTree::read_node(repo, &node_hash, load_recursive)?.ok_or(
                 OxenError::basic_str(format!(
-                    "Merkle tree hash not found for parent: '{}'",
-                    node_path.to_str().unwrap()
+                    "Merkle tree hash not found for dir: '{}' in commit: '{}'",
+                    node_path.to_str().unwrap(),
+                    commit.id
                 )),
             )?
         } else {
@@ -185,8 +186,9 @@ impl CommitMerkleTree {
             log::debug!("Look up file 📄 {:?}", node_path);
             CommitMerkleTree::read_file(repo, &dir_hashes, node_path)?.ok_or(
                 OxenError::basic_str(format!(
-                    "Merkle tree hash not found for parent: '{}'",
-                    node_path.to_str().unwrap()
+                    "Merkle tree hash not found for file: '{}' in commit: '{}'",
+                    node_path.to_str().unwrap(),
+                    commit.id
                 )),
             )?
         };

--- a/src/lib/src/model/diff/diff_entry.rs
+++ b/src/lib/src/model/diff/diff_entry.rs
@@ -171,6 +171,11 @@ impl DiffEntry {
         should_do_full_diff: bool,
         df_opts: Option<DFOpts>, // only for tabular
     ) -> Result<DiffEntry, OxenError> {
+        log::debug!(
+            "from_file_nodes: base_entry: {:?}, head_entry: {:?}",
+            base_entry,
+            head_entry
+        );
         let file_path = file_path.as_ref().to_path_buf();
         // Need to check whether we have the head or base entry to check data about the file
         let (current_entry, data_type) = if let Some(entry) = &head_entry {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved early error handling when attempting to calculate a diff with missing entries, providing clearer feedback if neither entry exists.

- **Enhancements**
  - Updated error messages for Merkle tree lookups to specify whether the missing node is a directory or file and to include the commit ID for better context.
  - Added debug logging to help trace inputs when creating diff entries from file nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->