### PR TITLE
add create large upload request to allow hub to check storage usage

### DIFF
--- a/src/lib/src/view/versions.rs
+++ b/src/lib/src/view/versions.rs
@@ -53,3 +53,11 @@ pub struct CompleteVersionUploadRequest {
     // otherwise, we will just add the file to the versions store
     pub workspace_id: Option<String>,
 }
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct CreateVersionUploadRequest {
+    pub hash: String,
+    pub file_name: String,
+    pub size: u64,
+    pub dst_dir: Option<PathBuf>,
+}

--- a/src/server/src/controllers/versions/chunks.rs
+++ b/src/server/src/controllers/versions/chunks.rs
@@ -118,5 +118,5 @@ pub async fn complete(req: HttpRequest, body: String) -> Result<HttpResponse, Ox
 }
 
 pub async fn create(_req: HttpRequest, _body: String) -> Result<HttpResponse, OxenHttpError> {
-    return Ok(HttpResponse::Ok().json(StatusMessage::resource_found()));
+    Ok(HttpResponse::Ok().json(StatusMessage::resource_found()))
 }

--- a/src/server/src/controllers/versions/chunks.rs
+++ b/src/server/src/controllers/versions/chunks.rs
@@ -116,3 +116,7 @@ pub async fn complete(req: HttpRequest, body: String) -> Result<HttpResponse, Ox
 
     Ok(HttpResponse::BadRequest().json(StatusMessage::error("Invalid request body")))
 }
+
+pub async fn create(_req: HttpRequest, _body: String) -> Result<HttpResponse, OxenHttpError> {
+    return Ok(HttpResponse::Ok().json(StatusMessage::resource_found()));
+}

--- a/src/server/src/services/versions.rs
+++ b/src/server/src/services/versions.rs
@@ -23,4 +23,8 @@ pub fn versions() -> Scope {
             "/{version_id}/complete",
             web::post().to(controllers::versions::chunks::complete),
         )
+        .route(
+            "/{version_id}/create",
+            web::post().to(controllers::versions::chunks::create),
+        )
 }


### PR DESCRIPTION
Add a request that allows the hub to check if the user in question has enough storage to accept the file being streamed. If there is no hub in the infrastructure its just a no op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for initiating large file uploads with additional metadata, including file hash, name, size, and optional destination directory.
  - Introduced a new upload creation endpoint to streamline the large file upload process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->