### PR TITLE
add directory check when doing `oxen add .`

### DIFF
--- a/src/lib/src/core/v_latest/add.rs
+++ b/src/lib/src/core/v_latest/add.rs
@@ -73,7 +73,6 @@ pub fn add(repo: &LocalRepository, path: impl AsRef<Path>) -> Result<(), OxenErr
             log::debug!("glob path: {}", path_str);
             // Match against any untracked entries in the current dir
             for entry in glob(path_str)? {
-                log::debug!("🥳 entry: {:?}", entry);
                 paths.insert(entry?);
             }
 
@@ -838,7 +837,6 @@ pub fn add_dir_to_staged_db(
         node: MerkleTreeNode::default_dir_from_path(relative_path),
     };
 
-    log::debug!("🔥 writing dir to staged db: {}", dir_entry);
     let mut buf = Vec::new();
     dir_entry.serialize(&mut Serializer::new(&mut buf)).unwrap();
     staged_db.put(relative_path_str, &buf).unwrap();

--- a/src/lib/src/core/v_latest/add.rs
+++ b/src/lib/src/core/v_latest/add.rs
@@ -896,6 +896,61 @@ mod tests {
     }
 
     #[test]
+    fn test_add_dot_on_committed_repo() -> Result<(), OxenError> {
+        test::run_empty_local_repo_test(|repo| {
+            let dir1 = repo.path.join("dir1");
+            let dir2 = repo.path.join("dir2");
+            std::fs::create_dir_all(&dir1)?;
+            std::fs::create_dir_all(&dir2)?;
+            println!("😂{:?}", repo.path);
+
+            let file1_1 = dir1.join("file1_1.txt");
+            let file1_2 = dir1.join("file1_2.txt");
+            let file2_1 = dir2.join("file2_1.txt");
+            let file_root = repo.path.join("file_root.txt");
+
+            test::write_txt_file_to_path(&file1_1, "dir1/file1_1")?;
+            test::write_txt_file_to_path(&file1_2, "dir1/file1_2")?;
+            test::write_txt_file_to_path(&file2_1, "dir2/file2_1")?;
+            test::write_txt_file_to_path(&file_root, "file_root")?;
+
+            add(&repo, &repo.path)?;
+
+            repositories::commits::commit(&repo, "Initial commit with multiple files and dirs")?;
+
+            add(&repo, &repo.path)?;
+
+            let status = repositories::status(&repo);
+            assert!(status.is_ok());
+            let status = status.unwrap();
+
+            assert!(status.staged_files.is_empty(), "No files should be staged");
+            assert!(
+                status.staged_dirs.is_empty(),
+                "No directories should be staged"
+            );
+            assert!(
+                status.untracked_files.is_empty(),
+                "No files should be untracked"
+            );
+            assert!(
+                status.untracked_dirs.is_empty(),
+                "No directories should be untracked"
+            );
+            assert!(
+                status.modified_files.is_empty(),
+                "No files should be modified"
+            );
+            assert!(
+                status.removed_files.is_empty(),
+                "No files should be removed"
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn test_add_respects_dir_ignore_patterns() -> Result<(), OxenError> {
         test::run_empty_local_repo_test(|repo| {
             let dir_to_ignore = "ignored_dir";

--- a/src/lib/src/core/v_latest/add.rs
+++ b/src/lib/src/core/v_latest/add.rs
@@ -902,7 +902,6 @@ mod tests {
             let dir2 = repo.path.join("dir2");
             std::fs::create_dir_all(&dir1)?;
             std::fs::create_dir_all(&dir2)?;
-            println!("😂{:?}", repo.path);
 
             let file1_1 = dir1.join("file1_1.txt");
             let file1_2 = dir1.join("file1_2.txt");

--- a/src/lib/src/core/v_latest/merge.rs
+++ b/src/lib/src/core/v_latest/merge.rs
@@ -447,10 +447,6 @@ fn fast_forward_merge(
         ));
     };
 
-    if merge_tree.hash == base_tree.hash {
-        return Err(OxenError::basic_str("both branches at same commit"));
-    }
-
     // Stop early if there are conflicts
     let mut merge_tree_results = MergeResult::new();
     let mut seen_files = HashSet::new();

--- a/src/lib/src/core/v_latest/merge.rs
+++ b/src/lib/src/core/v_latest/merge.rs
@@ -447,6 +447,10 @@ fn fast_forward_merge(
         ));
     };
 
+    if merge_tree.hash == base_tree.hash {
+        return Err(OxenError::basic_str("both branches at same commit"));
+    }
+
     // Stop early if there are conflicts
     let mut merge_tree_results = MergeResult::new();
     let mut seen_files = HashSet::new();

--- a/src/lib/src/repositories/checkout.rs
+++ b/src/lib/src/repositories/checkout.rs
@@ -262,7 +262,7 @@ mod tests {
             repositories::add(&repo, &world_file)?;
 
             // Commit the world file
-            let second_commit = repositories::commit(&repo, "Adding world")?;
+            let _ = repositories::commit(&repo, "Adding world")?;
 
             // Create and checkout branch
             let branch_name = "feature/my-branch";

--- a/src/lib/src/repositories/pull.rs
+++ b/src/lib/src/repositories/pull.rs
@@ -1929,7 +1929,7 @@ mod tests {
                 .await?;
 
                 // 6. Pull from main
-                repositories::pull_remote_branch(
+                let pull_result = repositories::pull_remote_branch(
                     &repo,
                     &FetchOpts {
                         remote: constants::DEFAULT_REMOTE_NAME.to_string(),
@@ -1940,7 +1940,12 @@ mod tests {
                         ..FetchOpts::new()
                     },
                 )
-                .await?;
+                .await;
+
+                assert_eq!(
+                    pull_result.unwrap_err().to_string(),
+                    OxenError::basic_str("No changes to commit").to_string()
+                );
 
                 // Verify the state after pull
                 assert!(repo.path.join("train").exists());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved directory staging to skip re-adding directories already present in the latest commit.

- **Bug Fixes**
  - Enhanced merge and pull operations to handle cases with no new changes gracefully, showing clear messages.

- **Tests**
  - Added tests covering directory staging, branch checkout, merge scenarios, and pull operations to ensure expected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->