### PR TITLE
Implement partial loads for push

### DIFF
--- a/src/cli/src/cmd/push.rs
+++ b/src/cli/src/cmd/push.rs
@@ -34,6 +34,7 @@ impl RunCmd for PushCmd {
             .arg(
                 Arg::new("BRANCH")
                     .help("Branch name to push to")
+                    .short('b')
                     .default_value(DEFAULT_BRANCH_NAME)
                     .default_missing_value(DEFAULT_BRANCH_NAME),
             )

--- a/src/lib/src/core/v_latest/index/commit_merkle_tree.rs
+++ b/src/lib/src/core/v_latest/index/commit_merkle_tree.rs
@@ -46,6 +46,8 @@ impl CommitMerkleTree {
             .join(DIR_HASHES_DIR)
     }
 
+    // MODULARIZE: We don't need to use this directly, go through repositories::tree
+
     pub fn root_with_children(
         repo: &LocalRepository,
         commit: &Commit,
@@ -53,6 +55,8 @@ impl CommitMerkleTree {
         let node_hash = MerkleHash::from_str(&commit.id)?;
         CommitMerkleTree::read_node(repo, &node_hash, true)
     }
+
+    // MODULARIZE: We don't need to use this directly, go through repositories::tree
 
     pub fn root_without_children(
         repo: &LocalRepository,
@@ -62,6 +66,8 @@ impl CommitMerkleTree {
         // Read the root node at depth 1 to get the directory node as well
         CommitMerkleTree::read_depth(repo, &node_hash, 1)
     }
+
+    // MODULARIZE: This needs an access method in repositories::tree
 
     // Used in the checkout logic to simultaneously load in the target tree and find all of its dir and vnode hashes
     // Saves an extra tree traversal needed to list these hashes
@@ -73,6 +79,8 @@ impl CommitMerkleTree {
         let node_hash = MerkleHash::from_str(&commit.id)?;
         CommitMerkleTree::read_node_with_hashes(repo, &node_hash, hashes)
     }
+
+    // MODULARIZE: This needs an access method in repositories::tree
 
     // Used in the checkout logic to simultaneosuly:
     // A: load only the children of the from tree which aren't present in the target tree
@@ -97,6 +105,23 @@ impl CommitMerkleTree {
         )
     }
 
+    pub fn get_unique_children_for_commit(
+        repo: &LocalRepository,
+        commit: &Commit,
+        shared_hashes: &mut HashSet<MerkleHash>,
+        unique_hashes: &mut HashSet<MerkleHash>,
+    ) -> Result<Option<MerkleTreeNode>, OxenError> {
+        let node_hash = MerkleHash::from_str(&commit.id)?;
+        CommitMerkleTree::read_unique_children_for_commit(
+            repo,
+            &node_hash,
+            shared_hashes,
+            unique_hashes,
+        )
+    }
+
+    // MODULARIZE: We don't need to use this, we can route through repositories::tree
+    // *** NOTE: Unless, that is, we actually need the CommitMerkle
     pub fn from_commit(repo: &LocalRepository, commit: &Commit) -> Result<Self, OxenError> {
         // This debug log is to help make sure we don't load the tree too many times
         // if you see it in the logs being called too much, it could be why the code is slow.
@@ -158,6 +183,9 @@ impl CommitMerkleTree {
         Ok(Some(root))
     }
 
+    // Note: seems that we always create the dir_hashes from the commit, regardless of whether we're loading in the full tree
+    // That theoretically can lead to situations where we have a CommitMerkleTree object with dirs in its dir_hashes that aren't loaded in
+    // Is that a problem?
     pub fn from_path(
         repo: &LocalRepository,
         commit: &Commit,
@@ -268,7 +296,7 @@ impl CommitMerkleTree {
         Ok(Some(node))
     }
 
-    pub fn read_node_with_hashes(
+    fn read_node_with_hashes(
         repo: &LocalRepository,
         hash: &MerkleHash,
         hashes: &mut HashSet<MerkleHash>,
@@ -285,7 +313,7 @@ impl CommitMerkleTree {
         Ok(Some(node))
     }
 
-    pub fn read_unique_nodes(
+    fn read_unique_nodes(
         repo: &LocalRepository,
         hash: &MerkleHash,
         base_hashes: &mut HashSet<MerkleHash>,
@@ -311,6 +339,34 @@ impl CommitMerkleTree {
             base_hashes,
             shared_hashes,
             partial_nodes,
+        )?;
+        Ok(Some(node))
+    }
+
+    fn read_unique_children_for_commit(
+        repo: &LocalRepository,
+        hash: &MerkleHash,
+        shared_hashes: &mut HashSet<MerkleHash>,
+        unique_hashes: &mut HashSet<MerkleHash>,
+    ) -> Result<Option<MerkleTreeNode>, OxenError> {
+        // log::debug!("Read node hash [{}]", hash);
+        if !MerkleNodeDB::exists(repo, hash) {
+            // log::debug!("read_node merkle node db does not exist for hash: {}", hash);
+            return Ok(None);
+        }
+
+        let mut node = MerkleTreeNode::from_hash(repo, hash)?;
+        let mut node_db = MerkleNodeDB::open_read_only(repo, hash)?;
+
+        let start_path = PathBuf::new();
+
+        CommitMerkleTree::load_unique_children_for_commit(
+            repo,
+            &mut node_db,
+            &mut node,
+            &start_path,
+            shared_hashes,
+            unique_hashes,
         )?;
         Ok(Some(node))
     }
@@ -412,8 +468,6 @@ impl CommitMerkleTree {
         // log::debug!("has_dir path: {:?}", path.as_ref());
         // log::debug!("has_dir dir_hashes: {:?}", self.dir_hashes);
         let path = path.as_ref();
-        // println!("Path for has_dir: {path:?}");
-        // println!("Dir hashes: {:?}", self.dir_hashes);
         self.dir_hashes.contains_key(path)
     }
 
@@ -461,6 +515,7 @@ impl CommitMerkleTree {
         Ok(children)
     }
 
+    // MODULARIZE: List_files_and_folders in repositories::tree
     pub fn node_files_and_folders(node: &MerkleTreeNode) -> Result<Vec<MerkleTreeNode>, OxenError> {
         if MerkleTreeNodeType::Dir != node.node.node_type() {
             return Err(OxenError::basic_str(format!(
@@ -482,6 +537,8 @@ impl CommitMerkleTree {
     pub fn total_vnodes(&self) -> usize {
         self.root.total_vnodes()
     }
+
+    // MODULARIZE: dir_entries_with_paths
 
     pub fn dir_entries(node: &MerkleTreeNode) -> Result<Vec<FileNode>, OxenError> {
         let mut file_entries = Vec::new();
@@ -848,7 +905,6 @@ impl CommitMerkleTree {
                     // TODO: Is this the wrong function? THe wrong check?
                     if let EMerkleTreeNode::File(file_node) = &child.node {
                         let file_path = current_path.join(PathBuf::from(file_node.name()));
-                        // println!("Adding path {file_path:?} to partial_nodes");
                         let partial_node = PartialNode::from(
                             *file_node.hash(),
                             file_node.last_modified_seconds(),
@@ -857,6 +913,77 @@ impl CommitMerkleTree {
                         partial_nodes.insert(file_path, partial_node);
                     }
 
+                    node.children.push(child);
+                }
+            }
+        }
+
+        // log::debug!("load_unique_children " done: {:?}", node.hash);
+
+        Ok(())
+    }
+
+    fn load_unique_children_for_commit(
+        repo: &LocalRepository,
+        node_db: &mut MerkleNodeDB,
+        node: &mut MerkleTreeNode,
+        current_path: &PathBuf,
+        shared_hashes: &mut HashSet<MerkleHash>,
+        unique_hashes: &mut HashSet<MerkleHash>,
+    ) -> Result<(), OxenError> {
+        let dtype = node.node.node_type();
+
+        if dtype != MerkleTreeNodeType::Commit
+            && dtype != MerkleTreeNodeType::Dir
+            && dtype != MerkleTreeNodeType::VNode
+        {
+            return Ok(());
+        }
+
+        // Don't continue loading if encountering a shared hash (Right now, the common hashes are the 'base' hashes. These are all the hashes that have been seen previously)
+        if shared_hashes.contains(&node.hash) {
+            return Ok(());
+        }
+
+        // If found a unique hash, insert it into unique_hashes so we won't step on it in future runs
+        unique_hashes.insert(node.hash);
+
+        let children: Vec<(MerkleHash, MerkleTreeNode)> = node_db.map()?;
+        // log::debug!("load_unique_children Got {} children", children.len());
+        for (_key, child) in children {
+            let mut child = child.to_owned();
+            // log::debug!("load_unique_children child: {} -> {}", key, child);
+            match &child.node.node_type() {
+                // Directories, VNodes, and Files have children
+                MerkleTreeNodeType::Commit
+                | MerkleTreeNodeType::Dir
+                | MerkleTreeNodeType::VNode => {
+                    // log::debug!("load_unique_children  recurse: {:?}", child.hash);
+                    let Ok(mut node_db) = MerkleNodeDB::open_read_only(repo, &child.hash) else {
+                        log::warn!("no child node db: {:?}", child.hash);
+                        return Ok(());
+                    };
+
+                    let new_path = if let EMerkleTreeNode::Directory(dir_node) = &child.node {
+                        let name = PathBuf::from(dir_node.name());
+                        &current_path.join(name)
+                    } else {
+                        current_path
+                    };
+
+                    // log::debug!("load_unique_children  opened node_db: {:?}", child.hash);
+                    CommitMerkleTree::load_unique_children_for_commit(
+                        repo,
+                        &mut node_db,
+                        &mut child,
+                        new_path,
+                        shared_hashes,
+                        unique_hashes,
+                    )?;
+                    node.children.push(child);
+                }
+                // TODO: Error handling for unknown MerkleTreeNode type?
+                MerkleTreeNodeType::FileChunk | MerkleTreeNodeType::File => {
                     node.children.push(child);
                 }
             }

--- a/src/lib/src/repositories/push.rs
+++ b/src/lib/src/repositories/push.rs
@@ -135,7 +135,6 @@ mod tests {
             assert_eq!(readme_1_contents, readme_2_contents);
 
             api::client::repositories::delete(&remote_repo).await?;
-
             future::ok::<(), OxenError>(()).await
         })
         .await

--- a/src/lib/src/repositories/tree.rs
+++ b/src/lib/src/repositories/tree.rs
@@ -631,10 +631,22 @@ pub fn list_missing_node_hashes(
     for hash in hashes {
         let dir_prefix = node_db_path(repo, hash);
 
-        if !(commit_sync_status::commit_is_synced(repo, hash)
-            && dir_prefix.join("node").exists()
-            && dir_prefix.join("children").exists())
-        {
+        if !(dir_prefix.join("node").exists() && dir_prefix.join("children").exists()) {
+            results.insert(*hash);
+        }
+    }
+
+    Ok(results)
+}
+
+// Given a set of commit hashes, return the hashes that are unsynced
+pub fn list_missing_commit_hashes(
+    repo: &LocalRepository,
+    hashes: &HashSet<MerkleHash>,
+) -> Result<HashSet<MerkleHash>, OxenError> {
+    let mut results = HashSet::new();
+    for hash in hashes {
+        if !commit_sync_status::commit_is_synced(repo, hash) {
             results.insert(*hash);
         }
     }

--- a/src/server/src/controllers/commits.rs
+++ b/src/server/src/controllers/commits.rs
@@ -164,7 +164,7 @@ pub async fn list_missing(
         merkle_hashes.hashes.len()
     );
     let missing_commits =
-        repositories::tree::list_missing_node_hashes(&repo, &merkle_hashes.hashes)?;
+        repositories::tree::list_missing_commit_hashes(&repo, &merkle_hashes.hashes)?;
     log::debug!(
         "list_missing found {} missing commits",
         missing_commits.len()

--- a/src/server/src/controllers/file.rs
+++ b/src/server/src/controllers/file.rs
@@ -49,11 +49,9 @@ pub async fn get(
         file.into_response(&req)
     } else {
         let entry = repositories::entries::get_file(&repo, &commit, &path)?;
-        log::debug!("entry {:?}", entry);
         let entry = entry.ok_or(OxenError::path_does_not_exist(path.clone()))?;
 
         let version_path = util::fs::version_path_from_hash(&repo, entry.hash().to_string());
-        log::debug!("version path {version_path:?}",);
 
         // TODO: refactor out of here and check for type,
         // but seeing if it works to resize the image and cache it to disk if we have a resize query
@@ -67,7 +65,6 @@ pub async fn get(
                 img_resize.width,
                 img_resize.height,
             )?;
-
             util::fs::resize_cache_image(&version_path, &resized_path, img_resize)?;
 
             log::debug!("In the resize cache! {:?}", resized_path);
@@ -83,13 +80,11 @@ pub async fn get(
         );
 
         let file = NamedFile::open(version_path)?;
-
         let mut response = file.into_response(&req);
 
         let last_commit_id = entry.last_commit_id().to_string();
         let meta_entry = repositories::entries::get_meta_entry(&repo, &commit, &path)?;
         let content_length = meta_entry.size.to_string();
-
         response.headers_mut().insert(
             header::HeaderName::from_static("oxen-revision-id"),
             header::HeaderValue::from_str(&last_commit_id).unwrap(),


### PR DESCRIPTION
Limits the loading and traversal of commit merkle trees when searching for candidate nodes in the core push logic. Now, it only traverses beneath and loads dir and vnode nodes that have not yet been seen. Previously, the entirety of every commit tree would be traversed and loaded

Also separates list_missing_commit_hashes out from list_missing_node_hashes in the core tree logic, fixing the issue where non-commit nodes would be checked for sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `-b` shorthand flag to specify a branch in the push CLI command.
  * Introduced the ability to retrieve unique child nodes for a commit, improving handling of shared and unique data during push operations.

* **Bug Fixes**
  * Improved detection and reporting of missing commit hashes and node data, ensuring more accurate synchronization.

* **Improvements**
  * Enhanced internal logging and removed unnecessary debug output for cleaner logs.
  * Updated documentation comments for increased modularity and clarity in method usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->