### PR TITLE
pre-commit hooks to run clippy and fmt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt -- --check
+        language: system
+        types: [rust]
+        pass_filenames: false
+        always_run: true
+
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --no-deps -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false
+        always_run: true

--- a/README.md
+++ b/README.md
@@ -281,6 +281,15 @@ To set a different test host you can set the `OXEN_TEST_HOST` environment variab
 env OXEN_TEST_HOST=0.0.0.0:4000 cargo test
 ```
 
+## Pre-Commit Hook
+
+We use [pre-commit-hooks](https://github.com/pre-commit/pre-commit-hooks) to check for commit consistency.
+make sure to install [`pre-commit-hooks`](https://pre-commit.com/) library
+and then install the precommits locally using
+```
+pre-commit install
+```
+
 # Oxen Server
 
 ## Structure


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced pre-commit hooks to automatically check for trailing whitespace and enforce Rust code formatting and linting before commits.

- **Documentation**
  - Updated the README with instructions for installing and using pre-commit hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->