### PR TITLE
fix packaging up non-existant sub-trees

### DIFF
--- a/src/lib/src/api/client/file.rs
+++ b/src/lib/src/api/client/file.rs
@@ -119,7 +119,7 @@ mod tests {
             let bytes = api::client::file::get_file(&remote_repo, branch_name, file_path).await;
 
             assert!(bytes.is_ok());
-            assert!(bytes.unwrap().len() > 0);
+            assert!(!bytes.unwrap().is_empty());
 
             Ok(remote_repo)
         })
@@ -153,7 +153,7 @@ mod tests {
             let bytes = api::client::file::get_file(&remote_repo, workspace_id, file_path).await;
 
             assert!(bytes.is_ok());
-            assert!(bytes.as_ref().unwrap().len() > 0);
+            assert!(!bytes.as_ref().unwrap().is_empty());
             assert_eq!(bytes.unwrap(), Bytes::from_static(b"test content"));
 
             Ok(remote_repo)

--- a/src/server/src/controllers/tree.rs
+++ b/src/server/src/controllers/tree.rs
@@ -339,8 +339,13 @@ fn get_unique_node_hashes_for_subtree(
     depth: &Option<i32>,
     unique_node_hashes: &mut HashSet<MerkleHash>,
 ) -> Result<(), OxenError> {
-    let tree = repositories::tree::get_subtree_by_depth(repository, commit, subtree_path, depth)?
-        .ok_or(OxenError::basic_str("subtree not found"))?;
+    // If the subtree is not found, then we don't need to add any nodes to the unique node hashes
+    let Ok(Some(tree)) =
+        repositories::tree::get_subtree_by_depth(repository, commit, subtree_path, depth)
+    else {
+        return Ok(());
+    };
+
     tree.walk_tree_without_leaves(|node| {
         unique_node_hashes.insert(node.hash);
     });


### PR DESCRIPTION
fixes OXB-108

Steps to reproduce:

1) Clone repo with subtree filter
2) oxen checkout -b branch1
3) oxen add dir1/newfile.txt
4) oxen commit dir1/newfile.txt
5) oxen push origin branch1
6) oxen pull origin main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new test covering subtree cloning, branching, pushing, and pulling to ensure correct behavior with subtree filters.

- **Bug Fixes**
  - Improved handling of missing subtrees by treating their absence as a non-error condition, preventing unnecessary error messages.

- **Style**
  - Updated test assertions to use a more idiomatic style for checking non-empty file content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->