### PR TITLE
Add runtime to user agent

### DIFF
--- a/src/lib/src/config.rs
+++ b/src/lib/src/config.rs
@@ -5,6 +5,7 @@ pub mod auth_config;
 pub mod embedding_config;
 pub mod endpoint;
 pub mod repository_config;
+pub mod runtime_config;
 pub mod user_config;
 
 pub use crate::config::auth_config::AuthConfig;
@@ -17,3 +18,5 @@ pub use crate::config::user_config::UserConfig;
 pub use crate::config::user_config::USER_CONFIG_FILENAME;
 
 pub use crate::config::repository_config::RepositoryConfig;
+
+pub use crate::config::runtime_config::RuntimeConfig;

--- a/src/lib/src/config/runtime_config.rs
+++ b/src/lib/src/config/runtime_config.rs
@@ -1,0 +1,63 @@
+pub mod platform;
+pub mod runtime;
+
+use crate::config::runtime_config::platform::Platform;
+use crate::config::runtime_config::runtime::Runtime;
+use crate::error::OxenError;
+use std::sync::OnceLock;
+use std::sync::RwLock;
+
+const VERSION: &str = crate::constants::OXEN_VERSION;
+
+#[derive(Debug, Clone)]
+pub struct RuntimeConfig {
+    pub runtime_name: Runtime,
+    pub runtime_version: String,
+    pub host_platform: Platform,
+}
+
+impl Default for RuntimeConfig {
+    fn default() -> Self {
+        RuntimeConfig {
+            runtime_name: Runtime::CLI,
+            runtime_version: String::from(VERSION),
+            host_platform: Platform::from_os_identifier(std::env::consts::OS),
+        }
+    }
+}
+
+static RUNTIME_CONFIG: OnceLock<RwLock<RuntimeConfig>> = OnceLock::new();
+
+fn get_runtime_config() -> &'static RwLock<RuntimeConfig> {
+    RUNTIME_CONFIG.get_or_init(|| RwLock::new(RuntimeConfig::default()))
+}
+
+impl RuntimeConfig {
+    pub fn set(runtime_name: String, runtime_version: String) -> Result<(), OxenError> {
+        let config = RuntimeConfig {
+            runtime_name: Runtime::from_runtime_name(runtime_name.as_str()),
+            runtime_version,
+            host_platform: Platform::from_os_identifier(std::env::consts::OS),
+        };
+
+        Self::update(config)
+    }
+
+    pub fn get() -> Result<RuntimeConfig, OxenError> {
+        get_runtime_config()
+            .read()
+            .map(|config| config.clone())
+            .map_err(|_| OxenError::basic_str("Failed to read global configuration"))
+    }
+
+    pub fn update(config: RuntimeConfig) -> Result<(), OxenError> {
+        if let Ok(mut runtime_config) = get_runtime_config().write() {
+            *runtime_config = config;
+            Ok(())
+        } else {
+            Err(OxenError::basic_str(
+                "Failed to update global configuration",
+            ))
+        }
+    }
+}

--- a/src/lib/src/config/runtime_config/platform.rs
+++ b/src/lib/src/config/runtime_config/platform.rs
@@ -1,0 +1,27 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Platform {
+    Linux,
+    Windows,
+    MacOS,
+    Unknown,
+}
+
+impl Platform {
+    pub fn from_os_identifier(s: &str) -> Self {
+        match s {
+            "linux" => Platform::Linux,
+            "windows" => Platform::Windows,
+            "macos" => Platform::MacOS,
+            _ => Platform::Unknown,
+        }
+    }
+
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            Platform::Linux => "Linux",
+            Platform::Windows => "Windows",
+            Platform::MacOS => "MacOS",
+            Platform::Unknown => "Unknown",
+        }
+    }
+}

--- a/src/lib/src/config/runtime_config/runtime.rs
+++ b/src/lib/src/config/runtime_config/runtime.rs
@@ -1,0 +1,21 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Runtime {
+    CLI,
+    Python,
+}
+
+impl Runtime {
+    pub fn from_runtime_name(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "python" => Runtime::Python,
+            _ => Runtime::CLI,
+        }
+    }
+
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            Runtime::Python => "Python",
+            Runtime::CLI => "CLI",
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://linear.app/oxenai/issue/OXB-139/be-able-to-differentiate-python-requests-from-regular-cli-requests-on

This reads from a global static variable set at library initialization time to get information on the runtime used to call liboxen.

It defaults to CLI. The Python bindings set it to `Python` and passes the Python version as well.

It uses this information to build a more detailed user agent.

Here are some examples:

```
Oxen/0.35.0 (MacOS; Python 3.13.3)
Oxen/0.35.0 (Windows; Python 3.11.0)
Oxen/0.35.0 (Linux; CLI)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced global runtime configuration management to track runtime name, version, and host platform.
  - Enhanced user agent string with detailed platform and runtime information.

- **Bug Fixes**
  - Improved version extraction from user agent strings for more reliable client version validation.

- **Documentation**
  - Publicly re-exported runtime configuration types for easier access in other parts of the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->