### PR TITLE
enable cloning with target directory name

### DIFF
--- a/src/cli/src/cmd/clone.rs
+++ b/src/cli/src/cmd/clone.rs
@@ -87,15 +87,12 @@ impl RunCmd for CloneCmd {
                 }
 
                 let joined = current_dir.join(path);
-                let canon = joined
-                    .canonicalize()
-                    .map_err(|_| OxenError::basic_str("Failed to resolve destination"))?;
-                if !canon.starts_with(&current_dir) {
+                if !joined.starts_with(&current_dir) {
                     return Err(OxenError::basic_str(
                         "Invalid destination: path escapes base directory",
                     ));
                 }
-                canon
+                joined
             }
             None => {
                 // Get the name of the repo from the url


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The clone command now supports an optional destination directory argument, allowing users to specify the folder name for cloned repositories. If not provided, the default naming behavior remains unchanged.  
  - Destination paths are validated to ensure they are relative and confined within the current working directory for improved safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->