### PR TITLE
Make sure 'oxen add' respects .oxenignore

### DIFF
--- a/src/lib/src/core/oxenignore.rs
+++ b/src/lib/src/core/oxenignore.rs
@@ -1,6 +1,8 @@
 use ignore::gitignore::Gitignore;
+use std::path::Path;
 
 use crate::constants;
+use crate::constants::OXEN_HIDDEN_DIR;
 use crate::model::LocalRepository;
 
 /// Create will load the .oxenignore if it exists. If it does not exist, it will return None.
@@ -16,4 +18,21 @@ pub fn create(repo: &LocalRepository) -> Option<Gitignore> {
             None
         }
     }
+}
+
+/// Check if a path should be ignored based on .oxenignore rules
+pub fn is_ignored(path: &Path, gitignore: &Option<Gitignore>, is_dir: bool) -> bool {
+    // Skip hidden .oxen files
+    if path.starts_with(OXEN_HIDDEN_DIR) {
+        return true;
+    }
+    if let Some(gitignore) = gitignore {
+        if gitignore
+            .matched_path_or_any_parents(path, is_dir)
+            .is_ignore()
+        {
+            return true;
+        }
+    }
+    false
 }

--- a/src/lib/src/core/v_latest/status.rs
+++ b/src/lib/src/core/v_latest/status.rs
@@ -564,7 +564,7 @@ fn count_removed_entries(
     gitignore: &Option<Gitignore>,
     removed_entries: &mut usize,
 ) -> Result<(), OxenError> {
-    if oxenignore::is_ignored(relative_path, gitignore, relative_path.is_dir()) {
+    if oxenignore::is_ignored(relative_path, gitignore, true) {
         return Ok(());
     }
 

--- a/src/lib/src/core/v_latest/status.rs
+++ b/src/lib/src/core/v_latest/status.rs
@@ -1,4 +1,3 @@
-use crate::constants::OXEN_HIDDEN_DIR;
 use crate::constants::STAGED_DIR;
 use crate::core::db;
 use crate::core::oxenignore;
@@ -392,7 +391,7 @@ fn find_changes(
     let mut untracked = UntrackedData::new();
     let mut modified = HashSet::new();
     let mut removed = HashSet::new();
-    let gitignore = oxenignore::create(repo);
+    let gitignore: Option<Gitignore> = oxenignore::create(repo);
 
     let mut entries: Vec<PathBuf> = Vec::new();
     if full_path.is_dir() {
@@ -427,7 +426,7 @@ fn find_changes(
             search_node_path
         );
 
-        if is_ignored(&relative_path, &gitignore, path.is_dir()) {
+        if oxenignore::is_ignored(&relative_path, &gitignore, path.is_dir()) {
             continue;
         }
 
@@ -565,7 +564,7 @@ fn count_removed_entries(
     gitignore: &Option<Gitignore>,
     removed_entries: &mut usize,
 ) -> Result<(), OxenError> {
-    if is_ignored(relative_path, gitignore, relative_path.is_dir()) {
+    if oxenignore::is_ignored(relative_path, gitignore, relative_path.is_dir()) {
         return Ok(());
     }
 
@@ -629,19 +628,6 @@ fn maybe_get_node(
     } else {
         CommitMerkleTree::read_file(repo, dir_hashes, path)
     }
-}
-
-fn is_ignored(path: &Path, gitignore: &Option<Gitignore>, is_dir: bool) -> bool {
-    // Skip hidden .oxen files
-    if path.starts_with(OXEN_HIDDEN_DIR) {
-        return true;
-    }
-    if let Some(gitignore) = gitignore {
-        if gitignore.matched(path, is_dir).is_ignore() {
-            return true;
-        }
-    }
-    false
 }
 
 fn is_staged(


### PR DESCRIPTION
This adds the support for the .oxenignore file in the add command and remove some dead code (the **add_dir** function).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for ignoring files and directories based on .oxenignore patterns when adding files to the repository.
  - Introduced a unified ignore check that respects hidden Oxen directories and .oxenignore rules across file operations.

- **Bug Fixes**
  - Ensured that files and directories matching .oxenignore rules are consistently excluded from being staged or tracked.

- **Tests**
  - Added tests to verify that ignored files are not staged, while other files and the .oxenignore file itself are staged as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->