### PR TITLE
Fix route shadowing in /tree API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_url_params",
+ "serde_with",
  "sha2",
  "signal-hook",
  "simdutf8",
@@ -742,7 +743,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "indexmap",
+ "indexmap 2.9.0",
  "lexical-core",
  "num",
  "serde",
@@ -1460,6 +1461,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
@@ -2562,7 +2564,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2581,7 +2583,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3043,6 +3045,17 @@ checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
@@ -3441,6 +3454,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_url_params",
+ "serde_with",
  "sha2",
  "signal-hook",
  "simdutf8",
@@ -4439,7 +4453,7 @@ dependencies = [
  "either",
  "hashbrown 0.14.5",
  "hashbrown 0.15.3",
- "indexmap",
+ "indexmap 2.9.0",
  "itoa",
  "num-traits",
  "once_cell",
@@ -4544,7 +4558,7 @@ dependencies = [
  "chrono",
  "fallible-streaming-iterator",
  "hashbrown 0.15.3",
- "indexmap",
+ "indexmap 2.9.0",
  "itoa",
  "num-traits",
  "polars-arrow",
@@ -4617,7 +4631,7 @@ dependencies = [
  "either",
  "hashbrown 0.15.3",
  "hex",
- "indexmap",
+ "indexmap 2.9.0",
  "jsonpath_lib_polars_vendor",
  "memchr",
  "num-traits",
@@ -4755,7 +4769,7 @@ version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c6aa4913cffc522cea3ccbc0cafb350bec18fed0a1ef8d417ac88ea320d7749"
 dependencies = [
- "indexmap",
+ "indexmap 2.9.0",
  "polars-error",
  "polars-utils",
  "version_check",
@@ -4846,7 +4860,7 @@ dependencies = [
  "bytes",
  "compact_str",
  "hashbrown 0.15.3",
- "indexmap",
+ "indexmap 2.9.0",
  "libc",
  "memmap2",
  "num-traits",
@@ -5667,6 +5681,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5758,7 +5784,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap",
+ "indexmap 2.9.0",
  "itoa",
  "memchr",
  "ryu",
@@ -5803,6 +5829,37 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.9.0",
+ "schemars",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6488,7 +6545,7 @@ version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
- "indexmap",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -7481,7 +7538,7 @@ dependencies = [
  "flate2",
  "getrandom 0.3.3",
  "hmac",
- "indexmap",
+ "indexmap 2.9.0",
  "lzma-rs",
  "memchr",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ serde = { version = "1.0.188", features = ["derive"] }
 serde_derive = "1.0.188"
 serde_json = "1.0.106"
 serde_url_params = "0.2.1"
+serde_with = "3.13.0"
 sha2 = "0.10.8"
 signal-hook = "0.3.17"
 simdutf8 = "0.1.4"

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -111,6 +111,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0.78"
 serde_url_params = "0.2.1"
+serde_with = "3.13.0"
 signal-hook = "0.3.13"
 simdutf8 = "0.1.4"
 sha2 = "0.10.8"

--- a/src/lib/src/api/client/tree.rs
+++ b/src/lib/src/api/client/tree.rs
@@ -28,7 +28,7 @@ pub async fn has_node(
     repository: &RemoteRepository,
     node_id: MerkleHash,
 ) -> Result<bool, OxenError> {
-    let uri = format!("/tree/nodes/{node_id}");
+    let uri = format!("/tree/nodes/hash/{node_id}");
     let url = api::endpoint::url_from_repo(repository, &uri)?;
     log::debug!("api::client::tree::has_node {}", url);
 
@@ -121,7 +121,7 @@ pub async fn download_node(
     node_id: &MerkleHash,
 ) -> Result<MerkleTreeNode, OxenError> {
     let node_hash_str = node_id.to_string();
-    let uri = format!("/tree/nodes/{node_hash_str}");
+    let uri = format!("/tree/nodes/hash/{node_hash_str}/download");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
     log::debug!("downloading node {} from {}", node_hash_str, url);
@@ -145,7 +145,7 @@ pub async fn download_node_with_children(
     node_id: &MerkleHash,
 ) -> Result<MerkleTreeNode, OxenError> {
     let node_hash_str = node_id.to_string();
-    let uri = format!("/tree/nodes/{node_hash_str}");
+    let uri = format!("/tree/nodes/hash/{node_hash_str}/download");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
     log::debug!(
@@ -214,7 +214,7 @@ pub async fn get_node_hash_by_path(
 ) -> Result<MerkleHash, OxenError> {
     let commit_id = commit_id.as_ref();
     let path_str = path.to_string_lossy();
-    let uri = format!("/tree/nodes/{commit_id}/{path_str}");
+    let uri = format!("/tree/nodes/resource/{commit_id}/{path_str}");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
 
     let client = client::new_for_url(&url)?;
@@ -415,7 +415,7 @@ pub async fn list_missing_file_hashes(
     remote_repo: &RemoteRepository,
     node_id: &MerkleHash,
 ) -> Result<HashSet<MerkleHash>, OxenError> {
-    let uri = format!("/tree/nodes/{node_id}/missing_file_hashes");
+    let uri = format!("/tree/nodes/hash/{node_id}/missing_file_hashes");
     let url = api::endpoint::url_from_repo(remote_repo, &uri)?;
     let client = client::new_for_url(&url)?;
     let res = client.get(&url).send().await?;

--- a/src/lib/src/view/tree/merkle_hash.rs
+++ b/src/lib/src/view/tree/merkle_hash.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+use crate::model::merkle_tree::merkle_hash::MerkleHashAsString;
 use crate::model::MerkleHash;
 use crate::view::StatusMessage;
 
@@ -7,5 +8,6 @@ use crate::view::StatusMessage;
 pub struct MerkleHashResponse {
     #[serde(flatten)]
     pub status: StatusMessage,
+    #[serde(with = "MerkleHashAsString")]
     pub hash: MerkleHash,
 }

--- a/src/lib/src/view/tree/merkle_hashes.rs
+++ b/src/lib/src/view/tree/merkle_hashes.rs
@@ -1,18 +1,24 @@
 use std::collections::HashSet;
 
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 
+use crate::model::merkle_tree::merkle_hash::MerkleHashAsString;
 use crate::model::MerkleHash;
 use crate::view::StatusMessage;
 
+#[serde_as]
 #[derive(Deserialize, Serialize, Debug)]
 pub struct MerkleHashes {
+    #[serde_as(as = "HashSet<MerkleHashAsString>")]
     pub hashes: HashSet<MerkleHash>,
 }
 
+#[serde_as]
 #[derive(Deserialize, Serialize, Debug)]
 pub struct MerkleHashesResponse {
     #[serde(flatten)]
     pub status: StatusMessage,
+    #[serde_as(as = "HashSet<MerkleHashAsString>")]
     pub hashes: HashSet<MerkleHash>,
 }

--- a/src/server/src/controllers/tree.rs
+++ b/src/server/src/controllers/tree.rs
@@ -147,12 +147,9 @@ pub async fn create_nodes(
         ByteSize::b(bytes.len() as u64)
     );
 
-    let hashes = repositories::tree::unpack_nodes(&repository, &bytes[..])?;
+    let _hashes = repositories::tree::unpack_nodes(&repository, &bytes[..])?;
 
-    Ok(HttpResponse::Ok().json(MerkleHashesResponse {
-        status: StatusMessage::resource_found(),
-        hashes,
-    }))
+    Ok(HttpResponse::Ok().json(StatusMessage::resource_found()))
 }
 
 pub async fn download_tree(req: HttpRequest) -> actix_web::Result<HttpResponse, OxenHttpError> {

--- a/src/server/src/services/tree.rs
+++ b/src/server/src/services/tree.rs
@@ -9,7 +9,7 @@ pub fn tree() -> Scope {
             web::scope("/nodes")
                 .route("", web::post().to(controllers::tree::create_nodes))
                 .route(
-                    "/{resource:.*}",
+                    "/resource/{resource:.*}",
                     web::get().to(controllers::tree::get_node_hash_by_path),
                 )
                 .route(
@@ -21,7 +21,7 @@ pub fn tree() -> Scope {
                     web::post().to(controllers::tree::list_missing_file_hashes_from_commits),
                 )
                 .service(
-                    web::scope("/{hash}")
+                    web::scope("/hash/{hash}")
                         .route("", web::get().to(controllers::tree::get_node_by_id))
                         .route("/download", web::get().to(controllers::tree::download_node))
                         .route(


### PR DESCRIPTION
The `/tree/nodes/{hash}` route for `controllers::tree::get_node_by_id` could never be reached because the `/tree/nodes/{resource:.*}` route would always match first.

Also Serialize MerkleHashes as strings in the API. They were serialized as u128s before, but that makes the API harder to
use and doesn't give any performance benefit when serializing to JSON.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Updated API endpoint paths for tree-related operations to include more descriptive sub-paths, improving URL clarity and consistency.
  - Adjusted server routing to match the updated API structure, ensuring seamless integration with client requests.
- **New Features**
  - Enhanced serialization of hash data to use hexadecimal string format for improved readability in API responses.
- **Bug Fixes**
  - Simplified server response by removing redundant hash data from node creation confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->