### PR TITLE
FIX: make oxen fetch consistent

### DIFF
--- a/src/lib/src/core/v_latest/fetch.rs
+++ b/src/lib/src/core/v_latest/fetch.rs
@@ -23,13 +23,7 @@ pub async fn fetch_remote_branch(
     remote_repo: &RemoteRepository,
     fetch_opts: &FetchOpts,
 ) -> Result<Branch, OxenError> {
-    log::debug!(
-        "fetching remote branch {} --all {} --subtree {:?} --depth {:?}",
-        fetch_opts.branch,
-        fetch_opts.all,
-        fetch_opts.subtree_paths,
-        fetch_opts.depth,
-    );
+    log::debug!("fetching remote branch with opts {:?}", fetch_opts);
 
     // Start the timer
     let start = std::time::Instant::now();


### PR DESCRIPTION
Fetch had a bug where oxen fetch on the current branch would rewrite the head causing inconsistent history. This PR fixes that inconsistency

now, branches that are not present locally will be created with correct commit history for branches that are already present locally, we only fetch the blobs without updating the HEAD, which means we'd have to do a pull

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved debug logging for fetch operations, making log messages more concise and informative.
  - Enhanced handling of branch fetching by clearly distinguishing between branches to fetch and branches to create, improving clarity in branch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->