### PR TITLE
enable empty repo file upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "actix-files",
  "actix-http",
  "actix-multipart",
+ "actix-multipart-test",
  "actix-service",
  "actix-web",
  "actix-web-httpauth",
@@ -232,6 +233,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "actix-multipart-test"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d622d3b8268b9c3d6788351eae9f028c29ba1151f4943aba4e5b794f475b445d"
+dependencies = [
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ uuid = { version = "1.4.1", features = ["serde", "v4"] }
 walkdir = "2.5.0"
 xxhash-rust = { version = "0.8.7", features = ["xxh3"] }
 zip = "2.4.1"
+actix-multipart-test = "0.0.3"
 
 
 [workspace]

--- a/src/lib/src/model/file.rs
+++ b/src/lib/src/model/file.rs
@@ -63,6 +63,12 @@ pub struct FileNew {
     pub user: User,
 }
 
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct TempFileNew {
+    pub path: PathBuf,
+    pub contents: FileContents,
+}
+
 impl FileNew {
     pub fn new_text(path: impl AsRef<Path>, contents: impl AsRef<str>, user: User) -> FileNew {
         FileNew {

--- a/src/lib/src/repositories/commits.rs
+++ b/src/lib/src/repositories/commits.rs
@@ -5,6 +5,7 @@
 
 use crate::core::versions::MinOxenVersion;
 use crate::error::OxenError;
+use crate::model::User;
 use crate::model::{Commit, LocalRepository, MerkleHash};
 use crate::opts::PaginateOpts;
 use crate::util;
@@ -50,6 +51,17 @@ pub fn commit(repo: &LocalRepository, message: &str) -> Result<Commit, OxenError
     match repo.min_version() {
         MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
         _ => core::v_latest::commits::commit(repo, message),
+    }
+}
+
+pub fn commit_with_user(
+    repo: &LocalRepository,
+    message: &str,
+    user: &User,
+) -> Result<Commit, OxenError> {
+    match repo.min_version() {
+        MinOxenVersion::V0_10_0 => panic!("v0.10.0 no longer supported"),
+        _ => core::v_latest::commits::commit_with_user(repo, message, user),
     }
 }
 

--- a/src/lib/src/test.rs
+++ b/src/lib/src/test.rs
@@ -755,6 +755,51 @@ where
 }
 
 /// Test interacting with a remote repo that has nothing synced
+pub async fn run_empty_configured_remote_repo_test<T, Fut>(test: T) -> Result<(), OxenError>
+where
+    T: FnOnce(LocalRepository, RemoteRepository) -> Fut,
+    Fut: Future<Output = Result<RemoteRepository, OxenError>>,
+{
+    init_test_env();
+    log::info!("<<<<< run_empty_remote_repo_test start");
+    let empty_dir = create_empty_dir(test_run_dir())?;
+    let name = format!("repo_{}", uuid::Uuid::new_v4());
+    let path = empty_dir.join(name);
+    let mut local_repo = repositories::init(&path)?;
+
+    // Set the proper remote
+    let remote_repo = create_remote_repo(&local_repo).await?;
+    command::config::set_remote(
+        &mut local_repo,
+        constants::DEFAULT_REMOTE_NAME,
+        remote_repo.url(),
+    )?;
+
+    println!("REMOTE REPO: {remote_repo:?}");
+
+    // Run test to see if it panic'd
+    log::info!(">>>>> run_empty_remote_repo_test running test");
+    let result = match test(local_repo, remote_repo).await {
+        Ok(repo) => {
+            // Cleanup remote repo
+            api::client::repositories::delete(&repo).await?;
+            true
+        }
+        Err(err) => {
+            eprintln!("Error running test. Err: {err}");
+            false
+        }
+    };
+
+    // Cleanup Local
+    maybe_cleanup_repo(&path)?;
+
+    // Assert everything okay after we cleanup the repo dir
+    assert!(result);
+    Ok(())
+}
+
+/// Test interacting with a remote repo that has nothing synced
 pub async fn run_readme_remote_repo_test<T, Fut>(test: T) -> Result<(), OxenError>
 where
     T: FnOnce(LocalRepository, RemoteRepository) -> Fut,


### PR DESCRIPTION
Reuse the same logic for create a repo with files to upload a file to an empty repo (no commit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled initial file uploads to empty repositories, allowing users to add files and create the first commit directly.
  * Added support for including commit author, email, and message within file upload forms.
  * Introduced new testing utilities to validate file uploads and commits on empty repositories.

* **Bug Fixes**
  * Improved handling of file uploads for repositories with no commits.

* **Chores**
  * Removed unnecessary debug output from tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->