### PR TITLE
implement post order traversal with time sorting

### DIFF
--- a/src/lib/src/core/v_latest/commits.rs
+++ b/src/lib/src/core/v_latest/commits.rs
@@ -263,9 +263,11 @@ fn recurse_commit(
         return Ok(());
     }
 
-    if stop_at_base.is_some() && &head_commit == stop_at_base.unwrap() {
-        results.push(head_commit.clone());
-        return Ok(());
+    if let Some(base) = stop_at_base {
+        if head_commit.id == base.id {
+            results.push(head_commit.clone());
+            return Ok(());
+        }
     }
 
     let mut parent_commits: Vec<Commit> = Vec::new();

--- a/src/lib/src/core/v_latest/commits.rs
+++ b/src/lib/src/core/v_latest/commits.rs
@@ -244,23 +244,44 @@ fn list_recursive(
     stop_at_base: Option<&Commit>,
     visited: &mut HashSet<String>,
 ) -> Result<(), OxenError> {
+    recurse_commit(repo, head_commit, results, stop_at_base, visited)?;
+    results.reverse();
+    Ok(())
+}
+
+// post-order traversal of the commit tree
+// returns a Topological sort with priority to timestamp in case of multiple parents
+fn recurse_commit(
+    repo: &LocalRepository,
+    head_commit: Commit,
+    results: &mut Vec<Commit>,
+    stop_at_base: Option<&Commit>,
+    visited: &mut HashSet<String>,
+) -> Result<(), OxenError> {
     // Check if we've already visited this commit
     if !visited.insert(head_commit.id.clone()) {
         return Ok(());
     }
 
-    results.push(head_commit.clone());
-
     if stop_at_base.is_some() && &head_commit == stop_at_base.unwrap() {
+        results.push(head_commit.clone());
         return Ok(());
     }
 
-    for parent_id in head_commit.parent_ids {
+    let mut parent_commits: Vec<Commit> = Vec::new();
+    for parent_id in head_commit.parent_ids.clone() {
         let parent_id = MerkleHash::from_str(&parent_id)?;
-        if let Some(parent_commit) = get_by_hash(repo, &parent_id)? {
-            list_recursive(repo, parent_commit, results, stop_at_base, visited)?;
+        if let Some(c) = get_by_hash(repo, &parent_id)? {
+            parent_commits.push(c);
         }
     }
+
+    parent_commits.sort_by_key(|c| c.timestamp);
+    for parent_commit in parent_commits {
+        recurse_commit(repo, parent_commit, results, stop_at_base, visited)?;
+    }
+    results.push(head_commit.clone());
+
     Ok(())
 }
 
@@ -342,9 +363,6 @@ pub fn list_from(
     if let Some(commit) = commit {
         list_recursive(repo, commit, &mut results, None, &mut HashSet::new())?;
     }
-    // TODO: Git does something called as a `date-order` traversal which guarantees that the parent never comes before a child
-    // irrespective of the timestamp. We should implement that at a later time.
-    results.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
 
     Ok(results)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the logic for listing commits to provide a more accurate ordering, prioritizing parent commits by timestamp and ensuring parents are listed before children. This results in a more intuitive and reliable commit history display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->