### PR TITLE
Make sure all 'text/*' MIME types are detected as text

### DIFF
--- a/src/lib/src/util/fs.rs
+++ b/src/lib/src/util/fs.rs
@@ -1077,7 +1077,7 @@ pub fn datatype_from_mimetype_from_extension(
             // Catch text and dataframe types from file extension
             if is_tabular_from_extension(data_path, file_path) {
                 EntryDataType::Tabular
-            } else if "text/plain" == mime_type || "text/markdown" == mime_type {
+            } else if mime_type.starts_with("text/") {
                 EntryDataType::Text
             } else {
                 // split on the first half of the mime type to fall back to audio, video, image
@@ -1769,6 +1769,38 @@ mod tests {
     #[test]
     fn detect_file_type() -> Result<(), OxenError> {
         test::run_training_data_repo_test_no_commits(|repo| {
+            let python_file = "add_1.py";
+            let python_with_interpreter_file = "add_2.py";
+
+            test::write_txt_file_to_path(
+                repo.path.join(python_file),
+                r"import os
+
+
+def add(a, b):
+    return a + b",
+            )?;
+
+            test::write_txt_file_to_path(
+                repo.path.join(python_with_interpreter_file),
+                r"#!/usr/bin/env python3
+import os
+
+
+def add(a, b):
+    return a + b",
+            )?;
+
+            assert_eq!(
+                EntryDataType::Text,
+                util::fs::file_data_type(&repo.path.join(python_file))
+            );
+
+            assert_eq!(
+                EntryDataType::Text,
+                util::fs::file_data_type(&repo.path.join(python_with_interpreter_file))
+            );
+
             assert_eq!(
                 EntryDataType::Tabular,
                 util::fs::file_data_type(


### PR DESCRIPTION
This fixes an issue where text files with a shebang line as the first line was detected as binary. This is because it's MIME type is `text/x-shellscript` which was not matched as a text type.

I don't think we need to strictly match on some text types and not others. Text is text. So I removed the strict condition on `text/plain` and `text/markdown`.

I didn't adapt this logic to the audio, video and image types since the system actually need to support the individual formats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved detection of text files to include all MIME types starting with "text/", ensuring more file types are correctly recognized as text.
- **Tests**
	- Added new tests to verify accurate detection of Python files as text files, including those with a shebang line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->