### PR TITLE
Fix paths for workspace add

### DIFF
--- a/src/lib/src/api/client/workspaces/files.rs
+++ b/src/lib/src/api/client/workspaces/files.rs
@@ -520,6 +520,7 @@ mod tests {
     use crate::opts::CloneOpts;
     use crate::{api, constants};
     use crate::{repositories, test};
+    use std::path::PathBuf;
 
     use std::path::Path;
     use uuid;
@@ -565,9 +566,11 @@ mod tests {
             .await?;
             assert_eq!(entries.added_files.entries.len(), 1);
             assert_eq!(entries.added_files.total_entries, 1);
+            let assert_path = PathBuf::from("images").join(PathBuf::from("dwight_vince.jpeg"));
+
             assert_eq!(
                 entries.added_files.entries[0].filename(),
-                "images/dwight_vince.jpeg"
+                assert_path.to_str().unwrap(),
             );
 
             Ok(remote_repo)
@@ -1315,9 +1318,11 @@ mod tests {
 
             assert_eq!(entries.added_files.entries.len(), 1);
             assert_eq!(entries.added_files.total_entries, 1);
+
+            let assert_path = PathBuf::from("new-images").join(PathBuf::from("dwight_vince.jpeg"));
             assert_eq!(
                 entries.added_files.entries[0].filename(),
-                "new-images/dwight_vince.jpeg"
+                assert_path.to_str().unwrap(),
             );
 
             Ok(remote_repo)

--- a/src/lib/src/core/v_latest/workspaces/files.rs
+++ b/src/lib/src/core/v_latest/workspaces/files.rs
@@ -76,9 +76,11 @@ pub fn add_version_files(
     repo: &LocalRepository,
     workspace: &Workspace,
     files_with_hash: &[FileWithHash],
+    directory: impl AsRef<str>,
 ) -> Result<Vec<ErrorFileInfo>, OxenError> {
     let version_store = repo.version_store()?;
 
+    let directory = directory.as_ref();
     let workspace_repo = &workspace.workspace_repo;
     let seen_dirs = Arc::new(Mutex::new(HashSet::new()));
 
@@ -86,11 +88,12 @@ pub fn add_version_files(
     with_staged_db_manager(workspace_repo, |staged_db_manager| {
         for item in files_with_hash.iter() {
             let version_path = version_store.get_version_path(&item.hash)?;
+            let target_path = PathBuf::from(directory).join(&item.path);
 
             match get_status_and_add_file(
                 workspace_repo,
                 &version_path,
-                &item.path,
+                &target_path,
                 staged_db_manager,
                 &seen_dirs,
             ) {

--- a/src/server/src/controllers/workspaces/files.rs
+++ b/src/server/src/controllers/workspaces/files.rs
@@ -96,6 +96,7 @@ pub async fn add_version_files(
     let namespace = path_param(&req, "namespace")?;
     let repo_name = path_param(&req, "repo_name")?;
     let workspace_id = path_param(&req, "workspace_id")?;
+    let directory = path_param(&req, "directory")?;
 
     let repo = get_repo(&app_data.path, namespace, repo_name)?;
 
@@ -106,8 +107,12 @@ pub async fn add_version_files(
 
     let files_with_hash: Vec<FileWithHash> = payload.into_inner();
 
-    let err_files =
-        core::v_latest::workspaces::files::add_version_files(&repo, &workspace, &files_with_hash)?;
+    let err_files = core::v_latest::workspaces::files::add_version_files(
+        &repo,
+        &workspace,
+        &files_with_hash,
+        &directory,
+    )?;
 
     // Return the error files for retry
     Ok(HttpResponse::Ok().json(ErrorFilesResponse {

--- a/src/server/src/services/workspaces.rs
+++ b/src/server/src/services/workspaces.rs
@@ -28,7 +28,7 @@ pub fn workspace() -> Scope {
                     web::delete().to(controllers::workspaces::files::delete),
                 )
                 .route(
-                    "/versions",
+                    "/versions/{directory:.*}",
                     web::post().to(controllers::workspaces::files::add_version_files),
                 )
                 .route(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a directory when adding versioned files to a workspace, enabling more flexible file organization during uploads.
  * The API endpoint for adding version files now accepts a directory path, allowing uploads to be scoped to specific directories.

* **Bug Fixes**
  * Improved error handling for file reading and path extraction, providing clearer error messages and preventing unexpected failures during uploads.

* **Tests**
  * Added a new test to verify correct handling of files with absolute paths and updated existing tests for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->